### PR TITLE
[Bugfix/#173] 스크롤 시 사이드 잘리는 현상 개선

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.1
         version: 7.71.1(react@19.2.4)
+      react-intersection-observer:
+        specifier: ^10.0.3
+        version: 10.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
@@ -2907,6 +2910,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-intersection-observer@10.0.3:
+    resolution: {integrity: sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -6518,6 +6530,12 @@ snapshots:
   react-hook-form@7.71.1(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  react-intersection-observer@10.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
 
   react-is@16.13.1: {}
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -78,7 +78,10 @@ export default function Sidebar() {
           <WorkspaceSwitcher isCollapsed={isCollapsed} />
         </div>
 
-        <nav className="flex flex-1 flex-col gap-1 px-2 overflow-y-auto min-h-0">
+        <nav
+          aria-label="사이드바 내비게이션"
+          className="flex flex-1 flex-col gap-1 px-2 overflow-y-auto min-h-0"
+        >
           {mainNav.map((item) => {
             const isOpen = openId === item.id;
             const { isParentActive } = mainNavSidebar.getItemActiveState(

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -73,12 +73,12 @@ export default function Sidebar() {
       animate={{ width: isCollapsed ? 88 : 256 }}
       transition={{ type: "spring", stiffness: 320, damping: 34 }}
     >
-      <div className="mx-auto mt-5 flex w-full max-w-58 flex-1 flex-col">
+      <div className="mx-auto mt-5 flex w-full max-w-58 flex-1 flex-col min-h-0">
         <div className="px-2">
           <WorkspaceSwitcher isCollapsed={isCollapsed} />
         </div>
 
-        <nav className="flex flex-1 flex-col gap-1 px-2">
+        <nav className="flex flex-1 flex-col gap-1 px-2 overflow-y-auto min-h-0">
           {mainNav.map((item) => {
             const isOpen = openId === item.id;
             const { isParentActive } = mainNavSidebar.getItemActiveState(
@@ -145,7 +145,9 @@ export default function Sidebar() {
           })}
         </nav>
 
-        <div className={twMerge("mt-2 pb-3", isCollapsed ? "" : "px-2")}>
+        <div
+          className={twMerge("mt-2 pb-3 shrink-0", isCollapsed ? "" : "px-2")}
+        >
           {footerNav.map((item) => {
             const isActive =
               item.path != null ? isPathMatch(pathname, item.path) : false;
@@ -171,7 +173,7 @@ export default function Sidebar() {
               aria-label={isCollapsed ? "사이드바 펼치기" : "사이드바 접기"}
               onClick={toggleSidebar}
               className={twMerge(
-                "w-full h-[55px] rounded-component-md text-sm transition-all duration-200 inline-flex items-center",
+                "w-full h-button-big rounded-component-md text-sm transition-all duration-200 inline-flex items-center",
                 isCollapsed ? "justify-center px-0" : "gap-4 px-3",
                 "text-text-auth-sub hover:text-chart-3 hover:bg-bg-surface",
               )}

--- a/src/index.css
+++ b/src/index.css
@@ -15,10 +15,6 @@ body,
   padding: 0;
 }
 
-body {
-  min-height: 100dvh;
-}
-
 button {
   cursor: pointer;
 }

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -80,12 +80,11 @@ export default function MainLayout() {
   }, [pathname]);
 
   return (
-    <div className="flex min-h-dvh w-full items-start bg-gray-50">
-      {/* 뷰포트 높이에 고정 + sticky: 본문은 문서 스크롤(전체 페이지 캡처·DevTools와 호환) */}
-      <div className="sticky top-0 z-40 flex h-dvh shrink-0">
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
+      <div className="flex h-full shrink-0">
         <Sidebar />
       </div>
-      <main className="flex min-h-dvh min-w-0 flex-1 flex-col">
+      <main className="flex h-full min-w-0 flex-1 flex-col overflow-y-auto">
         <header className="sticky top-0 z-30 border-b border-bg-surface bg-white">
           <div className="flex h-14 items-center justify-between px-6 tablet:px-4">
             <div className="flex min-w-0 items-center gap-2">


### PR DESCRIPTION
<!--
📌 제목: [Type] 작업 요약

예시:
- [Feature] 반응형 수정
- [Bugfix] 에러 잡기
- [Deploy] 배포
- [Refactor] 사용성 높이기

사용 가능한 Type:
Feature | Bugfix | Refactor | Deploy | Design | Docs | Setting | Test |
-->

## 🚨 관련 이슈

#173 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- 기존 sticky + min-h-dvh 조합에서는  문서 전체가 스크롤될 때 sticky가 불안정하게 동작함 -> 스크롤시 사이드바 하단 잘리는 현상 발생
- 외부 컨테이너를 h-dvh overflow-hidden으로 고정하고, main 내부만 overflow-y-auto로 스크롤되는 구조로 바꿈

## 😅 미완성 작업
N/A


## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **스타일**
  * 사이드바의 스크롤 동작 개선을 위해 레이아웃 제약 조건 최적화
  * 전체 높이 레이아웃 일관성 강화
  * 메인 콘텐츠 영역의 오버플로우 처리 개선

* **리팩터**
  * 메인 레이아웃 구조 재조정으로 스크롤 동작 정규화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->