### PR TITLE
[Feature/#160] 워크스페이스/멤버관리 페이지 스켈레톤 UI 적용

### DIFF
--- a/src/components/workspace/MemberManagementLoading.tsx
+++ b/src/components/workspace/MemberManagementLoading.tsx
@@ -1,19 +1,71 @@
-function MemberManagementSkeleton() {
+import { Skeleton, SkeletonCircle } from "../common/skeleton/Skeleton";
+
+function MemberRowSkeleton() {
   return (
-    <>
-      <li>
-        <div>aa</div>
-      </li>
-    </>
+    <div className="flex items-center justify-between rounded-component-md bg-white px-6 py-5 shadow-Soft border border-gray-100 tablet:px-4 tablet:py-4">
+      <div className="flex items-center gap-4 min-w-0">
+        <SkeletonCircle className="w-12 h-12 shrink-0 tablet:w-10 tablet:h-10" />
+        <div className="flex flex-col gap-2 min-w-0">
+          <Skeleton className="h-5 w-28" />
+          <Skeleton className="h-4 w-44 tablet:w-36" />
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Skeleton className="h-9 w-22 rounded-component-md" />
+        <Skeleton className="h-9 w-9 rounded-component-md" />
+      </div>
+    </div>
+  );
+}
+
+function PermissionRowSkeleton() {
+  return (
+    <div className="flex items-center justify-between py-4 border-b border-gray-100 last:border-b-0">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-4 w-40" />
+      </div>
+      <Skeleton className="h-6 w-12 rounded-full" />
+    </div>
   );
 }
 
 export default function MemberManagementLoading() {
   return (
-    <ul role="status" aria-label="멤버관리 불러오는 중" className="space-y-5">
-      {Array.from({ length: 3 }).map((_, i) => (
-        <MemberManagementSkeleton key={i} />
-      ))}
-    </ul>
+    <section
+      role="status"
+      aria-label="멤버 관리 정보 불러오는 중"
+      className="w-full min-w-0 flex flex-col gap-8"
+    >
+      <div className="flex w-full min-w-0 flex-col gap-10">
+        <div className="rounded-component-lg border border-gray-100 bg-white p-6 shadow-Soft">
+          <div className="space-y-5">
+            <div className="flex items-center justify-between">
+              <div className="space-y-2">
+                <Skeleton className="h-7 w-28" />
+                <Skeleton className="h-4 w-40" />
+              </div>
+              <Skeleton className="h-10 w-28 rounded-component-md" />
+            </div>
+            <div className="space-y-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <MemberRowSkeleton key={i} />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="rounded-component-lg border border-gray-100 bg-white p-6 shadow-Soft">
+          <div className="space-y-2 mb-6">
+            <Skeleton className="h-6 w-28" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+          <div>
+            {Array.from({ length: 9 }).map((_, i) => (
+              <PermissionRowSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/workspace/MemberManagementLoading.tsx
+++ b/src/components/workspace/MemberManagementLoading.tsx
@@ -1,0 +1,19 @@
+function MemberManagementSkeleton() {
+  return (
+    <>
+      <li>
+        <div>aa</div>
+      </li>
+    </>
+  );
+}
+
+export default function MemberManagementLoading() {
+  return (
+    <ul role="status" aria-label="멤버관리 불러오는 중" className="space-y-5">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <MemberManagementSkeleton key={i} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/workspace/WorkspaceListLoading.tsx
+++ b/src/components/workspace/WorkspaceListLoading.tsx
@@ -29,7 +29,7 @@ export default function WorkspaceListLoading() {
         <Skeleton className="h-5 w-60 tablet:w-56" />
       </div>
       <div className="flex items-center justify-between gap-4 tablet:flex-col tablet:items-stretch">
-        <Skeleton className="h-15 w-full rounded-component-md tablet:" />
+        <Skeleton className="h-15 w-full rounded-component-md" />
         <Skeleton className="h-15 w-56 rounded-component-md tablet:w-full" />
       </div>
       <ul className="space-y-5">

--- a/src/components/workspace/WorkspaceListLoading.tsx
+++ b/src/components/workspace/WorkspaceListLoading.tsx
@@ -5,14 +5,13 @@ function WorkspaceCardSkeleton() {
     <>
       <li className="flex items-center justify-between rounded-component-md bg-white px-6 py-5 shadow-Soft border border-gray-100 tablet:px-4 tablet:py-4">
         <div className="flex items-center gap-5 min-w-0 tablet:gap-3">
-          <Skeleton className="w-24 h-24 shrink-0 rounded-component-sm tablet:h-16 tablet:w-16" />
+          <Skeleton className="w-24 h-24 shrink-0 rounded-component-sm tablet:h-18 tablet:w-18" />
           <div className="flex flex-col gap-2 min-w-0">
             <Skeleton className="h-5 w-40" />
             <Skeleton className="h-4 w-64" />
             <Skeleton className="h-4 w-16" />
           </div>
         </div>
-        <Skeleton className="h-10 w-10 shrink-0 rounded-component-sm" />
       </li>
     </>
   );
@@ -20,14 +19,24 @@ function WorkspaceCardSkeleton() {
 
 export default function WorkspaceListLoading() {
   return (
-    <ul
+    <section
       role="status"
       aria-label="워크스페이스 목록 불러오는 중"
-      className="space-y-5"
+      className="w-full flex flex-col gap-8"
     >
-      {Array.from({ length: 3 }).map((_, i) => (
-        <WorkspaceCardSkeleton key={i} />
-      ))}
-    </ul>
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-50" />
+        <Skeleton className="h-5 w-60 tablet:w-56" />
+      </div>
+      <div className="flex items-center justify-between gap-4 tablet:flex-col tablet:items-stretch">
+        <Skeleton className="h-15 w-full rounded-component-md tablet:" />
+        <Skeleton className="h-15 w-56 rounded-component-md tablet:w-full" />
+      </div>
+      <ul className="space-y-5">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <WorkspaceCardSkeleton key={i} />
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/src/components/workspace/WorkspaceSettingLoading.tsx
+++ b/src/components/workspace/WorkspaceSettingLoading.tsx
@@ -1,0 +1,23 @@
+function WorkspaceSettingSkeleton() {
+  return (
+    <>
+      <li>
+        <div>aa</div>
+      </li>
+    </>
+  );
+}
+
+export default function WorkspaceSettingLoading() {
+  return (
+    <ul
+      role="status"
+      aria-label="워크스페이스 관리 불러오는 중"
+      className="space-y-5"
+    >
+      {Array.from({ length: 3 }).map((_, i) => (
+        <WorkspaceSettingSkeleton key={i} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/workspace/WorkspaceSettingLoading.tsx
+++ b/src/components/workspace/WorkspaceSettingLoading.tsx
@@ -1,23 +1,52 @@
-function WorkspaceSettingSkeleton() {
-  return (
-    <>
-      <li>
-        <div>aa</div>
-      </li>
-    </>
-  );
-}
+import { Skeleton } from "../common/skeleton/Skeleton";
 
 export default function WorkspaceSettingLoading() {
   return (
-    <ul
+    <section
       role="status"
-      aria-label="워크스페이스 관리 불러오는 중"
-      className="space-y-5"
+      aria-label="워크스페이스 설정 불러오는 중"
+      className="w-full flex flex-col gap-8"
     >
-      {Array.from({ length: 3 }).map((_, i) => (
-        <WorkspaceSettingSkeleton key={i} />
-      ))}
-    </ul>
+      <div className="bg-white border border-gray-100 rounded-component-lg p-8 shadow-Soft">
+        <div className="mt-9 flex flex-row gap-12 items-start tablet:flex-col tablet:gap-8">
+          <div className="flex flex-col items-center w-60 tablet:w-full shrink-0">
+            <Skeleton className="h-5 w-24 mb-3 self-start tablet:self-center" />
+            <Skeleton className="h-60 w-60 rounded-component-sm tablet:h-46 tablet:w-46" />
+            <div className="flex gap-2 mt-4 justify-center">
+              <Skeleton className="h-7 w-18 rounded-component-lg" />
+              <Skeleton className="h-7 w-18 rounded-component-lg" />
+            </div>
+          </div>
+          <div className="flex-1 w-full space-y-6">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-12 w-full rounded-component-md" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-90 w-full rounded-component-md" />
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end mt-6 gap-4 tablet:flex-col">
+          <Skeleton className="h-12 w-40 rounded-component-md tablet:w-full" />
+        </div>
+      </div>
+      <div className="w-full">
+        <div className="flex items-center h-41 rounded-component-lg border border-status-red/20 bg-status-red/5 p-6">
+          <div className="flex w-full items-center justify-between gap-4 tablet:flex-col tablet:items-stretch">
+            <div className="flex items-start gap-4">
+              <Skeleton className="w-12 h-12 rounded-full shrink-0" />
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-6 w-12" />
+                <Skeleton className="h-4 w-50" />
+                <Skeleton className="h-4 w-50" />
+              </div>
+            </div>
+            <Skeleton className="h-12 w-40 rounded-component-md tablet:w-full" />
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -17,6 +17,7 @@ import {
 
 import DeleteMemberModal from "@/components/workspace/DeleteMemberModal";
 import MemberList from "@/components/workspace/MemberList";
+import MemberManagementLoading from "@/components/workspace/MemberManagementLoading";
 import PermissionTable from "@/components/workspace/PermissionTable";
 
 import {
@@ -39,19 +40,31 @@ export default function MemberManagement() {
     useState<TWorkspaceMember | null>(null);
 
   const observerRef = useRef<HTMLDivElement | null>(null);
+  const delay = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
 
   const memberCountQuery = useQuery<
     Awaited<ReturnType<typeof getWorkspaceMemberCount>>,
     IApiErrorResponse
   >({
     queryKey: ["workspaceMemberCount", orgId],
-    queryFn: () => getWorkspaceMemberCount(orgId),
+    queryFn: async () => {
+      if (import.meta.env.DEV) {
+        await delay(1500);
+      }
+      return getWorkspaceMemberCount(orgId);
+    },
     enabled: Number.isFinite(orgId) && orgId > 0,
   });
   const membersQuery = useInfiniteQuery({
     queryKey: ["workspaceMembers", orgId, PAGE_SIZE],
-    queryFn: ({ pageParam }: { pageParam: string | null }) =>
-      getWorkspaceMembers(orgId, pageParam, PAGE_SIZE),
+    queryFn: async ({ pageParam }: { pageParam: string | null }) => {
+      if (import.meta.env.DEV) {
+        await delay(1500);
+      }
+      return getWorkspaceMembers(orgId, pageParam, PAGE_SIZE);
+    },
+
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
       if (!lastPage.hasNext) return undefined;
@@ -75,7 +88,12 @@ export default function MemberManagement() {
     IApiErrorResponse
   >({
     queryKey: ["workspacePendingMembers", orgId],
-    queryFn: () => getPendingMember(orgId),
+    queryFn: async () => {
+      if (import.meta.env.DEV) {
+        await delay(1500);
+      }
+      return getPendingMember(orgId);
+    },
     enabled: Number.isFinite(orgId) && orgId > 0,
   });
 
@@ -239,16 +257,7 @@ export default function MemberManagement() {
     membersQuery.isLoading ||
     pendingMembersQuery.isLoading
   ) {
-    return (
-      <section className="w-full min-w-0">
-        <header className="mb-7">
-          <h1 className="font-heading2">멤버 관리</h1>
-          <p className="font-body1 text-text-sub">
-            팀 구성원 정보를 불러오는 중입니다...
-          </p>
-        </header>
-      </section>
-    );
+    return <MemberManagementLoading />;
   }
 
   if (

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -40,31 +40,19 @@ export default function MemberManagement() {
     useState<TWorkspaceMember | null>(null);
 
   const observerRef = useRef<HTMLDivElement | null>(null);
-  const delay = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
 
   const memberCountQuery = useQuery<
     Awaited<ReturnType<typeof getWorkspaceMemberCount>>,
     IApiErrorResponse
   >({
     queryKey: ["workspaceMemberCount", orgId],
-    queryFn: async () => {
-      if (import.meta.env.DEV) {
-        await delay(1500);
-      }
-      return getWorkspaceMemberCount(orgId);
-    },
+    queryFn: () => getWorkspaceMemberCount(orgId),
     enabled: Number.isFinite(orgId) && orgId > 0,
   });
   const membersQuery = useInfiniteQuery({
     queryKey: ["workspaceMembers", orgId, PAGE_SIZE],
-    queryFn: async ({ pageParam }: { pageParam: string | null }) => {
-      if (import.meta.env.DEV) {
-        await delay(1500);
-      }
-      return getWorkspaceMembers(orgId, pageParam, PAGE_SIZE);
-    },
-
+    queryFn: ({ pageParam }: { pageParam: string | null }) =>
+      getWorkspaceMembers(orgId, pageParam, PAGE_SIZE),
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
       if (!lastPage.hasNext) return undefined;
@@ -88,12 +76,7 @@ export default function MemberManagement() {
     IApiErrorResponse
   >({
     queryKey: ["workspacePendingMembers", orgId],
-    queryFn: async () => {
-      if (import.meta.env.DEV) {
-        await delay(1500);
-      }
-      return getPendingMember(orgId);
-    },
+    queryFn: () => getPendingMember(orgId),
     enabled: Number.isFinite(orgId) && orgId > 0,
   });
 

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -10,6 +10,7 @@ import ControlBox from "@/components/common/controlbox/ControlBox";
 import Input from "@/components/common/input/Input";
 import Modal from "@/components/common/modal/Modal";
 import TextareaField from "@/components/common/textarea/TextareaField";
+import WorkspaceSettingLoading from "@/components/workspace/WorkspaceSettingLoading";
 
 import {
   deleteWorkspace,
@@ -175,11 +176,7 @@ export default function WorkspaceSetting() {
 
   return (
     <section className="w-full flex flex-col gap-8">
-      {loading && (
-        <div className="bg-white p-10 text-center border border-gray-100 rounded-component-lg">
-          <p className="font-body2 text-text-sub">불러오는중..</p>
-        </div>
-      )}
+      {loading && <WorkspaceSettingLoading />}
       {!loading && errorMsg && (
         <div className="bg-white p-10 text-center border border-gray-100 rounded-component-lg space-y-4">
           <p className="font-body2 text-status-red">{errorMsg}</p>

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -57,6 +57,7 @@ export default function WorkspaceSetting() {
     setImageError(false);
     try {
       const detail = await getWorkspace(orgId);
+      await new Promise((res) => setTimeout(res, 1500));
       setName(detail.name);
       setDesc(detail.description ?? "");
       setServerLogoUrl(detail.logoUrl ?? null);

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -57,7 +57,6 @@ export default function WorkspaceSetting() {
     setImageError(false);
     try {
       const detail = await getWorkspace(orgId);
-      await new Promise((res) => setTimeout(res, 1500));
       setName(detail.name);
       setDesc(detail.description ?? "");
       setServerLogoUrl(detail.logoUrl ?? null);


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #160 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `WorkspaceSetting.tsx`, `MemberManagement.tsx` 에 스켈레톤 UI 적용
- `Workspace.tsx`는 기존에 적용해둔 스켈레톤 UI 보완 작업 진행
- 반응형 확인 완료
- 공통 Skeleton 컴포넌트 활용해서 각 페이지 구조에 맞게 스켈레톤 구성

### Workspace.tsx 스켈레톤 UI 적용
<img width="1425" height="868" alt="image" src="https://github.com/user-attachments/assets/f1ae967b-e281-44ea-8537-7dc93e28c71a" />

### WorkspaceSetting.tsx 스켈레톤 UI 적용
<img width="1404" height="858" alt="image" src="https://github.com/user-attachments/assets/bc0f7044-46d2-46e5-a0ce-5960ee7680b3" />

### MemberManagement.tsx 스켈레톤 UI 적용
<img width="1465" height="884" alt="image" src="https://github.com/user-attachments/assets/98fcee53-a4c4-44cb-9e02-e93674da62b3" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

워크스페이스 수정페이지와 멤버관리 페이지의 상단 레이아웃은 고정되어있고, 로딩 상태와 관련없이 항상 동일하게 보여지기 때문에 스켈레톤 UI 적용대상에서 제외했습니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팀 구성원 관리 페이지의 로딩 상태 UI 개선
  * 워크스페이스 설정 페이지의 로딩 상태 UI 개선

* **개선 사항**
  * 실제 콘텐츠 구조를 모방한 스켈레톤 로딩 인디케이터 추가
  * 워크스페이스 목록의 로딩 표시 개선
  * 데이터 로딩 중 더 나은 시각적 피드백 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->