### PR TITLE
[refactor#40] 보안 및 인증 로직의 안정성 강화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,13 @@ import "./App.css";
 
 import { RouterProvider } from "react-router-dom";
 
+import { useTokenRefresh } from "@/hooks/auth/useTokenRefresh";
+
 import { router } from "@/routes/Router";
 
 function App() {
+  useTokenRefresh();
+
   return (
     <>
       <RouterProvider router={router} />

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,2 +1,0 @@
-// 인증번호 입력 시간 상수화
-export const AUTH_TIMER_DURATION = 180;

--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -4,8 +4,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import type { z } from "zod";
 
-import { AUTH_TIMER_DURATION } from "@/constants/auth";
-
 import { step01Schema } from "@/utils/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
@@ -43,14 +41,11 @@ export const useEmailVerification = ({
   const watchedEmail = useWatch({ control, name: "email" });
   const watchedCode = useWatch({ control, name: "code" });
 
-  const { formattedTime, restart, stop, isExpired } = useTimer(
-    AUTH_TIMER_DURATION,
-    {
-      onExpire: () => {
-        toast.error("인증 시간이 만료되었습니다. 다시 시도해주세요.");
-      },
+  const { formattedTime, restart, stop, isExpired } = useTimer(0, {
+    onExpire: () => {
+      toast.error("인증 시간이 만료되었습니다. 다시 시도해주세요.");
     },
-  );
+  });
 
   const handleEditEmail = useCallback(() => {
     setSendCode(false);

--- a/src/hooks/auth/useTokenRefresh.ts
+++ b/src/hooks/auth/useTokenRefresh.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+import { reissueToken } from "@/api/auth/auth";
+import useAuthStore from "@/store/useAuthStore";
+
+export const useTokenRefresh = () => {
+  const { setAccessToken, login, logout } = useAuthStore();
+
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        const { data } = await reissueToken();
+        if (data.accessToken) {
+          // TODO: 재발급 성공 시 로그인 처리
+          login("user@example.com", data.accessToken);
+        }
+      } catch (error) {
+        console.log("토큰 재발급 실패:", error);
+        logout();
+      }
+    };
+
+    initAuth();
+  }, [login, logout, setAccessToken]);
+};

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -4,7 +4,6 @@ import useAuthStore from "@/store/useAuthStore";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-// 환경변수 확인
 if (!BASE_URL) {
   throw new Error("API 서버 주소(VITE_API_BASE_URL)가 설정되지 않았습니다.");
 }
@@ -17,10 +16,7 @@ const axiosConfig: AxiosRequestConfig = {
   },
 };
 
-// 일반 요청용 인스턴스
 export const axiosInstance = axios.create(axiosConfig);
-
-// 토큰 재발급 요청용 인스턴스
 export const authInstance = axios.create(axiosConfig);
 
 axiosInstance.interceptors.request.use(
@@ -37,22 +33,31 @@ axiosInstance.interceptors.request.use(
   },
 );
 
-// 토큰 재발급 상태 및 대기열
 let isRefreshing = false;
-let refreshSubscribers: ((token: string) => void)[] = [];
+interface IRefreshSubscriber {
+  resolve: (token: string) => void;
+  reject: (error: unknown) => void;
+}
 
-// 대기 중인 요청 처리
+let refreshSubscribers: IRefreshSubscriber[] = [];
+
 const onRefreshed = (accessToken: string) => {
-  refreshSubscribers.forEach((callback) => callback(accessToken));
+  refreshSubscribers.forEach(({ resolve }) => resolve(accessToken));
   refreshSubscribers = [];
 };
 
-// 대기열에 요청 추가
-const addRefreshSubscriber = (callback: (token: string) => void) => {
-  refreshSubscribers.push(callback);
+const onRefreshFailed = (error: unknown) => {
+  refreshSubscribers.forEach(({ reject }) => reject(error));
+  refreshSubscribers = [];
 };
 
-// [응답 인터셉터] 토큰 만료 처리
+const addRefreshSubscriber = (
+  resolve: (token: string) => void,
+  reject: (error: unknown) => void,
+) => {
+  refreshSubscribers.push({ resolve, reject });
+};
+
 axiosInstance.interceptors.response.use(
   (response) => {
     return response;
@@ -60,19 +65,21 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // 401 인증 에러 발생
     if (error.response?.status === 401) {
-      // 이미 재발급 중이면 대기열에 추가
       if (isRefreshing) {
-        return new Promise((resolve) => {
-          addRefreshSubscriber((accessToken: string) => {
-            originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-            resolve(axiosInstance(originalRequest));
-          });
+        return new Promise((resolve, reject) => {
+          addRefreshSubscriber(
+            (accessToken: string) => {
+              originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+              resolve(axiosInstance(originalRequest));
+            },
+            (refreshError: unknown) => {
+              reject(refreshError);
+            },
+          );
         });
       }
 
-      // 재발급 요청 자체가 실패했거나 이미 재시도한 경우 -> 로그아웃
       if (
         originalRequest.url?.includes("/api/auth/reissue") ||
         originalRequest._retry
@@ -81,7 +88,6 @@ axiosInstance.interceptors.response.use(
         return Promise.reject(error);
       }
 
-      // 첫 401 에러, 재발급 시도
       originalRequest._retry = true;
       isRefreshing = true;
 
@@ -90,22 +96,17 @@ axiosInstance.interceptors.response.use(
 
         const newAccessToken = data.data.accessToken;
 
-        // 새 토큰 저장
         useAuthStore.getState().setAccessToken(newAccessToken);
-
-        // 대기 중이던 요청들 일괄 처리
         onRefreshed(newAccessToken);
 
-        // 실패했던 요청 재시도
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return axiosInstance(originalRequest);
       } catch (refreshError) {
-        // 재발급 실패 시 로그아웃
         console.error("토큰 재발급 실패:", refreshError);
+        onRefreshFailed(refreshError);
         useAuthStore.getState().logout();
         return Promise.reject(refreshError);
       } finally {
-        // 상태 초기화
         isRefreshing = false;
         refreshSubscribers = [];
       }

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -2,23 +2,30 @@ import axios, { type AxiosRequestConfig } from "axios";
 
 import useAuthStore from "@/store/useAuthStore";
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+// 환경변수 확인
+if (!BASE_URL) {
+  throw new Error("API 서버 주소(VITE_API_BASE_URL)가 설정되지 않았습니다.");
+}
+
 const axiosConfig: AxiosRequestConfig = {
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: BASE_URL,
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",
   },
 };
 
-// 일반 API 요청용
+// 일반 요청용 인스턴스
 export const axiosInstance = axios.create(axiosConfig);
 
-// 토큰 재발급 전용
+// 토큰 재발급 요청용 인스턴스
 export const authInstance = axios.create(axiosConfig);
 
 axiosInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("accessToken");
+    const token = useAuthStore.getState().accessToken;
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
@@ -30,19 +37,22 @@ axiosInstance.interceptors.request.use(
   },
 );
 
+// 토큰 재발급 상태 및 대기열
 let isRefreshing = false;
 let refreshSubscribers: ((token: string) => void)[] = [];
 
-// 대기 요청 처리
+// 대기 중인 요청 처리
 const onRefreshed = (accessToken: string) => {
   refreshSubscribers.forEach((callback) => callback(accessToken));
   refreshSubscribers = [];
 };
 
+// 대기열에 요청 추가
 const addRefreshSubscriber = (callback: (token: string) => void) => {
   refreshSubscribers.push(callback);
 };
 
+// [응답 인터셉터] 토큰 만료 처리
 axiosInstance.interceptors.response.use(
   (response) => {
     return response;
@@ -50,9 +60,9 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // 401 에러 감지
+    // 401 인증 에러 발생
     if (error.response?.status === 401) {
-      // 재발급 진행 중: 대기열 등록
+      // 이미 재발급 중이면 대기열에 추가
       if (isRefreshing) {
         return new Promise((resolve) => {
           addRefreshSubscriber((accessToken: string) => {
@@ -62,16 +72,16 @@ axiosInstance.interceptors.response.use(
         });
       }
 
-      // 재발급 실패: 로그아웃
+      // 재발급 요청 자체가 실패했거나 이미 재시도한 경우 -> 로그아웃
       if (
         originalRequest.url?.includes("/api/auth/reissue") ||
         originalRequest._retry
       ) {
-        localStorage.removeItem("accessToken");
+        useAuthStore.getState().logout();
         return Promise.reject(error);
       }
 
-      // 첫 401: 재발급 시도
+      // 첫 401 에러, 재발급 시도
       originalRequest._retry = true;
       isRefreshing = true;
 
@@ -79,17 +89,19 @@ axiosInstance.interceptors.response.use(
         const { data } = await authInstance.post("/api/auth/reissue");
 
         const newAccessToken = data.data.accessToken;
-        localStorage.setItem("accessToken", newAccessToken);
 
-        // 대기 요청 일괄 처리
+        // 새 토큰 저장
+        useAuthStore.getState().setAccessToken(newAccessToken);
+
+        // 대기 중이던 요청들 일괄 처리
         onRefreshed(newAccessToken);
 
-        // 현재 요청 재시도
+        // 실패했던 요청 재시도
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return axiosInstance(originalRequest);
       } catch (refreshError) {
-        // 재발급 실패: 로그아웃
-        console.error("Token reissue failed:", refreshError);
+        // 재발급 실패 시 로그아웃
+        console.error("토큰 재발급 실패:", refreshError);
         useAuthStore.getState().logout();
         return Promise.reject(refreshError);
       } finally {

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -19,16 +19,22 @@ export default function RedirectPage() {
       if (parts.length === 2) return parts.pop()?.split(";").shift();
     };
 
+    const deleteCookie = (name: string) => {
+      document.cookie =
+        name + "=; Max-Age=0; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+    };
+
     const accessToken = getCookie("access_token");
 
     if (accessToken) {
-      // TODO: Zustand 로그인 상태 업데이트 - 추후 내 정보 조회 API 연동 시 수정
+      // TODO: 로그인 상태 업데이트
       login("social@user.com", accessToken);
+
+      deleteCookie("access_token");
 
       toast.success("소셜 로그인되었습니다.");
       navigate("/", { replace: true });
     } else {
-      console.error("No access token found in cookies.");
       toast.error("소셜 로그인에 실패했습니다. 다시 시도해주세요.");
       navigate("/login", { replace: true });
     }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -2,12 +2,14 @@ import { create } from "zustand";
 
 interface IAuthState {
   isLoggedIn: boolean;
+  accessToken: string | null;
   email: string;
   password: string;
   socialId: number;
 
   login: (email: string, accessToken: string) => void;
   logout: () => void;
+  setAccessToken: (token: string) => void;
   setEmail: (email: string) => void;
   setPassword: (password: string) => void;
   setSocialId: (socialId: number) => void;
@@ -16,22 +18,31 @@ interface IAuthState {
 
 const useAuthStore = create<IAuthState>((set) => ({
   isLoggedIn: false,
+  accessToken: null,
   email: "",
   password: "",
   socialId: -1,
+
   login: (email, accessToken) => {
-    localStorage.setItem("accessToken", accessToken);
-    set({ isLoggedIn: true, email });
+    set({ isLoggedIn: true, email, accessToken });
   },
   logout: () => {
     localStorage.removeItem("accessToken");
-    set({ isLoggedIn: false, email: "", password: "", socialId: -1 });
+    localStorage.removeItem("refreshToken");
+    set({
+      isLoggedIn: false,
+      accessToken: null,
+      email: "",
+      password: "",
+      socialId: -1,
+    });
   },
 
+  setAccessToken: (token) => set({ accessToken: token }),
   setEmail: (email) => set({ email }),
   setPassword: (password) => set({ password }),
   setSocialId: (socialId) => set({ socialId }),
-  resetAuth: () => set({ email: "", password: "" }),
+  resetAuth: () => set({ email: "", password: "", accessToken: null }),
 }));
 
 export default useAuthStore;

--- a/src/types/common/common.ts
+++ b/src/types/common/common.ts
@@ -11,7 +11,6 @@ export interface ICommonResponse<T> {
   data: T;
 }
 
-// useCoreQuery 옵션 타입
 export type TUseQueryCustomOptions<
   TQueryFnData = unknown,
   TData = TQueryFnData,
@@ -20,7 +19,6 @@ export type TUseQueryCustomOptions<
   "queryKey" | "queryFn"
 >;
 
-// useCoreMutation 옵션 타입
 export type TUseMutationCustomOptions<
   TData = unknown,
   TVariables = unknown,


### PR DESCRIPTION
## 🚨 관련 이슈

#40 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 1. 소셜 로그인 토큰 보안 강화
- **문제점** : 소셜 로그인 리다이렉트 시 `RedirectPage`에서 를 통해 Access Token을 가져온 후, 
해당 쿠키를 브라우저에 그대로 방치하는 보안 취약점이 있었음
- **해결방법** : getCookie로 토큰을 추충해 상태 관리에 저장한 직후에 deleteCookie 함수를 호출해서 쿠키를 즉시 만료하도록 변경

### 2. 토큰 재발급 실패 시 상태 동기화
- **문제점** : API 요청 중 401 에러로 인해 토큰 재발급을 시도했지만 실패했을 때, localStorage만 비우고 Zustand Store의 상태는 초기화하지 않아서 UI 상 여전히 로그인된 것처럼 보이는 불일치 발생
- **해결 방법** : `axiosInstance`에서 재발급 실패 시에 `useAuthStore.getState().logout()`를 호출해 메모리 상의 인증 상태도 함께 초기화하게 수정

### 3. API Base URL 예외 처리 강화
- **문제점** : 환경 변수가 없을 때, API 요청이 기본 로컬호스트로 전송되는 등 원인 파악이 어려운 에러에 대비함
- **해결 방법** : 명시적인 에러를 발생시키도록 검증할 수 있는 로직을 추가


## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
