### PR TITLE
[Feature/#114] 통합 대시보드 예산 소진 현황 API 연동

### DIFF
--- a/src/api/dashboard/overview.ts
+++ b/src/api/dashboard/overview.ts
@@ -1,5 +1,8 @@
 import type { ICommonResponse } from "@/types/common/common";
-import type { IMetricsResponse } from "@/types/dashboard/overview";
+import type {
+  IBudgetsResponse,
+  IMetricsResponse,
+} from "@/types/dashboard/overview";
 
 import { axiosInstance } from "@/lib/axiosInstance";
 
@@ -13,6 +16,18 @@ export const getOverview = async (
   const { data } = await axiosInstance.get<ICommonResponse<IMetricsResponse>>(
     `/api/dashboard/${orgId}/metrics`,
     { params: providerType ? { providerType } : undefined },
+  );
+  return data.data;
+};
+
+// 대시보드 - 예산 집계 API
+export const getBudget = async (
+  orgId: number,
+  providerType?: TProviderType,
+): Promise<IBudgetsResponse> => {
+  const { data } = await axiosInstance.get<ICommonResponse<IBudgetsResponse>>(
+    `/api/dashboard/budgets`,
+    { params: { orgId, ...(providerType ? { providerType } : {}) } },
   );
   return data.data;
 };

--- a/src/hooks/dashboard/useOverviewBudget.ts
+++ b/src/hooks/dashboard/useOverviewBudget.ts
@@ -1,0 +1,21 @@
+import { useCoreQuery } from "@/hooks/customQuery";
+
+import { getBudget } from "@/api/dashboard/overview";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+const WARNING_THRESHOLD = 50;
+const DANGER_THRESHOLD = 75;
+
+export function useOverviewBudget() {
+  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+
+  return useCoreQuery(["overview", "budget", orgId], () => getBudget(orgId!), {
+    enabled: !!orgId,
+    select: (data) => ({
+      totalBudget: data.totalBudget,
+      spent: data.totalSpend,
+      warningThreshold: WARNING_THRESHOLD,
+      dangerThreshold: DANGER_THRESHOLD,
+    }),
+  });
+}

--- a/src/pages/dashboard/overview/OverviewDashboard.tsx
+++ b/src/pages/dashboard/overview/OverviewDashboard.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 
 import { printAsPdf } from "@/utils/download";
 
+import { useOverviewBudget } from "@/hooks/dashboard/useOverviewBudget";
 import { useOverviewMetrics } from "@/hooks/dashboard/useOverviewMetrics";
 
 import Badge from "@/components/common/badge/Badge";
@@ -17,7 +18,6 @@ import BudgetGaugeChart, {
   getBudgetStatus,
   statusBadgeVariant,
 } from "@/components/dashboard/charts/BudgetGaugeChart";
-import { budgetGaugeChartMock } from "@/components/dashboard/charts/budgetGaugeChart.mock";
 import TrafficChart, {
   TrafficChartDownload,
 } from "@/components/dashboard/charts/TrafficChart";
@@ -39,6 +39,7 @@ export default function OverviewDashboard() {
     isLoading: isKpisLoading,
     isError: isKpisError,
   } = useOverviewMetrics();
+  const { data: budget } = useOverviewBudget();
   const [currentDate] = useState(() =>
     new Date().toLocaleString("ko-KR", {
       year: "numeric",
@@ -49,10 +50,13 @@ export default function OverviewDashboard() {
     }),
   );
 
-  const { totalBudget, spent, warningThreshold, dangerThreshold } =
-    budgetGaugeChartMock;
+  // 예산 상태 계산 - 카드 헤더 배지
+  const warningThreshold = budget?.warningThreshold ?? 50;
+  const dangerThreshold = budget?.dangerThreshold ?? 75;
   const budgetPct =
-    totalBudget > 0 ? Math.round((spent / totalBudget) * 100) : 0;
+    budget && budget.totalBudget > 0
+      ? Math.round((budget.spent / budget.totalBudget) * 100)
+      : 0;
   const budgetStatus = getBudgetStatus(
     budgetPct,
     warningThreshold,
@@ -138,7 +142,11 @@ export default function OverviewDashboard() {
             </Badge>
           }
         >
-          <BudgetGaugeChart {...budgetGaugeChartMock} />
+          {budget ? (
+            <BudgetGaugeChart {...budget} />
+          ) : (
+            <div className="flex-1 animate-pulse rounded-2xl bg-bg-surface" />
+          )}
         </Card>
       </div>
 

--- a/src/pages/dashboard/overview/OverviewDashboard.tsx
+++ b/src/pages/dashboard/overview/OverviewDashboard.tsx
@@ -89,6 +89,7 @@ export default function OverviewDashboard() {
             지표 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
           </div>
         ) : isKpisLoading ? (
+          // TODO: 스켈레톤 UI 통일 작업 시 개선
           Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
@@ -145,6 +146,7 @@ export default function OverviewDashboard() {
           {budget ? (
             <BudgetGaugeChart {...budget} />
           ) : (
+            // TODO: 스켈레톤 UI 통일 작업 시 개선
             <div className="flex-1 animate-pulse rounded-2xl bg-bg-surface" />
           )}
         </Card>

--- a/src/types/dashboard/overview.ts
+++ b/src/types/dashboard/overview.ts
@@ -8,3 +8,11 @@ export interface IMetricsResponse {
   ROAS: number;
   ROASChangeRate: number;
 }
+
+export interface IBudgetsResponse {
+  providerType: string;
+  usagePercentage: number;
+  totalBudget: number;
+  totalSpend: number;
+  remainingBudget: number;
+}


### PR DESCRIPTION
#114 

## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

1. useOverviewBudget 훅 생성
- getBudget API를 호출하고 BudgetGaugeChart props 형태로 데이터 변환

2. 통합 대시보드 예산 섹션 실제 데이터 연동
- mock 데이터 제거 후 useOverviewBudget 훅으로 교체

3. 임시 스켈레톤 UI TODO 주석 처리
- 스켈레톤 UI 통일 이슈에서 개선 예정
- KPI 카드, 예산 카드 스켈레톤에 주석 추가

## 😅 미완성 작업
N/A


## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 대시보드 개요의 예산 차트가 실시간 예산 데이터로 업데이트되었습니다. 총 예산, 현재 지출액, 남은 예산, 사용률을 한눈에 확인할 수 있으며, 경고 및 위험 수준의 임계값 표시 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->