### PR TITLE
[Refactor/#80] ControlBox 커스터마이징, WorkspaceSetting 삭제영역 구조 통일

### DIFF
--- a/src/components/common/controlbox/ControlBox.tsx
+++ b/src/components/common/controlbox/ControlBox.tsx
@@ -1,4 +1,5 @@
-import type { HTMLAttributes } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
+import type React from "react";
 import { twMerge } from "tailwind-merge";
 
 import Button from "../button/Button";
@@ -8,6 +9,15 @@ interface IControlBoxProps extends HTMLAttributes<HTMLDivElement> {
   description: string;
   buttonText: string;
   onButtonClick: () => void;
+  containerClassName?: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+  buttonSize?: React.ComponentProps<typeof Button>["size"];
+  buttonClassName?: string;
+  buttonSlot?: ReactNode;
+  leadingSlot?: ReactNode;
+  contentClassName?: string;
 }
 
 export default function ControlBox({
@@ -16,30 +26,62 @@ export default function ControlBox({
   buttonText,
   onButtonClick,
   className,
+  containerClassName,
+  titleClassName,
+  descriptionClassName,
+  buttonVariant = "primary",
+  buttonSize = "small",
+  buttonClassName,
+  buttonSlot,
+  leadingSlot,
+  contentClassName,
   ...rest
 }: IControlBoxProps) {
   return (
     <div
       className={twMerge(
-        "flex items-center justify-between min-w-180 px-7 py-6 bg-chart-3/7 border-[0.5px] border-chart-3 rounded-component-lg",
+        "flex items-center justify-between min-w-180 px-7 py-6 border-[0.5px]  rounded-component-lg",
+        "border-chart-3 bg-chart-3/7",
+        containerClassName,
         className,
       )}
       {...rest}
     >
-      <div className="flex flex-col gap-2">
-        <h3 className="font-heading3 text-chart-3">{title}</h3>
-        <p className="font-body2 text-text-sub whitespace-pre-line leading-relaxed">
-          {description}
-        </p>
-      </div>
-      <Button
-        variant="primary"
-        size="small"
-        onClick={onButtonClick}
-        className="shrink-0 !h-button-big px-8 !rounded-component-md"
+      <div
+        className={twMerge(
+          "flex items-center gap-4 sm:gap-8",
+          contentClassName,
+        )}
       >
-        {buttonText}
-      </Button>
+        {leadingSlot ? <div className="shrink-0">{leadingSlot}</div> : null}
+        <div className="flex flex-col gap-2">
+          <h3 className={twMerge("font-heading3 text-chart-3", titleClassName)}>
+            {title}
+          </h3>
+          <p
+            className={twMerge(
+              "font-body2 text-text-sub whitespace-pre-line leading-relaxed",
+              descriptionClassName,
+            )}
+          >
+            {description}
+          </p>
+        </div>
+      </div>
+
+      {buttonSlot ?? (
+        <Button
+          variant={buttonVariant}
+          size={buttonSize}
+          onClick={onButtonClick}
+          className={twMerge(
+            "shrink-0 !h-button-big px-8 !rounded-component-md",
+            buttonClassName,
+          )}
+        >
+          {buttonText}
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/common/controlbox/ControlBox.tsx
+++ b/src/components/common/controlbox/ControlBox.tsx
@@ -15,6 +15,7 @@ interface IControlBoxProps extends HTMLAttributes<HTMLDivElement> {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"];
   buttonSize?: React.ComponentProps<typeof Button>["size"];
   buttonClassName?: string;
+  buttonDisabled?: boolean;
   buttonSlot?: ReactNode;
   leadingSlot?: ReactNode;
   contentClassName?: string;
@@ -32,6 +33,7 @@ export default function ControlBox({
   buttonVariant = "primary",
   buttonSize = "small",
   buttonClassName,
+  buttonDisabled,
   buttonSlot,
   leadingSlot,
   contentClassName,
@@ -74,8 +76,9 @@ export default function ControlBox({
           variant={buttonVariant}
           size={buttonSize}
           onClick={onButtonClick}
+          disabled={buttonDisabled}
           className={twMerge(
-            "shrink-0 !h-button-big px-8 !rounded-component-md",
+            "shrink-0 px-8 !rounded-component-md",
             buttonClassName,
           )}
         >

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import Button from "@/components/common/button/Button";
+import ControlBox from "@/components/common/controlbox/ControlBox";
 import Input from "@/components/common/input/Input";
 import Modal from "@/components/common/modal/Modal";
 import TextareaField from "@/components/common/textarea/TextareaField";
@@ -211,28 +212,21 @@ export default function WorkspaceSetting() {
               {saving ? "저장 중.." : "변경사항 저장하기"}
             </Button>
           </div>
-          <div className="bg-status-red/10 border border-status-red rounded-component-lg p-6 sm:p-8 mt-12 flex flex-col gap-6 md:flex-row md:justify-between md:items-center">
-            <div className="flex gap-4 sm:gap-8 items-start sm:items-center">
-              <WarningIcon />
-              <div>
-                <div className="text-status-red font-heading4">
-                  워크스페이스 삭제
-                </div>
-                <p className="font-body1 text-text-auth-sub mt-2">
-                  워크스페이스를 삭제하면 모든 데이터가 영구적으로 삭제됩니다.
-                  <br />이 작업은 되돌릴 수 없습니다.
-                </p>
-              </div>
-            </div>
-            <Button
-              variant="dangerSoft"
-              size="big"
-              aria-label="워크스페이스 삭제 버튼"
-              onClick={openDeleteModal}
-              disabled={saving || deleting}
-            >
-              워크스페이스 삭제
-            </Button>
+          <div className="w-full flex flex-col">
+            <ControlBox
+              title="워크스페이스 삭제"
+              description={`워크스페이스를 삭제하면 모든 데이터가 영구적으로 삭제됩니다.\n 이 작업은 되돌릴 수 없습니다`}
+              buttonText="워크스페이스 삭제"
+              onButtonClick={openDeleteModal}
+              className="w-full mt-12"
+              containerClassName="bg-status-red/10 border-status-red"
+              titleClassName="text-status-red"
+              descriptionClassName="text-text-auth-sub"
+              buttonVariant="dangerSoft"
+              buttonSize="big"
+              buttonClassName="px-8 !rounded-component-md"
+              leadingSlot={<WarningIcon />}
+            />
           </div>
           <Modal
             isOpen={deleteOpen}

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -225,6 +225,7 @@ export default function WorkspaceSetting() {
               buttonVariant="dangerSoft"
               buttonSize="big"
               buttonClassName="px-8 !rounded-component-md"
+              buttonDisabled={saving || deleting}
               leadingSlot={<WarningIcon />}
             />
           </div>


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #80 

## ✨ 변경사항

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- WorkspaceSetting 삭제 섹션이 인라인 UI로 구현되어있어 공통 컴포넌트 구조로 리팩토링
- 삭제 영역 UI에 맞게 ControlBox 컴포넌트를 커스터마이징 가능하도록 확장

## 😅 미완성 작업

N/A


## 📢 논의 사항 및 참고 사항

기존 WorkspaceSetting의 삭제 섹션 인라인 UI를 ControlBox 구조를 변경하여 공통 컴포넌트 재사용성과 일관성을 높였습니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 제어 박스(UI 컴포넌트)에 스타일·레이아웃 및 버튼 옵션(변형, 크기, 비활성화 등)과 추가 슬롯(선행 아이콘·버튼 대체 등)을 도입해 커스터마이제이션을 확대했습니다.
  * 작업 공간 설정의 삭제 섹션을 통합된 제어 박스로 재구성해 UI 일관성과 유지보수성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->