### PR TITLE
[Refactor/#67] 인증코드 이메일 전송 응답값 변화에 따른 리팩토링

### DIFF
--- a/src/hooks/auth/useEmailVerification.ts
+++ b/src/hooks/auth/useEmailVerification.ts
@@ -66,11 +66,29 @@ export const useEmailVerification = ({
     stop();
   }, [stop]);
 
+  const PROVIDER_NAME: Record<string, string> = {
+    GOOGLE: "구글",
+    KAKAO: "카카오",
+    NAVER: "네이버",
+  };
+
   const sendVerificationEmail = (email: string, successMessage: string) => {
     activeSendCode.mutate(
       { email },
       {
         onSuccess: (data) => {
+          const { isProviderLinked, providerTypes } = data.data;
+
+          if (isProviderLinked) {
+            const providerNames = providerTypes
+              .map((type) => PROVIDER_NAME[type])
+              .join(", ");
+            toast.error("이미 소셜 로그인으로 가입된 이메일입니다.", {
+              description: `${providerNames}계정으로 로그인해주세요`,
+            });
+            return;
+          }
+
           setSendCode(true);
           toast.success(successMessage);
           restart(data.data.expireIn);

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -6,6 +6,8 @@ export interface IEmailSendResponse {
   message: string;
   email: string;
   expireIn: number;
+  isProviderLinked: boolean;
+  providerTypes: TLoginProvider[];
 }
 
 export interface IEmailVerifyRequest {


### PR DESCRIPTION

## 🚨 관련 이슈

#67 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- `PROVIDER_NAME`으로 소셜 한국어 변환
- 백엔드 응답값에 맞추어 소셜 로그인으로 가입된 이메일로 이메일 회원가입 인증코드 발송 요청 시, 
- 가입된 계정임을 toast 메시지로 안내

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

[//]: # "리뷰어가 알면 좋은 내용을 작성해주세요."

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이메일 인증 시 해당 이메일이 소셜 로그인(Google, Kakao, Naver)으로 이미 등록된 경우를 감지하고 사용자에게 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->