### PR TITLE
[Feature/#38] 비밀번호 재설정 API 연동

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -4,6 +4,7 @@ import type {
   IEmailVerifyRequest,
   ILoginRequest,
   ILoginResponse,
+  IPasswordResetRequest,
   ISignUpRequest,
   ISignUpResponse,
   ISmsSendRequest,
@@ -91,5 +92,33 @@ export const verifySMS = async ({
     phoneNumber,
     verificationCode,
   });
+  return data;
+};
+
+// 비밀번호 재설정 요청
+export const requestPasswordReset = async ({
+  email,
+}: IEmailSendRequest): Promise<ICommonResponse<IEmailSendResponse>> => {
+  const { data } = await axiosInstance.post(
+    "/api/users/password-reset/request",
+    {
+      email,
+    },
+  );
+  return data;
+};
+
+// 비밀번호 재설정
+export const resetPassword = async ({
+  email,
+  password,
+}: IPasswordResetRequest): Promise<ICommonResponse<string>> => {
+  const { data } = await axiosInstance.post(
+    "/api/users/password-reset/confirm",
+    {
+      email,
+      password,
+    },
+  );
   return data;
 };

--- a/src/components/auth/flows/reset-password/EmailVerificationStep.tsx
+++ b/src/components/auth/flows/reset-password/EmailVerificationStep.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from "@/hooks/auth/useAuth";
 import { useEmailVerification } from "@/hooks/auth/useEmailVerification";
 
 import CommonAuthInput from "@/components/auth/common/CommonAuthInput";
@@ -10,6 +11,7 @@ interface IEmailVerificationStepProps {
 export default function EmailVerificationStep({
   onNext,
 }: IEmailVerificationStepProps) {
+  const { useRequestPasswordReset } = useAuth();
   const {
     form: { register },
     watchedEmail,
@@ -26,7 +28,7 @@ export default function EmailVerificationStep({
       handleEditEmail,
       handleSubmit,
     },
-  } = useEmailVerification({ onNext });
+  } = useEmailVerification({ onNext, sendMutation: useRequestPasswordReset });
 
   return (
     <div className="w-full min-h-screen bg-white flex items-center justify-center">

--- a/src/components/auth/flows/reset-password/NewPasswordStep.tsx
+++ b/src/components/auth/flows/reset-password/NewPasswordStep.tsx
@@ -20,7 +20,7 @@ export default function NewPasswordStep() {
           toast.success("비밀번호가 변경되었습니다.", {
             description: "로그인 페이지로 이동합니다.",
           });
-          navigate("/login");
+          navigate("/login", { replace: true });
         },
         onError: (error) => {
           toast.error(

--- a/src/components/auth/flows/reset-password/NewPasswordStep.tsx
+++ b/src/components/auth/flows/reset-password/NewPasswordStep.tsx
@@ -1,20 +1,34 @@
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
+import { useAuth } from "@/hooks/auth/useAuth";
+
 import PasswordForm from "@/components/auth/common/PasswordForm";
 
 import useAuthStore from "@/store/useAuthStore";
 
 export default function NewPasswordStep() {
   const navigate = useNavigate();
-  const { setPassword } = useAuthStore();
+  const { email } = useAuthStore();
+  const { useResetPassword } = useAuth();
 
   const handleSubmit = (password: string) => {
-    setPassword(password);
-    toast.success("비밀번호가 변경되었습니다.", {
-      description: "로그인 페이지로 이동합니다.",
-    });
-    navigate("/login");
+    useResetPassword.mutate(
+      { email, password },
+      {
+        onSuccess: () => {
+          toast.success("비밀번호가 변경되었습니다.", {
+            description: "로그인 페이지로 이동합니다.",
+          });
+          navigate("/login");
+        },
+        onError: (error) => {
+          toast.error(
+            error.response?.data?.message || "비밀번호 변경에 실패했습니다.",
+          );
+        },
+      },
+    );
   };
 
   return (
@@ -28,6 +42,7 @@ export default function NewPasswordStep() {
       }
       buttonText="비밀번호 변경하기"
       onSubmit={handleSubmit}
+      disabled={useResetPassword.isPending}
     />
   );
 }

--- a/src/components/auth/flows/signup/ProfileSetupStep.tsx
+++ b/src/components/auth/flows/signup/ProfileSetupStep.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -22,6 +23,12 @@ export default function ProfileSetupStep() {
   const { email, password, resetAuth } = useAuthStore();
   const { openModal } = useModalStore();
   const { useSignUp } = useAuth();
+
+  useEffect(() => {
+    if (!email || !password) {
+      navigate("/signup", { replace: true });
+    }
+  }, [email, password, navigate]);
 
   const {
     register,

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -10,9 +10,16 @@ import {
   verifyEmail,
   verifySMS,
 } from "@/api/auth/auth";
+import useAuthStore from "@/store/useAuthStore";
 
 export const useAuth = () => {
-  const useLogin = useCoreMutation(login);
+  const { login: loginAction } = useAuthStore();
+
+  const useLogin = useCoreMutation(login, {
+    userOnSuccess: (response, vars) => {
+      loginAction(vars.email, response.data.accessToken);
+    },
+  });
   const useSignUp = useCoreMutation(signUp);
   const useSendCode = useCoreMutation(sendEmail);
   const useCheckCode = useCoreMutation(verifyEmail);

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -2,6 +2,8 @@ import { useCoreMutation } from "@/hooks/customQuery";
 
 import {
   login,
+  requestPasswordReset,
+  resetPassword,
   sendEmail,
   sendSMS,
   signUp,
@@ -16,6 +18,8 @@ export const useAuth = () => {
   const useCheckCode = useCoreMutation(verifyEmail);
   const useSendSMS = useCoreMutation(sendSMS);
   const useVerifySMS = useCoreMutation(verifySMS);
+  const useRequestPasswordReset = useCoreMutation(requestPasswordReset);
+  const useResetPassword = useCoreMutation(resetPassword);
 
   return {
     useLogin,
@@ -24,5 +28,7 @@ export const useAuth = () => {
     useCheckCode,
     useSendSMS,
     useVerifySMS,
+    useRequestPasswordReset,
+    useResetPassword,
   };
 };

--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 import { toast } from "sonner";
 import type { z } from "zod";
+
+import type { IEmailSendRequest, IEmailSendResponse } from "@/types/auth/auth";
+import type { ICommonResponse } from "@/types/common/common";
 
 import { signupEmailSchema } from "@/utils/validation";
 
@@ -13,15 +18,24 @@ import useAuthStore from "@/store/useAuthStore";
 
 export type TSignupEmailFormValues = z.infer<typeof signupEmailSchema>;
 
+type TSendCodeMutation = UseMutationResult<
+  ICommonResponse<IEmailSendResponse>,
+  AxiosError<{ message?: string }>,
+  IEmailSendRequest
+>;
+
 interface IUseEmailVerificationProps {
   onNext: () => void;
+  sendMutation?: TSendCodeMutation;
 }
 
 export const useEmailVerification = ({
   onNext,
+  sendMutation,
 }: IUseEmailVerificationProps) => {
   const { setEmail } = useAuthStore();
   const { useSendCode, useCheckCode } = useAuth();
+  const activeSendCode = sendMutation ?? useSendCode;
 
   const [sendCode, setSendCode] = useState(false);
   const [codeError, setCodeError] = useState("");
@@ -53,7 +67,7 @@ export const useEmailVerification = ({
   }, [stop]);
 
   const sendVerificationEmail = (email: string, successMessage: string) => {
-    useSendCode.mutate(
+    activeSendCode.mutate(
       { email },
       {
         onSuccess: (data) => {
@@ -113,7 +127,7 @@ export const useEmailVerification = ({
     codeError,
     errors,
     isValid,
-    isPending: useSendCode.isPending || useCheckCode.isPending,
+    isPending: activeSendCode.isPending || useCheckCode.isPending,
     handlers: {
       postSendCode,
       handleResendEmail,

--- a/src/hooks/auth/useTokenRefresh.ts
+++ b/src/hooks/auth/useTokenRefresh.ts
@@ -7,6 +7,8 @@ export const useTokenRefresh = () => {
   const { setAccessToken, logout } = useAuthStore();
 
   useEffect(() => {
+    if (!localStorage.getItem("hasSession")) return;
+
     const initAuth = async () => {
       try {
         const { data } = await reissueToken();

--- a/src/hooks/auth/useTokenRefresh.ts
+++ b/src/hooks/auth/useTokenRefresh.ts
@@ -1,12 +1,16 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { reissueToken } from "@/api/auth/auth";
 import useAuthStore from "@/store/useAuthStore";
 
 export const useTokenRefresh = () => {
   const { setAccessToken, logout } = useAuthStore();
+  const initialized = useRef(false);
 
   useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
     if (!localStorage.getItem("hasSession")) return;
 
     const initAuth = async () => {

--- a/src/hooks/auth/useTokenRefresh.ts
+++ b/src/hooks/auth/useTokenRefresh.ts
@@ -4,15 +4,14 @@ import { reissueToken } from "@/api/auth/auth";
 import useAuthStore from "@/store/useAuthStore";
 
 export const useTokenRefresh = () => {
-  const { login, logout } = useAuthStore();
+  const { setAccessToken, logout } = useAuthStore();
 
   useEffect(() => {
     const initAuth = async () => {
       try {
         const { data } = await reissueToken();
         if (data.accessToken) {
-          // TODO: 재발급 성공 시 로그인 처리
-          login("user@example.com", data.accessToken);
+          setAccessToken(data.accessToken);
         }
       } catch {
         logout();
@@ -20,5 +19,5 @@ export const useTokenRefresh = () => {
     };
 
     initAuth();
-  }, [login, logout]);
+  }, [setAccessToken, logout]);
 };

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -16,7 +16,6 @@ import Button from "@/components/common/button/Button";
 import GoogleIcon from "@/assets/auth/social/google.svg?react";
 import KakaoIcon from "@/assets/auth/social/kakao.svg?react";
 import NaverIcon from "@/assets/auth/social/naver.svg?react";
-import useAuthStore from "@/store/useAuthStore";
 
 type TLoginFormValues = z.infer<typeof loginSchema>;
 
@@ -32,14 +31,11 @@ export default function Login() {
 
   const navigate = useNavigate();
   const { useLogin } = useAuth();
-  const { login: loginAction } = useAuthStore();
   const { handleSocialLogin } = useSocialLogin();
 
   const onSubmit: SubmitHandler<TLoginFormValues> = (data) => {
     useLogin.mutate(data, {
-      onSuccess: (response) => {
-        const { accessToken } = response.data;
-        loginAction(data.email, accessToken);
+      onSuccess: () => {
         navigate("/", { replace: true });
       },
       onError: (error: AxiosError<{ message?: string }>) => {

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -29,7 +29,6 @@ export default function RedirectPage() {
     if (accessToken) {
       deleteCookie("access_token");
       setAccessToken(accessToken);
-      localStorage.setItem("hasSession", "true");
 
       toast.success("소셜 로그인되었습니다.");
       navigate("/", { replace: true });

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -6,7 +6,7 @@ import useAuthStore from "@/store/useAuthStore";
 
 export default function RedirectPage() {
   const navigate = useNavigate();
-  const { login } = useAuthStore();
+  const { setAccessToken } = useAuthStore();
   const processed = useRef(false);
 
   useEffect(() => {
@@ -28,6 +28,8 @@ export default function RedirectPage() {
 
     if (accessToken) {
       deleteCookie("access_token");
+      setAccessToken(accessToken);
+      localStorage.setItem("hasSession", "true");
 
       toast.success("소셜 로그인되었습니다.");
       navigate("/", { replace: true });
@@ -35,7 +37,7 @@ export default function RedirectPage() {
       toast.error("소셜 로그인에 실패했습니다. 다시 시도해주세요.");
       navigate("/login", { replace: true });
     }
-  }, [navigate, login]);
+  }, [navigate, setAccessToken]);
 
   return (
     <div className="relative flex justify-center items-center h-screen w-full bg-white">

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -40,7 +40,10 @@ const useAuthStore = create<IAuthState>((set) => ({
     });
   },
 
-  setAccessToken: (token) => set({ accessToken: token }),
+  setAccessToken: (token) => {
+    localStorage.setItem("hasSession", "true");
+    set({ accessToken: token, isLoggedIn: true });
+  },
   setEmail: (email) => set({ email }),
   setPassword: (password) => set({ password }),
   setSocialId: (socialId) => set({ socialId }),

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -24,11 +24,13 @@ const useAuthStore = create<IAuthState>((set) => ({
   socialId: -1,
 
   login: (email, accessToken) => {
+    localStorage.setItem("hasSession", "true");
     set({ isLoggedIn: true, email, accessToken });
   },
   logout: () => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    localStorage.removeItem("hasSession");
     set({
       isLoggedIn: false,
       accessToken: null,

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -83,3 +83,9 @@ export interface ISmsVerifyResponse {
   verificationMessage: string;
   email: string;
 }
+
+// 비밀번호 재설정 요청
+export interface IPasswordResetRequest {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
## 🚨 관련 이슈

#38 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
### 비밀번호 재설정 API 연동
- 비밀번호 재설정 기능 구현

### useTokenRefresh 조건부 실행
- 앱 초기화 시 무조건 토큰 재발급 API를 호출하던 문제 수정

### 관심사 분리 
- `Login.tsx / useAuth.ts`
- `Login.tsx`가 `useAuthStore`를 직접 import해서 인증 상태를 업데이트하던 로직을 훅 내부로 이동


## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이메일 기반 비밀번호 재설정 흐름 추가(요청 및 새 비밀번호 제출)

* **개선 사항**
  * 재설정 흐름에서 제출 로딩 상태 및 서버 오류 안내 개선
  * 로그인/리다이렉트 시 토큰 영구화 강화(세션 상태 저장 및 토큰 갱신 처리)
  * 회원가입 과정에서 이메일/비밀번호 누락 시 자동 리다이렉트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->