### PR TITLE
 [Bugfix/#181] reissue Authorization 제거 후 요청 변경-auth 전용 인스턴스 분리

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -54,7 +54,8 @@ export const signUp = async ({
 export const reissueToken = async (): Promise<
   ICommonResponse<ITokenRefreshResponse>
 > => {
-  const { data } = await axiosInstance.post("/api/auth/reissue");
+  // refreshToken 쿠키 기반 재발급은 credentials가 필요한 authInstance로 요청합니다.
+  const { data } = await authInstance.post("/api/auth/reissue");
   return data;
 };
 

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -6,19 +6,22 @@ import useAuthStore from "@/store/useAuthStore";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-// 개발 환경에서는 Vite proxy(`/api` → `VITE_API_TARGET_URL`)를 활용하기 위해
-// baseURL이 없어도 상대경로 요청이 가능하도록 허용합니다.
 if (import.meta.env.PROD && !BASE_URL) {
   throw new Error("API 서버 주소(VITE_API_BASE_URL)가 설정되지 않았습니다.");
 }
 
-const axiosConfig: AxiosRequestConfig = {
+const baseConfig: AxiosRequestConfig = {
   baseURL: BASE_URL || undefined,
-  withCredentials: true,
 };
 
-export const axiosInstance = axios.create(axiosConfig);
-export const authInstance = axios.create(axiosConfig);
+// 일반 API 요청용 인스턴스
+export const axiosInstance = axios.create(baseConfig);
+
+// 인증 전용 인스턴스 (쿠키 필요)
+export const authInstance = axios.create({
+  ...baseConfig,
+  withCredentials: true,
+});
 
 axiosInstance.interceptors.request.use(
   (config) => {
@@ -67,6 +70,14 @@ axiosInstance.interceptors.response.use(
     const originalRequest = error.config;
 
     if (error.response?.status === 401) {
+      // AccessToken이 없는 상태라면 재발급을 시도할 근거가 없습니다.
+      // (refreshToken 쿠키가 없을 경우 reissue 루프가 쉽게 발생)
+      if (!useAuthStore.getState().accessToken) {
+        return Promise.reject(
+          (error.response?.data as IApiErrorResponse) ?? error,
+        );
+      }
+
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           addRefreshSubscriber(


### PR DESCRIPTION
## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- `reissue` 요청이 `axiosInstance`를 타면서 `Authorization` 헤더가 섞일 수 있던 흐름을 정리
- 쿠키 기반 인증이 필요한 요청을 위해 `authInstance(withCredentials: true)`를 별도로 분리
- `reissueToken()`을 `axiosInstance` → `authInstance`로 변경하여 **RefreshToken 쿠키 기반**으로만 재발급 요청되도록 수정
- 401 처리 로직에서 accessToken이 없는 상태에서는 불필요한 재발급 시도를 하지 않도록 방어 로직 추가

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토큰 갱신 요청이 자격증명과 함께 올바르게 전송되도록 개선
  * 인증 실패 시 불필요한 토큰 갱신 시도를 방지하여 인증 오류 처리 개선

* **개선 사항**
  * 인증 시스템의 안정성 및 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->