### PR TITLE
[Feature/#118] 멤버 권한 변경 및 삭제 API 연동

### DIFF
--- a/src/api/workspace/org.ts
+++ b/src/api/workspace/org.ts
@@ -2,15 +2,16 @@ import type { ICommonResponse } from "@/types/common/common";
 import {
   type TCreateOrgRequest,
   type TCreateOrgResponse,
+  type TDeleteWorkspaceMemberResponse,
   type TGetOrgResponse,
   type TGetWorkspaceMembersData,
   type TMyOrgsData,
   type TUpdateMemberRoleRequest,
+  type TUpdateMemberRoleResponse,
   type TUpdateWorkspaceRequest,
   type TUploadImageResponse,
   type TWorkspace,
   type TWorkspaceDetail,
-  type TWorkspaceMember,
   type TWorkspaceMemberCount,
 } from "@/types/workspace/workspace";
 
@@ -89,18 +90,21 @@ export const updateWorkspaceMemberPermission = async (
   orgId: number,
   memberId: number,
   body: TUpdateMemberRoleRequest,
-): Promise<void> => {
-  await axiosInstance.patch<ICommonResponse<TWorkspaceMember>>(
-    `/api/org/members/${orgId}/${memberId}`,
-    body,
-  );
+): Promise<TUpdateMemberRoleResponse> => {
+  const { data } = await axiosInstance.patch<
+    ICommonResponse<TUpdateMemberRoleResponse>
+  >(`/api/org/members/${orgId}/${memberId}`, body);
+
+  return data.data;
 };
 
-export const deleteMember = async (
+export const deleteWorkspaceMember = async (
   orgId: number,
   memberId: number,
-): Promise<void> => {
-  (await axiosInstance.delete)<ICommonResponse<string>>(
-    `/api/org/${orgId}/members/${memberId}`,
-  );
+): Promise<TDeleteWorkspaceMemberResponse> => {
+  const { data } = await axiosInstance.delete<
+    ICommonResponse<TDeleteWorkspaceMemberResponse>
+  >(`/api/org/${orgId}/members/${memberId}`);
+
+  return data.data;
 };

--- a/src/api/workspace/org.ts
+++ b/src/api/workspace/org.ts
@@ -5,10 +5,12 @@ import {
   type TGetOrgResponse,
   type TGetWorkspaceMembersData,
   type TMyOrgsData,
+  type TUpdateMemberRoleRequest,
   type TUpdateWorkspaceRequest,
   type TUploadImageResponse,
   type TWorkspace,
   type TWorkspaceDetail,
+  type TWorkspaceMember,
   type TWorkspaceMemberCount,
 } from "@/types/workspace/workspace";
 
@@ -81,4 +83,24 @@ export const getWorkspaceMemberCount = async (
     ICommonResponse<TWorkspaceMemberCount>
   >(`/api/org/members/${orgId}/count`);
   return data.data;
+};
+
+export const updateWorkspaceMemberPermission = async (
+  orgId: number,
+  memberId: number,
+  body: TUpdateMemberRoleRequest,
+): Promise<void> => {
+  await axiosInstance.patch<ICommonResponse<TWorkspaceMember>>(
+    `/api/org/members/${orgId}/${memberId}`,
+    body,
+  );
+};
+
+export const deleteMember = async (
+  orgId: number,
+  memberId: number,
+): Promise<void> => {
+  (await axiosInstance.delete)<ICommonResponse<string>>(
+    `/api/org/${orgId}/members/${memberId}`,
+  );
 };

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import {
   type TMemberRole,
+  type TUpdateMemberRoleRequest,
   type TWorkspaceMember,
 } from "@/types/workspace/workspace";
 
@@ -16,10 +22,13 @@ import TransferOwnershipBlockedModal from "@/components/workspace/TransferOwners
 import TransferOwnershipModal from "@/components/workspace/TransferOwnershipModal";
 
 import {
+  deleteWorkspaceMember,
   getWorkspaceMemberCount,
   getWorkspaceMembers,
+  updateWorkspaceMemberPermission,
 } from "@/api/workspace/org";
 import WarnIcon from "@/assets/icon/common/warn-circle.svg?react";
+import { getAxiosMessage } from "@/lib/getAxiosMessage";
 
 const PAGE_SIZE = 20;
 
@@ -27,9 +36,9 @@ export default function MemberManagement() {
   const navigate = useNavigate();
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const orgId = Number(workspaceId);
+  const queryClient = useQueryClient();
 
   const [changing, setChanging] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isBlockedModalOpen, setIsBlockedModalOpen] = useState(false);
@@ -67,9 +76,48 @@ export default function MemberManagement() {
     return members.filter((member) => member.role === "ADMIN").length;
   }, [members]);
 
+  // 소유권이전. 나빼고, 이미 ADMIN인 사람
+  // 기능 보류. 회의 거쳐야함.
   const transferableCandidates = useMemo(() => {
     return members.filter((member) => !member.isMe && member.role === "ADMIN");
   }, [members]);
+
+  const updateMemberRoleMutation = useMutation({
+    mutationFn: ({
+      memberId,
+      body,
+    }: {
+      memberId: number;
+      body: TUpdateMemberRoleRequest;
+    }) => updateWorkspaceMemberPermission(orgId, memberId, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["workspaceMembers", orgId],
+      });
+    },
+    onError: (error) => {
+      toast.error(
+        getAxiosMessage(error, "권한 변경에 실패했습니다. 다시 시도해주세요"),
+      );
+    },
+  });
+
+  const deleteMemberMutation = useMutation({
+    mutationFn: (memberId: number) => deleteWorkspaceMember(orgId, memberId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["workspaceMembers", orgId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["workspaceMemberCount", orgId],
+      });
+    },
+    onError: (error) => {
+      toast.error(
+        getAxiosMessage(error, "팀원 삭제에 실패했습니다. 다시 시도해주세요"),
+      );
+    },
+  });
 
   useEffect(() => {
     const target = observerRef.current;
@@ -101,7 +149,10 @@ export default function MemberManagement() {
     membersQuery.fetchNextPage,
   ]);
 
-  const handleRoleChange = (targetMemberId: number, newRole: TMemberRole) => {
+  const handleRoleChange = async (
+    targetMemberId: number,
+    newRole: TMemberRole,
+  ) => {
     const targetMember = members.find(
       (member) => member.memberId === targetMemberId,
     );
@@ -121,7 +172,17 @@ export default function MemberManagement() {
       toast.error("마지막 관리자는 멤버로 변경할 수 없습니다");
       return;
     }
-    // TODO:관리자 변경 API 연동
+    try {
+      await updateMemberRoleMutation.mutateAsync({
+        memberId: targetMemberId,
+        body: { orgRole: newRole },
+      });
+      toast.success(
+        `${targetMember.name}님의 권한이 ${newRole === "ADMIN" ? "관리자" : "멤버"}로 변경되었습니다`,
+      );
+    } catch (error) {
+      console.error("권한 변경 실패", error);
+    }
   };
 
   const openChangeModal = () => {
@@ -169,23 +230,19 @@ export default function MemberManagement() {
   };
 
   const closeDeleteMember = () => {
-    if (deleting) return;
+    if (deleteMemberMutation.isPending) return;
     setIsDeleteModalOpen(false);
     setSelectedDeleteMember(null);
   };
 
   const handleDeleteMember = async (member: TWorkspaceMember) => {
-    setDeleting(true);
     try {
-      // TODO: 삭제 API 연동
+      await deleteMemberMutation.mutateAsync(member.memberId);
       toast.success(`${member.name}님이 삭제되었습니다`);
       setIsDeleteModalOpen(false);
       setSelectedDeleteMember(null);
     } catch (error) {
-      toast.error("팀원 삭제에 실패했습니다. 다시 시도해주세요");
       console.error("팀원 삭제 실패", error);
-    } finally {
-      setDeleting(false);
     }
   };
 
@@ -278,7 +335,7 @@ export default function MemberManagement() {
           onClose={closeDeleteMember}
           member={selectedDeleteMember}
           onConfirm={handleDeleteMember}
-          isLoading={deleting}
+          isLoading={deleteMemberMutation.isPending}
         />
       </div>
     </section>


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #118 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 멤버 권한 변경 API PATCH `/api/org/members/${orgId}/${memberId}` 연동 진행
- 멤버 삭제 API DELETE `/api/org/${orgId}/members/${memberId}` 연동 진행

## 😅 미완성 작업

팀원 초대 API 연동

## 📢 논의 사항 및 참고 사항

현재 UI상에서는 관리자 변경 (소유권 이전) 기능이 있지만, 관련 API는 따로 없어서 미연동상태입니다.
현재 멤버 권한이 ADMIN/MEMBER 구조로 진행되기 때문에, 관리자가 여러명이 존재할 수 있는 구조입니다. 
그래서 지금 상태로면 소유권 이전이라는 개념이 존재할수 없기 때문에 기능 정의가 필요할 것으로 보입니다.

현재 MemberList에서 마지막 관리자 한명만 있을때, 마지막 관리자는 삭제할수없게 만들어둔 상태이기에, 현재 구조대로 여러명의 관리자가 있는 상태를 유지하고, 소유권 관련 UI와 기능을 삭제하는게 가장 적절해보입니다. 
의견 부탁드립니다.

현재로써는 마지막 관리자가 삭제하고 싶을때는 다른 멤버에게 관리자 역할을 넘겨주고 멤버로 역할이 변경이 된 후 삭제되는 개념이기에 관리자는 무조건 1명이상이 있는 구조 입니다.


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 멤버 권한 변경 기능 추가
  * 워크스페이스 멤버 삭제 기능 추가
  * 멤버 관리 작업 중 개선된 오류 및 성공 알림

<!-- end of auto-generated comment: release notes by coderabbit.ai -->