### PR TITLE
[Feature/#36] 이메일 찾기 API 연동

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -6,6 +6,10 @@ import type {
   ILoginResponse,
   ISignUpRequest,
   ISignUpResponse,
+  ISmsSendRequest,
+  ISmsSendResponse,
+  ISmsVerifyRequest,
+  ISmsVerifyResponse,
   ITokenRefreshResponse,
 } from "@/types/auth/auth";
 import type { ICommonResponse } from "@/types/common/common";
@@ -60,5 +64,27 @@ export const login = async (
     data,
   );
 
+  return responseData;
+};
+
+// SMS 인증 코드 전송
+export const sendSMS = async (
+  data: ISmsSendRequest,
+): Promise<ICommonResponse<ISmsSendResponse>> => {
+  const { data: responseData } = await axiosInstance.post(
+    "/api/users/sms-send",
+    data,
+  );
+  return responseData;
+};
+
+// SMS 인증 코드 검증
+export const verifySMS = async (
+  data: ISmsVerifyRequest,
+): Promise<ICommonResponse<ISmsVerifyResponse>> => {
+  const { data: responseData } = await axiosInstance.post(
+    "/api/users/sms-verify",
+    data,
+  );
   return responseData;
 };

--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -37,14 +37,19 @@ export const verifyEmail = async ({
 };
 
 // 단순 회원가입
-export const signUp = async (
-  data: ISignUpRequest,
-): Promise<ICommonResponse<ISignUpResponse>> => {
-  const { data: responseData } = await axiosInstance.post(
-    "/api/users/signup",
-    data,
-  );
-  return responseData;
+export const signUp = async ({
+  email,
+  password,
+  name,
+  phone_number,
+}: ISignUpRequest): Promise<ICommonResponse<ISignUpResponse>> => {
+  const { data } = await axiosInstance.post("/api/users/signup", {
+    email,
+    password,
+    name,
+    phone_number,
+  });
+  return data;
 };
 
 // 토큰 재발급
@@ -56,35 +61,35 @@ export const reissueToken = async (): Promise<
 };
 
 // 로그인
-export const login = async (
-  data: ILoginRequest,
-): Promise<ICommonResponse<ILoginResponse>> => {
-  const { data: responseData } = await axiosInstance.post(
-    "/api/auth/login",
-    data,
-  );
-
-  return responseData;
+export const login = async ({
+  email,
+  password,
+}: ILoginRequest): Promise<ICommonResponse<ILoginResponse>> => {
+  const { data } = await axiosInstance.post("/api/auth/login", {
+    email,
+    password,
+  });
+  return data;
 };
 
 // SMS 인증 코드 전송
-export const sendSMS = async (
-  data: ISmsSendRequest,
-): Promise<ICommonResponse<ISmsSendResponse>> => {
-  const { data: responseData } = await axiosInstance.post(
-    "/api/users/sms-send",
-    data,
-  );
-  return responseData;
+export const sendSMS = async ({
+  phoneNumber,
+}: ISmsSendRequest): Promise<ICommonResponse<ISmsSendResponse>> => {
+  const { data } = await axiosInstance.post("/api/users/sms-send", {
+    phoneNumber,
+  });
+  return data;
 };
 
 // SMS 인증 코드 검증
-export const verifySMS = async (
-  data: ISmsVerifyRequest,
-): Promise<ICommonResponse<ISmsVerifyResponse>> => {
-  const { data: responseData } = await axiosInstance.post(
-    "/api/users/sms-verify",
-    data,
-  );
-  return responseData;
+export const verifySMS = async ({
+  phoneNumber,
+  verificationCode,
+}: ISmsVerifyRequest): Promise<ICommonResponse<ISmsVerifyResponse>> => {
+  const { data } = await axiosInstance.post("/api/users/sms-verify", {
+    phoneNumber,
+    verificationCode,
+  });
+  return data;
 };

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -86,7 +86,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
     stop();
   };
 
-  const onSubmit: SubmitHandler<TFindEmailFormValues> = async (formData) => {
+  const onSubmit: SubmitHandler<TFindEmailFormValues> = (formData) => {
     const phoneNumber = stripPhoneHyphens(formData.phoneNum);
     verifySMSMutate(
       { phoneNumber, verificationCode: formData.code },

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -41,6 +41,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
     handleSubmit,
     control,
     trigger,
+    setValue,
     formState: { errors, isValid },
   } = useForm<TFindEmailFormValues>({
     mode: "onBlur",
@@ -84,6 +85,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   const handleEditPhone = () => {
     setSendCode(false);
     stop();
+    setValue("code", "");
   };
 
   const onSubmit: SubmitHandler<TFindEmailFormValues> = (formData) => {
@@ -146,6 +148,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
                 type="text"
                 value={watchedPhone || ""}
                 readOnly
+                aria-label="입력된 전화번호"
                 className="w-full h-13.5 px-5 border rounding-15 text-body1 text-text-main bg-white border-brand-400 focus:outline-none focus:border-brand-400"
               />
               <button

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -25,8 +25,8 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   const navigate = useNavigate();
   const { setEmail } = useAuthStore();
   const { useSendSMS, useVerifySMS } = useAuth();
-  const { mutate: sendSMSMutate } = useSendSMS;
-  const { mutate: verifySMSMutate } = useVerifySMS;
+  const { mutate: sendSMSMutate, isPending: isSending } = useSendSMS;
+  const { mutate: verifySMSMutate, isPending: isVerifying } = useVerifySMS;
 
   const [sendCode, setSendCode] = useState(false);
   const [codeError, setCodeError] = useState("");
@@ -114,8 +114,8 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
     <div className="w-full min-h-screen bg-white flex items-center justify-center">
       <div className="w-full max-w-130 px-6 pb-12">
         <h1 className="text-start font-heading2 text-text-main mb-10">
-          <p>이메일 찾기를 위해</p>
-          <p>휴대폰 인증을 진행할게요</p>
+          <span className="block">이메일 찾기를 위해</span>
+          <span className="block">휴대폰 인증을 진행할게요</span>
         </h1>
 
         <div className="flex flex-col gap-6">
@@ -135,6 +135,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
                 className="shrink-0 h-13.5! border border-brand-400 text-status-blue bg-white hover:bg-gray-50 px-4 rounded-15 font-body2 whitespace-nowrap"
                 onClick={postSendCode}
                 type="button"
+                disabled={isSending}
               >
                 인증번호 받기
               </Button>
@@ -183,7 +184,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
             fullWidth
             onClick={handleSubmit(onSubmit)}
             variant="gradient"
-            disabled={!isValid || (isExpired && sendCode)}
+            disabled={!isValid || isVerifying || (isExpired && sendCode)}
           >
             다음으로
           </Button>
@@ -194,7 +195,8 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
             <button
               type="button"
               onClick={handleResendSMS}
-              className="font-body2 text-text-placeholder underline underline-offset-4 hover:text-text-auth-sub"
+              disabled={isSending}
+              className="font-body2 text-text-placeholder underline underline-offset-4 hover:text-text-auth-sub disabled:opacity-50"
             >
               인증번호 다시 받기
             </button>

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { type SubmitHandler, useForm, useWatch } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import type { z } from "zod";
@@ -23,7 +23,6 @@ interface IEnterPhoneStepProps {
 type TFindEmailFormValues = z.infer<typeof findEmailSchema>;
 
 export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
-  const navigate = useNavigate();
   const { setEmail } = useAuthStore();
   const { useSendSMS, useVerifySMS } = useAuth();
   const { mutate: sendSMSMutate, isPending: isSending } = useSendSMS;
@@ -205,13 +204,12 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
         )}
 
         <div className="mt-10 flex justify-center">
-          <button
-            type="button"
+          <Link
+            to="/find-pw"
             className="font-body2 text-text-placeholder underline underline-offset-4 hover:text-text-auth-sub"
-            onClick={() => navigate("/find-pw")}
           >
             비밀번호 찾기
-          </button>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -30,7 +30,11 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
 
   const [sendCode, setSendCode] = useState(false);
   const [codeError, setCodeError] = useState("");
-  const { formattedTime, isExpired, restart } = useTimer(180);
+  const { formattedTime, isExpired, restart, stop } = useTimer(0, {
+    onExpire: () => {
+      toast.error("인증 시간이 만료되었습니다. 다시 시도해주세요.");
+    },
+  });
 
   const {
     register,
@@ -46,24 +50,40 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   const watchedPhone = useWatch({ control, name: "phoneNum" });
   const watchedCode = useWatch({ control, name: "code" });
 
+  const sendVerificationSMS = (phoneNumber: string, message: string) => {
+    sendSMSMutate(
+      { phoneNumber },
+      {
+        onSuccess: (res) => {
+          setSendCode(true);
+          restart(res.data.expireIn);
+          toast.success(message);
+        },
+        onError: () => {
+          toast.error("인증번호 발송에 실패했습니다.");
+        },
+      },
+    );
+  };
+
   const postSendCode = async () => {
     const isPhoneValid = await trigger("phoneNum");
     if (isPhoneValid && watchedPhone) {
       const phoneNumber = watchedPhone.replace(/-/g, "");
-      sendSMSMutate(
-        { phoneNumber },
-        {
-          onSuccess: () => {
-            setSendCode(true);
-            restart();
-            toast.success("인증번호가 발송되었습니다.");
-          },
-          onError: () => {
-            toast.error("인증번호 발송에 실패했습니다.");
-          },
-        },
-      );
+      sendVerificationSMS(phoneNumber, "인증번호가 발송되었습니다.");
     }
+  };
+
+  const handleResendSMS = () => {
+    if (watchedPhone) {
+      const phoneNumber = watchedPhone.replace(/-/g, "");
+      sendVerificationSMS(phoneNumber, "인증번호가 재발송되었습니다.");
+    }
+  };
+
+  const handleEditPhone = () => {
+    setSendCode(false);
+    stop();
   };
 
   const onSubmit: SubmitHandler<TFindEmailFormValues> = async (formData) => {
@@ -89,10 +109,6 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   useEffect(() => {
     setCodeError("");
   }, [watchedCode, watchedPhone]);
-
-  useEffect(() => {
-    setSendCode(false);
-  }, [watchedPhone]);
 
   return (
     <div className="w-full min-h-screen bg-white flex items-center justify-center">
@@ -124,12 +140,22 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
               </Button>
             </div>
           ) : (
-            <CommonAuthInput
-              type="text"
-              value={watchedPhone || ""}
-              readOnly
-              className="w-full h-13.5 px-5 border rounding-15 text-body1 text-text-main bg-white border-brand-400 focus:outline-none focus:border-brand-400"
-            />
+            <div className="relative w-full">
+              <CommonAuthInput
+                type="text"
+                value={watchedPhone || ""}
+                readOnly
+                className="w-full h-13.5 px-5 border rounding-15 text-body1 text-text-main bg-white border-brand-400 focus:outline-none focus:border-brand-400"
+              />
+              <button
+                type="button"
+                onClick={handleEditPhone}
+                aria-label="전화번호 수정"
+                className="absolute right-5 top-1/2 -translate-y-1/2 font-body2 text-text-placeholder underline hover:text-text-main"
+              >
+                수정
+              </button>
+            </div>
           )}
 
           <CommonAuthInput
@@ -162,6 +188,18 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
             다음으로
           </Button>
         </div>
+
+        {sendCode && (
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={handleResendSMS}
+              className="font-body2 text-text-placeholder underline underline-offset-4 hover:text-text-auth-sub"
+            >
+              인증번호 다시 받기
+            </button>
+          </div>
+        )}
 
         <div className="mt-10 flex justify-center">
           <button

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -7,6 +7,8 @@ import type { z } from "zod";
 
 import { findEmailSchema } from "@/utils/validation";
 
+import { useAuth } from "@/hooks/auth/useAuth";
+
 import CommonAuthInput from "@/components/auth/common/CommonAuthInput";
 import Button from "@/components/common/button/Button";
 
@@ -21,6 +23,9 @@ type TFindEmailFormValues = z.infer<typeof findEmailSchema>;
 export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   const navigate = useNavigate();
   const { setEmail } = useAuthStore();
+  const { useSendSMS, useVerifySMS } = useAuth();
+  const { mutate: sendSMSMutate } = useSendSMS;
+  const { mutate: verifySMSMutate } = useVerifySMS;
 
   const [sendCode, setSendCode] = useState(false);
   const [codeError, setCodeError] = useState("");
@@ -42,17 +47,40 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   const postSendCode = async () => {
     const isPhoneValid = await trigger("phoneNum");
     if (isPhoneValid && watchedPhone) {
-      setSendCode(true);
-      toast.success("인증번호가 발송되었습니다.", {
-        description: "테스트용: 아무 번호나 입력하세요",
-      });
+      const phoneNumber = watchedPhone.replace(/-/g, "");
+      sendSMSMutate(
+        { phoneNumber },
+        {
+          onSuccess: () => {
+            setSendCode(true);
+            toast.success("인증번호가 발송되었습니다.");
+          },
+          onError: () => {
+            toast.error("인증번호 발송에 실패했습니다.");
+          },
+        },
+      );
     }
   };
 
-  const onSubmit: SubmitHandler<TFindEmailFormValues> = async () => {
-    // 임시 이메일
-    setEmail("smu2021@naver.com");
-    onNext();
+  const onSubmit: SubmitHandler<TFindEmailFormValues> = async (formData) => {
+    const phoneNumber = formData.phoneNum.replace(/-/g, "");
+    verifySMSMutate(
+      { phoneNumber, verificationCode: formData.code },
+      {
+        onSuccess: (res) => {
+          if (res.data.isVerified) {
+            setEmail(res.data.email);
+            onNext();
+          } else {
+            setCodeError(res.data.verificationMessage);
+          }
+        },
+        onError: () => {
+          setCodeError("인증번호가 올바르지 않습니다.");
+        },
+      },
+    );
   };
 
   useEffect(() => {

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -8,6 +8,7 @@ import type { z } from "zod";
 import { findEmailSchema } from "@/utils/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
+import { useTimer } from "@/hooks/common/useTimer";
 
 import CommonAuthInput from "@/components/auth/common/CommonAuthInput";
 import Button from "@/components/common/button/Button";
@@ -29,6 +30,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
 
   const [sendCode, setSendCode] = useState(false);
   const [codeError, setCodeError] = useState("");
+  const { formattedTime, isExpired, restart } = useTimer(180);
 
   const {
     register,
@@ -53,6 +55,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
         {
           onSuccess: () => {
             setSendCode(true);
+            restart();
             toast.success("인증번호가 발송되었습니다.");
           },
           onError: () => {
@@ -136,10 +139,15 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
                 : "인증번호를 입력하세요"
             }
             type="text"
-            timer={sendCode ? "03:00" : undefined}
+            timer={sendCode ? formattedTime : undefined}
             {...register("code")}
-            error={!!errors.code || !!codeError}
-            errorMessage={errors.code?.message || codeError}
+            disabled={isExpired && sendCode}
+            error={!!errors.code || !!codeError || (isExpired && sendCode)}
+            errorMessage={
+              isExpired && sendCode
+                ? "인증 시간이 만료되었습니다."
+                : errors.code?.message || codeError
+            }
           />
         </div>
 
@@ -149,7 +157,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
             fullWidth
             onClick={handleSubmit(onSubmit)}
             variant="gradient"
-            disabled={!isValid}
+            disabled={!isValid || (isExpired && sendCode)}
           >
             다음으로
           </Button>

--- a/src/components/auth/flows/find-email/EnterPhoneStep.tsx
+++ b/src/components/auth/flows/find-email/EnterPhoneStep.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import type { z } from "zod";
 
+import { stripPhoneHyphens } from "@/utils/formatPhoneNumber";
 import { findEmailSchema } from "@/utils/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
@@ -69,14 +70,14 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   const postSendCode = async () => {
     const isPhoneValid = await trigger("phoneNum");
     if (isPhoneValid && watchedPhone) {
-      const phoneNumber = watchedPhone.replace(/-/g, "");
+      const phoneNumber = stripPhoneHyphens(watchedPhone);
       sendVerificationSMS(phoneNumber, "인증번호가 발송되었습니다.");
     }
   };
 
   const handleResendSMS = () => {
     if (watchedPhone) {
-      const phoneNumber = watchedPhone.replace(/-/g, "");
+      const phoneNumber = stripPhoneHyphens(watchedPhone);
       sendVerificationSMS(phoneNumber, "인증번호가 재발송되었습니다.");
     }
   };
@@ -87,7 +88,7 @@ export default function EnterPhoneStep({ onNext }: IEnterPhoneStepProps) {
   };
 
   const onSubmit: SubmitHandler<TFindEmailFormValues> = async (formData) => {
-    const phoneNumber = formData.phoneNum.replace(/-/g, "");
+    const phoneNumber = stripPhoneHyphens(formData.phoneNum);
     verifySMSMutate(
       { phoneNumber, verificationCode: formData.code },
       {

--- a/src/components/auth/flows/find-email/ShowEmailResultStep.tsx
+++ b/src/components/auth/flows/find-email/ShowEmailResultStep.tsx
@@ -14,8 +14,8 @@ export default function ShowEmailResultStep() {
     <div className="w-full min-h-screen bg-white flex items-center justify-center">
       <div className="w-full max-w-130 px-6 pb-12">
         <h1 className="text-start font-heading2 text-text-main mb-10">
-          <p>입력하신 정보로</p>
-          <p>WYA에 가입된 계정을 찾았어요</p>
+          <span className="block">입력하신 정보로</span>
+          <span className="block">WYA에 가입된 계정을 찾았어요</span>
         </h1>
 
         <div className="w-full h-24 bg-gray-50 rounded-2xl flex items-center justify-between px-5 mb-10">

--- a/src/components/auth/flows/reset-password/EmailVerificationStep.tsx
+++ b/src/components/auth/flows/reset-password/EmailVerificationStep.tsx
@@ -32,8 +32,8 @@ export default function EmailVerificationStep({
     <div className="w-full min-h-screen bg-white flex items-center justify-center">
       <div className="w-full max-w-130 px-6 pb-12">
         <h1 className="text-start font-heading2 text-text-main mb-10">
-          <p>비밀번호 찾기를 위해</p>
-          <p>이메일 인증을 진행할게요</p>
+          <span className="block">비밀번호 찾기를 위해</span>
+          <span className="block">이메일 인증을 진행할게요</span>
         </h1>
 
         <div className="flex flex-col gap-6">

--- a/src/components/auth/flows/signup/EnterEmailStep.tsx
+++ b/src/components/auth/flows/signup/EnterEmailStep.tsx
@@ -30,8 +30,8 @@ export default function EnterEmailStep({ onNext }: IEnterEmailStepProps) {
     <div className="w-full min-h-screen bg-white flex items-center justify-center">
       <div className="w-full max-w-130 px-6 pb-12">
         <h1 className="text-start font-heading2 text-text-main mb-10">
-          <p>회원가입을 위해</p>
-          <p>이메일 인증을 진행할게요</p>
+          <span className="block">회원가입을 위해</span>
+          <span className="block">이메일 인증을 진행할게요</span>
         </h1>
 
         <div className="flex flex-col gap-6">

--- a/src/components/auth/flows/signup/ProfileSetupStep.tsx
+++ b/src/components/auth/flows/signup/ProfileSetupStep.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import type { z } from "zod";
 
+import { stripPhoneHyphens } from "@/utils/formatPhoneNumber";
 import { signupProfileSchema } from "@/utils/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
@@ -39,7 +40,7 @@ export default function ProfileSetupStep() {
         email,
         password,
         name: data.name,
-        phone_number: data.phoneNum.replace(/-/g, ""),
+        phone_number: stripPhoneHyphens(data.phoneNum),
       },
       {
         onSuccess: () => {

--- a/src/components/auth/flows/signup/ProfileSetupStep.tsx
+++ b/src/components/auth/flows/signup/ProfileSetupStep.tsx
@@ -39,7 +39,7 @@ export default function ProfileSetupStep() {
         email,
         password,
         name: data.name,
-        phone_number: data.phoneNum,
+        phone_number: data.phoneNum.replace(/-/g, ""),
       },
       {
         onSuccess: () => {

--- a/src/components/auth/flows/signup/ProfileSetupStep.tsx
+++ b/src/components/auth/flows/signup/ProfileSetupStep.tsx
@@ -63,8 +63,8 @@ export default function ProfileSetupStep() {
     <div className="w-full min-h-screen bg-white flex items-center justify-center">
       <div className="w-full max-w-130 px-6 pb-12">
         <h1 className="text-start font-heading2 text-text-main mb-10">
-          <p>사용자의</p>
-          <p>기본 정보를 입력해 주세요</p>
+          <span className="block">사용자의</span>
+          <span className="block">기본 정보를 입력해 주세요</span>
         </h1>
 
         <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-7">

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,17 +1,28 @@
 import { useCoreMutation } from "@/hooks/customQuery";
 
-import { login, sendEmail, signUp, verifyEmail } from "@/api/auth/auth";
+import {
+  login,
+  sendEmail,
+  sendSMS,
+  signUp,
+  verifyEmail,
+  verifySMS,
+} from "@/api/auth/auth";
 
 export const useAuth = () => {
   const useLogin = useCoreMutation(login);
   const useSignUp = useCoreMutation(signUp);
   const useSendCode = useCoreMutation(sendEmail);
   const useCheckCode = useCoreMutation(verifyEmail);
+  const useSendSMS = useCoreMutation(sendSMS);
+  const useVerifySMS = useCoreMutation(verifySMS);
 
   return {
     useLogin,
     useSignUp,
     useSendCode,
     useCheckCode,
+    useSendSMS,
+    useVerifySMS,
   };
 };

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -27,9 +27,6 @@ export default function RedirectPage() {
     const accessToken = getCookie("access_token");
 
     if (accessToken) {
-      // TODO: 로그인 상태 업데이트
-      login("social@user.com", accessToken);
-
       deleteCookie("access_token");
 
       toast.success("소셜 로그인되었습니다.");

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -58,3 +58,28 @@ export interface ITokenRefreshResponse {
 
 // 소셜 로그인 플랫폼
 export type TSocialLoginPlatform = "kakao" | "naver" | "google";
+
+// SMS 인증 요청
+export interface ISmsSendRequest {
+  phoneNumber: string;
+}
+
+// SMS 인증 요청 응답
+export interface ISmsSendResponse {
+  message: string;
+  phoneNumber: string;
+  expireIn: number;
+}
+
+// SMS 인증 확인 요청
+export interface ISmsVerifyRequest {
+  phoneNumber: string;
+  verificationCode: string;
+}
+
+// SMS 인증 확인 응답
+export interface ISmsVerifyResponse {
+  isVerified: boolean;
+  verificationMessage: string;
+  email: string;
+}

--- a/src/utils/formatPhoneNumber.ts
+++ b/src/utils/formatPhoneNumber.ts
@@ -1,3 +1,7 @@
+export function stripPhoneHyphens(value: string): string {
+  return value.replace(/-/g, "");
+}
+
 export default function formatPhoneNumber(value: string): string {
   // 1. 숫자만 남기기
   const digits = value.replace(/\D/g, "").slice(0, 11);


### PR DESCRIPTION
## 🚨 관련 이슈

Closes #36 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### find-email SMS 인증 API 연결
- SMS 인증번호 전송 API
- SMS 인증번호 확인 API
- 인증번호 재발송 UI 추가

### Auth API 파라미터 스타일 통일
- signUp, login, sendSMS, verifySMS 모두 구조 분해 파라미터 방식으로 통일했습니다.
- data: responseData 별칭 패턴 제거

### 회원가입 전화번호 형식 버그 수정
- 전화번호 하이픈 제거 후 전송

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * SMS 인증 흐름이 도입되어 가입·비밀번호 찾기에서 SMS로 인증할 수 있습니다.
  * 인증번호 전송 및 검증, 인증번호 재전송 기능이 추가되었습니다.
  * 인증 중 휴대폰 번호를 즉시 수정할 수 있는 UI가 제공됩니다.

* **개선**
  * 인증 코드 만료를 보여주는 타이머가 추가되어 만료 상태를 반영합니다.
  * 휴대폰 번호 입력 시 하이픈 등 형식이 자동으로 정규화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->