### PR TITLE
[Feature/#198] 플랫폼 대시보드(전체) 상/하단 지표 API 연동

### DIFF
--- a/src/api/dashboard/platform.ts
+++ b/src/api/dashboard/platform.ts
@@ -1,0 +1,16 @@
+import type { ICommonResponse } from "@/types/common/common";
+import type { IAdCountParams, IAdStatusData } from "@/types/dashboard/platform";
+
+import { axiosInstance } from "@/lib/axiosInstance";
+
+// 광고 소재 현황 조회 API
+export const getAdCount = async (
+  orgId: number,
+  params?: IAdCountParams,
+): Promise<IAdStatusData> => {
+  const { data } = await axiosInstance.get<ICommonResponse<IAdStatusData>>(
+    `/api/dashboard/${orgId}/ad-count`,
+    { params },
+  );
+  return data.data;
+};

--- a/src/components/dashboard/charts/performanceEfficiencyChart.config.ts
+++ b/src/components/dashboard/charts/performanceEfficiencyChart.config.ts
@@ -40,7 +40,7 @@ export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
   },
   yaxis: [
     {
-      seriesName: "클릭률",
+      seriesName: "클릭률(CTR)",
       labels: {
         formatter: (val) => `${val.toFixed(1)}%`,
         style: {
@@ -49,7 +49,10 @@ export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
         },
       },
     },
-    { show: false, seriesName: "전환율" },
+    {
+      seriesName: "클릭률(CTR)",
+      show: false,
+    },
     {
       opposite: true,
       seriesName: "노출수",

--- a/src/components/dashboard/platform/AllPlatformView.tsx
+++ b/src/components/dashboard/platform/AllPlatformView.tsx
@@ -1,3 +1,5 @@
+import { usePlatformRoasRankings } from "@/hooks/dashboard/usePlatformRoasRankings";
+
 import Badge from "@/components/common/badge/Badge";
 import Card from "@/components/common/card/Card";
 import ChartLegend from "@/components/common/chart/ChartLegend";
@@ -17,7 +19,6 @@ import TopPerformanceList from "@/components/dashboard/platform/TopPerformanceLi
 import {
   adStatusMock,
   performanceEfficiencyMock,
-  roasRankingMock,
 } from "@/pages/dashboard/platform/platformDashboard.mock";
 
 interface IAllPlatformViewProps {
@@ -25,6 +26,12 @@ interface IAllPlatformViewProps {
 }
 
 export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
+  const {
+    data: roasRankings,
+    isLoading: isRankingsLoading,
+    isError: isRankingsError,
+  } = usePlatformRoasRankings();
+
   return (
     <div className="flex flex-col gap-8">
       <div className="grid grid-cols-3 tablet:grid-cols-1 gap-6">
@@ -42,10 +49,18 @@ export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
           }
           className="flex-1 min-h-67 flex flex-col"
         >
-          {isLoading ? (
+          {isLoading || isRankingsLoading ? (
             <TopPerformanceListSkeleton />
+          ) : isRankingsError || !roasRankings ? (
+            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+              데이터를 불러오지 못했습니다.
+            </div>
+          ) : roasRankings.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+              표시할 순위 데이터가 없습니다.
+            </div>
           ) : (
-            <TopPerformanceList rankings={roasRankingMock} />
+            <TopPerformanceList rankings={roasRankings} />
           )}
         </Card>
 

--- a/src/components/dashboard/platform/AllPlatformView.tsx
+++ b/src/components/dashboard/platform/AllPlatformView.tsx
@@ -1,3 +1,4 @@
+import { usePlatformAdCount } from "@/hooks/dashboard/usePlatformAdCount";
 import { usePlatformRoasRankings } from "@/hooks/dashboard/usePlatformRoasRankings";
 
 import Badge from "@/components/common/badge/Badge";
@@ -16,10 +17,7 @@ import {
 } from "@/components/dashboard/platform/skeleton/PlatformSkeleton";
 import TopPerformanceList from "@/components/dashboard/platform/TopPerformanceList";
 
-import {
-  adStatusMock,
-  performanceEfficiencyMock,
-} from "@/pages/dashboard/platform/platformDashboard.mock";
+import { performanceEfficiencyMock } from "@/pages/dashboard/platform/platformDashboard.mock";
 
 interface IAllPlatformViewProps {
   isLoading: boolean;
@@ -31,6 +29,12 @@ export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
     isLoading: isRankingsLoading,
     isError: isRankingsError,
   } = usePlatformRoasRankings();
+
+  const {
+    data: adStatus,
+    isLoading: isAdStatusLoading,
+    isError: isAdStatusError,
+  } = usePlatformAdCount();
 
   return (
     <div className="flex flex-col gap-8">
@@ -78,20 +82,28 @@ export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
             />
           }
           RightElement={
-            isLoading ? (
+            isLoading || isAdStatusLoading ? (
               <BadgeSkeleton className="w-14" />
-            ) : (
+            ) : adStatus ? (
               <Badge variant="stopped" size="sm" className="text-text-auth-sub">
-                총 {adStatusMock.totalCount}개
+                총 {adStatus.totalCount}개
               </Badge>
-            )
+            ) : null
           }
           className="flex-1 min-h-67 flex flex-col"
         >
-          {isLoading ? (
+          {isLoading || isAdStatusLoading ? (
             <AdStatusChartSkeleton />
+          ) : isAdStatusError || !adStatus ? (
+            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+              데이터를 불러오지 못했습니다.
+            </div>
+          ) : adStatus.providerCount.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+              표시할 광고 소재가 없습니다.
+            </div>
           ) : (
-            <AdStatusChart data={adStatusMock.providerCount} />
+            <AdStatusChart data={adStatus.providerCount} />
           )}
         </Card>
 

--- a/src/components/dashboard/platform/AllPlatformView.tsx
+++ b/src/components/dashboard/platform/AllPlatformView.tsx
@@ -1,4 +1,5 @@
 import { usePlatformAdCount } from "@/hooks/dashboard/usePlatformAdCount";
+import { usePlatformPerformance } from "@/hooks/dashboard/usePlatformPerformance";
 import { usePlatformRoasRankings } from "@/hooks/dashboard/usePlatformRoasRankings";
 
 import Badge from "@/components/common/badge/Badge";
@@ -35,6 +36,12 @@ export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
     isLoading: isAdStatusLoading,
     isError: isAdStatusError,
   } = usePlatformAdCount();
+
+  const {
+    data: platformPerformance,
+    isLoading: isPerformanceLoading,
+    isError: isPerformanceError,
+  } = usePlatformPerformance();
 
   return (
     <div className="flex flex-col gap-8">
@@ -121,10 +128,18 @@ export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
             />
           }
         >
-          {isLoading ? (
+          {isLoading || isPerformanceLoading ? (
             <PerformanceEfficiencyChartSkeleton />
+          ) : isPerformanceError || !platformPerformance ? (
+            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+              데이터를 불러오지 못했습니다.
+            </div>
+          ) : platformPerformance.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+              표시할 성과 데이터가 없습니다.
+            </div>
           ) : (
-            <PerformanceEfficiencyChart data={performanceEfficiencyMock} />
+            <PerformanceEfficiencyChart data={platformPerformance} />
           )}
         </Card>
       </div>

--- a/src/components/dashboard/platform/AllPlatformView.tsx
+++ b/src/components/dashboard/platform/AllPlatformView.tsx
@@ -18,8 +18,6 @@ import {
 } from "@/components/dashboard/platform/skeleton/PlatformSkeleton";
 import TopPerformanceList from "@/components/dashboard/platform/TopPerformanceList";
 
-import { performanceEfficiencyMock } from "@/pages/dashboard/platform/platformDashboard.mock";
-
 interface IAllPlatformViewProps {
   isLoading: boolean;
 }
@@ -165,13 +163,23 @@ export default function AllPlatformView({ isLoading }: IAllPlatformViewProps) {
 
       {/* 개별 플랫폼 상세 */}
       <div className="grid grid-cols-3 tablet:grid-cols-1 gap-6">
-        {isLoading
-          ? Array.from({ length: 3 }).map((_, i) => (
-              <PlatformDetailCardSkeleton key={i} />
-            ))
-          : performanceEfficiencyMock.map((platform) => (
-              <PlatformDetailCard key={platform.provider} data={platform} />
-            ))}
+        {isLoading || isPerformanceLoading ? (
+          Array.from({ length: 3 }).map((_, i) => (
+            <PlatformDetailCardSkeleton key={i} />
+          ))
+        ) : isPerformanceError || !platformPerformance ? (
+          <div className="col-span-3 tablet:col-span-1 flex items-center justify-center font-body2 text-text-sub py-16">
+            데이터를 불러오지 못했습니다.
+          </div>
+        ) : platformPerformance.length === 0 ? (
+          <div className="col-span-3 tablet:col-span-1 flex items-center justify-center font-body2 text-text-sub py-16">
+            표시할 플랫폼 데이터가 없습니다.
+          </div>
+        ) : (
+          platformPerformance.map((platform) => (
+            <PlatformDetailCard key={platform.provider} data={platform} />
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/platform/PlatformDetailCard.tsx
+++ b/src/components/dashboard/platform/PlatformDetailCard.tsx
@@ -52,7 +52,7 @@ export const PlatformDetailCard = memo(
               impressionChangeRate !== 0
                 ? {
                     direction: impressionChangeRate > 0 ? "up" : "down",
-                    value: `${Math.abs(impressionChangeRate * 100).toFixed(1)}%`,
+                    value: `${Math.abs(impressionChangeRate).toFixed(1)}%`,
                   }
                 : undefined
             }
@@ -65,7 +65,7 @@ export const PlatformDetailCard = memo(
               clickChangeRate !== 0
                 ? {
                     direction: clickChangeRate > 0 ? "up" : "down",
-                    value: `${Math.abs(clickChangeRate * 100).toFixed(1)}%`,
+                    value: `${Math.abs(clickChangeRate).toFixed(1)}%`,
                   }
                 : undefined
             }
@@ -78,7 +78,7 @@ export const PlatformDetailCard = memo(
               cvrChangeRate !== 0
                 ? {
                     direction: cvrChangeRate > 0 ? "up" : "down",
-                    value: `${Math.abs(cvrChangeRate * 100).toFixed(1)}%`,
+                    value: `${Math.abs(cvrChangeRate).toFixed(1)}%`,
                   }
                 : undefined
             }
@@ -91,7 +91,7 @@ export const PlatformDetailCard = memo(
               ROASChangeRate !== 0
                 ? {
                     direction: ROASChangeRate > 0 ? "up" : "down",
-                    value: `${Math.abs(ROASChangeRate * 100).toFixed(1)}%`,
+                    value: `${Math.abs(ROASChangeRate).toFixed(1)}%`,
                   }
                 : undefined
             }

--- a/src/hooks/dashboard/usePlatformAdCount.ts
+++ b/src/hooks/dashboard/usePlatformAdCount.ts
@@ -1,0 +1,33 @@
+import type {
+  IAdStatusData,
+  TPlatformProvider,
+} from "@/types/dashboard/platform";
+
+import { useCoreQuery } from "@/hooks/customQuery";
+
+import { getAdCount } from "@/api/dashboard/platform";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+// TODO: 추후 제거
+const normalizeProvider = (provider: string): TPlatformProvider =>
+  provider === "KAKAO" ? "META" : (provider as TPlatformProvider);
+
+// 광고 소재 현황
+export function usePlatformAdCount() {
+  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+
+  return useCoreQuery<IAdStatusData>(
+    ["platform", "adCount", orgId],
+    () => getAdCount(orgId!),
+    {
+      enabled: !!orgId,
+      select: (data): IAdStatusData => ({
+        ...data,
+        providerCount: data.providerCount.map((item) => ({
+          ...item,
+          provider: normalizeProvider(item.provider),
+        })),
+      }),
+    },
+  );
+}

--- a/src/hooks/dashboard/usePlatformPerformance.ts
+++ b/src/hooks/dashboard/usePlatformPerformance.ts
@@ -1,0 +1,39 @@
+import type { TProviderType } from "@/types/dashboard/overview";
+import type {
+  IPlatformPerformance,
+  TPlatformProvider,
+} from "@/types/dashboard/platform";
+
+import { useCoreQuery } from "@/hooks/customQuery";
+
+import { getOverview } from "@/api/dashboard/overview";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+// TODO: 추후 제거
+const normalizeProvider = (provider: string): TPlatformProvider =>
+  provider === "KAKAO" ? "META" : (provider as TPlatformProvider);
+
+const PROVIDERS: TProviderType[] = ["GOOGLE", "NAVER", "KAKAO"];
+
+// 플랫폼별 성과 효율 (3개 플랫폼 병렬 조회 후 병합)
+export function usePlatformPerformance() {
+  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+
+  return useCoreQuery(
+    ["platform", "performance", orgId],
+    async (): Promise<IPlatformPerformance[]> => {
+      const results = await Promise.all(
+        PROVIDERS.map((provider) =>
+          getOverview(orgId!, provider)
+            .then((metrics) => ({
+              ...metrics,
+              provider: normalizeProvider(provider),
+            }))
+            .catch(() => null),
+        ),
+      );
+      return results.filter((r): r is IPlatformPerformance => r !== null);
+    },
+    { enabled: !!orgId },
+  );
+}

--- a/src/hooks/dashboard/usePlatformPerformance.ts
+++ b/src/hooks/dashboard/usePlatformPerformance.ts
@@ -22,17 +22,26 @@ export function usePlatformPerformance() {
   return useCoreQuery(
     ["platform", "performance", orgId],
     async (): Promise<IPlatformPerformance[]> => {
-      const results = await Promise.all(
+      const settled = await Promise.allSettled(
         PROVIDERS.map((provider) =>
-          getOverview(orgId!, provider)
-            .then((metrics) => ({
-              ...metrics,
-              provider: normalizeProvider(provider),
-            }))
-            .catch(() => null),
+          getOverview(orgId!, provider).then((metrics) => ({
+            ...metrics,
+            provider: normalizeProvider(provider),
+          })),
         ),
       );
-      return results.filter((r): r is IPlatformPerformance => r !== null);
+
+      const success = settled
+        .filter(
+          (r): r is PromiseFulfilledResult<IPlatformPerformance> =>
+            r.status === "fulfilled",
+        )
+        .map((r) => r.value);
+
+      if (success.length !== PROVIDERS.length) {
+        throw new Error("일부 플랫폼 성과 데이터를 불러오지 못했습니다.");
+      }
+      return success;
     },
     { enabled: !!orgId },
   );

--- a/src/hooks/dashboard/usePlatformRoasRankings.ts
+++ b/src/hooks/dashboard/usePlatformRoasRankings.ts
@@ -1,0 +1,30 @@
+import type { IRoasRanking } from "@/types/dashboard/overview";
+
+import { useCoreQuery } from "@/hooks/customQuery";
+
+import { getRoasRankings } from "@/api/dashboard/overview";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+// TODO: 추후 제거
+const normalizeProvider = (provider: string): string =>
+  provider === "KAKAO" ? "META" : provider;
+// ROAS 성과 순위 (상위 3개)
+export function usePlatformRoasRankings() {
+  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+  return useCoreQuery(
+    ["platform", "roasRankings", orgId],
+    // TODO: 추후 제거
+    () =>
+      getRoasRankings(orgId!, {
+        startDate: "2026-01-22",
+        endDate: "2026-03-22",
+      }),
+    {
+      enabled: !!orgId,
+      select: (data): IRoasRanking[] =>
+        data.rankings.map((item) => ({
+          ...item,
+          provider: normalizeProvider(item.provider),
+        })),
+    },
+  );
+}

--- a/src/pages/dashboard/platform/platformDashboard.mock.ts
+++ b/src/pages/dashboard/platform/platformDashboard.mock.ts
@@ -1,5 +1,4 @@
 import type {
-  IAdStatusData,
   IBudgetStatus,
   IPlatformPerformance,
   IRoasRanking,
@@ -32,16 +31,6 @@ export const roasRankingMock: IRoasRanking[] = [
     adSpend: 472000,
   },
 ];
-
-// 광고 소재 현황
-export const adStatusMock: IAdStatusData = {
-  totalCount: 14,
-  providerCount: [
-    { provider: "GOOGLE", count: 7 },
-    { provider: "NAVER", count: 5 },
-    { provider: "META", count: 2 },
-  ],
-};
 
 // 플랫폼별 성과 효율 비교
 export const performanceEfficiencyMock: IPlatformPerformance[] = [

--- a/src/types/dashboard/platform.ts
+++ b/src/types/dashboard/platform.ts
@@ -26,8 +26,16 @@ export interface IAdCount {
 
 // 광고 소재 현황
 export interface IAdStatusData {
+  startDate: string;
+  endDate: string;
   totalCount: number;
   providerCount: IAdCount[];
+}
+
+//광고 소재 현황 조회 요청 파라미터
+export interface IAdCountParams {
+  startDate?: string;
+  endDate?: string;
 }
 
 // 플랫폼별 성과


### PR DESCRIPTION
## 🚨 관련 이슈

close #198 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

<img width="3420" height="2560" alt="screencapture-localhost-5173-platform-2026-05-11-23_16_36" src="https://github.com/user-attachments/assets/442fe8a5-881a-4c7e-8678-f3c11423dd56" />

### API 연동

> 성과 우수 플랫폼 (ROAS 순위)
- `/api/dashboard/{orgId}/rankings/roas`
- `usePlatformRoasRankings` 생성
- KAKAO 응답 → META로 표시되도록 정규화
- 데이터 제한으로 날짜 하드 코딩 

> 광고 소재 현황
- `/api/dashboard/{orgId}/ad-count`
- `usePlatformAdCount` 생성

> 플랫폼별 성과 효율 비교
- `/api/dashboard/{orgId}/metrics?providerType=GOOGLE|NAVER|KAKAO`
- `usePlatformPerformance` 생성 → 3개 플랫폼 병렬 호출 후 하나의 배열로 병합
- 차트 Y축 스케일 버그 수정

> 개별 플랫폼 상세 카드 3개
- `/api/dashboard/{orgId}/metrics?providerType=GOOGLE|NAVER|KAKAO`
- % 단위 버그 수정

## 😅 미완성 작업

- 플랫폼별 실시간 클릭수 비교


## 📢 논의 사항 및 참고 사항

플랫폼 대시보드 일부 지표가 통합 대시보드와 동일한 API를 사용하기 때문에, 기존 `api/dashboard/overview.ts` · `types/dashboard/overview.ts`의 함수/타입을 그대로 끌어다 썼습니다.

현재 데이터가 아직 메타로 변경되기 전이라 임시로 카카오를 메타로 변경하여 나타냈습니다. 추후 삭제 예정입니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 플랫폼 대시보드가 실시간 API 기반으로 전환되어 광고 소재 현황, ROAS 순위, 플랫폼별 성과를 실제 데이터로 로드합니다.
  * 광고 소재 수 조회와 플랫폼 성과 조회를 위한 데이터 훅이 추가되었습니다.
  * 광고 소재 조회에 시작/종료일 파라미터가 지원됩니다.

* **버그 수정**
  * 플랫폼 상세 카드의 트렌드 퍼센트 포맷을 수정했습니다.
  * CTR 차트 라벨링을 개선했습니다.

* **기타**
  * 임시 광고 소재 목업이 제거되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Frontend/pull/204)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->