### PR TITLE
[refactor/#190] 설정 페이지 헤더뜨도록 수정

### DIFF
--- a/src/constants/sidebarNav.ts
+++ b/src/constants/sidebarNav.ts
@@ -61,6 +61,12 @@ export const mainNav: INavItem[] = [
       },
     ],
   },
+  {
+    id: "settings",
+    label: "개인 설정",
+    icon: SettingsIcon,
+    path: "/setting",
+  },
 ];
 
 export const footerNav: INavItem[] = [

--- a/src/constants/sidebarNav.ts
+++ b/src/constants/sidebarNav.ts
@@ -61,12 +61,6 @@ export const mainNav: INavItem[] = [
       },
     ],
   },
-  {
-    id: "settings",
-    label: "개인 설정",
-    icon: SettingsIcon,
-    path: "/setting",
-  },
 ];
 
 export const footerNav: INavItem[] = [

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 
-import { mainNav } from "@/constants/sidebarNav";
+import { footerNav, mainNav } from "@/constants/sidebarNav";
 
 import { isPathMatch, normalizePathname } from "@/utils/navigation/pathMatch";
 
@@ -17,6 +17,8 @@ export default function MainLayout() {
   useCoreQuery(["myInfo"], getMyInfo);
   const location = useLocation();
   const [headerRight, setHeaderRight] = useState<ReactNode | null>(null);
+
+  const allNav = [...mainNav, ...footerNav];
 
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
 
@@ -55,7 +57,7 @@ export default function MainLayout() {
 
   const pathname = normalizePathname(location.pathname);
   const { parentLabel, currentLabel } = useMemo(() => {
-    for (const parent of mainNav) {
+    for (const parent of allNav) {
       const children = parent.children ?? [];
       const exactChild = children.find((c) =>
         c.path ? normalizePathname(c.path) === pathname : false,


### PR DESCRIPTION

## 🚨 관련 이슈
Closed #190 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

Setting페이지에서 상단 header에 헤더명이 뜨도록 수정했습니다. 
기존 mainNav에 있는것만 header에 제목 표시되어서, footerNav에 포함되어있는 설정은 header 제목이 표시되지 않는 문제점이 있었습니다.
그래서, footerNav 아이템들도 header에 label 뜨도록 수정완료했습니다.
<img width="1865" height="902" alt="image" src="https://github.com/user-attachments/assets/215f9c98-8e86-4ce4-a8fe-cec65eb2644e" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 메인 네비게이션에 개인 설정 메뉴가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->