### PR TITLE
[Feature/#203] 마이페이지 skeleton UI 구현

### DIFF
--- a/src/components/setting/PasswordSectionSkeleton.tsx
+++ b/src/components/setting/PasswordSectionSkeleton.tsx
@@ -1,0 +1,30 @@
+import { Skeleton, SkeletonCircle } from "../common/skeleton/Skeleton";
+
+export default function PasswordSectionSkeleton() {
+  return (
+    <div className="bg-white border border-gray-100 rounded-component-lg p-8 shadow-Soft">
+      <div className="mb-7">
+        <div className="flex gap-4 items-center mb-3">
+          <SkeletonCircle className="w-8 h-8" />
+          <Skeleton className="w-40 h-7" />
+        </div>
+        <Skeleton className="w-96 h-4 mb-2" />
+        <Skeleton className="w-80 h-4" />
+      </div>
+      <div className="grid grid-cols-1 gap-y-6 tablet:max-w-4xl">
+        <div>
+          <Skeleton className="w-32 h-5 mb-2" />
+          <Skeleton className="w-full h-12 rounded-xl" />
+        </div>
+        <div>
+          <Skeleton className="w-32 h-5 mb-2" />
+          <Skeleton className="w-full h-12 rounded-xl" />
+        </div>
+        <div>
+          <Skeleton className="w-40 h-5 mb-2" />
+          <Skeleton className="w-full h-12 rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/setting/ProfileSectionSkeleton.tsx
+++ b/src/components/setting/ProfileSectionSkeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton, SkeletonCircle } from "../common/skeleton/Skeleton";
+
+export default function ProfileSectionSkeleton() {
+  return (
+    <div className="bg-white border border-gray-100 rounded-component-lg p-8 shadow-Soft">
+      <div className="mb-7 flex items-start gap-4">
+        <SkeletonCircle className="w-8 h-8" />
+        <Skeleton className="w-24 h-7" />
+      </div>
+
+      <div className="flex tablet:flex-row gap-10">
+        <div className="flex flex-col items-center basis-1/4 shrink-0">
+          <Skeleton className="w-24 h-5 mb-4" />
+          <SkeletonCircle className="w-60 h-60" />
+          <div className="mt-5 flex gap-3">
+            <Skeleton className="w-16 h-7 rounded-component-lg" />
+            <Skeleton className="w-16 h-7 rounded-component-lg" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 tablet:grid-cols-2 gap-x-6 basis-3/4 gap-y-5 w-full">
+          <div className="col-span-2">
+            <Skeleton className="w-16 h-5 mb-2" />
+            <Skeleton className="w-full h-12 rounded-xl" />
+          </div>
+          <div className="col-span-2">
+            <Skeleton className="w-20 h-5 mb-2" />
+            <Skeleton className="w-full h-12 rounded-xl" />
+          </div>
+          <div className="col-span-2">
+            <Skeleton className="w-20 h-5 mb-2" />
+            <Skeleton className="w-full h-12 rounded-xl" />
+          </div>
+          <div className="col-span-2">
+            <Skeleton className="w-24 h-5 mb-2" />
+            <Skeleton className="w-full h-12 rounded-xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -7,7 +7,9 @@ import { useImageUploader } from "@/hooks/common/useImageUploader";
 
 import Button from "@/components/common/button/Button";
 import PasswordSection from "@/components/setting/PasswordSection";
+import PasswordSectionSkeleton from "@/components/setting/PasswordSectionSkeleton";
 import ProfileSection from "@/components/setting/ProfileSection";
+import ProfileSectionSkeleton from "@/components/setting/ProfileSectionSkeleton";
 
 import { getMyInfo, updateMyInfo } from "@/api/auth/auth";
 
@@ -42,6 +44,7 @@ export default function Setting() {
   const [newPassword, setNewPassword] = useState("");
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
   const [isImageDeleted, setIsImageDeleted] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const {
     fileRef,
     file,
@@ -141,6 +144,7 @@ export default function Setting() {
   useEffect(() => {
     const fetchMyInfo = async () => {
       try {
+        setIsLoading(true);
         const res = await getMyInfo();
 
         const profileData = {
@@ -162,6 +166,8 @@ export default function Setting() {
       } catch (error) {
         toast.error("회원 정보를 불러오는데 실패했습니다");
         console.error(error);
+      } finally {
+        setIsLoading(false);
       }
     };
     fetchMyInfo();
@@ -169,30 +175,39 @@ export default function Setting() {
   return (
     <section className="w-full flex flex-col gap-8">
       <div className="flex flex-col gap-6">
-        <ProfileSection
-          name={draftProfile.name}
-          setName={(v) => setDraftProfile((prev) => ({ ...prev, name: v }))}
-          organizations={draftProfile.organizations}
-          email={draftProfile.email}
-          phoneNumber={draftProfile.phoneNumber}
-          fileRef={fileRef}
-          preview={preview}
-          onPickFile={handlePickFile}
-          openFilePicker={openFilePicker}
-          resetImage={() => {
-            resetImage();
-            setIsImageDeleted(true);
-          }}
-        />
-        <PasswordSection
-          currentPassword={currentPassword}
-          setCurrentPassword={setCurrentPassword}
-          newPassword={newPassword}
-          setNewPassword={setNewPassword}
-          confirmNewPassword={confirmNewPassword}
-          setConfirmNewPassword={setConfirmNewPassword}
-          errors={passwordErrors}
-        />
+        {isLoading ? (
+          <>
+            <ProfileSectionSkeleton />
+            <PasswordSectionSkeleton />
+          </>
+        ) : (
+          <>
+            <ProfileSection
+              name={draftProfile.name}
+              setName={(v) => setDraftProfile((prev) => ({ ...prev, name: v }))}
+              organizations={draftProfile.organizations}
+              email={draftProfile.email}
+              phoneNumber={draftProfile.phoneNumber}
+              fileRef={fileRef}
+              preview={preview}
+              onPickFile={handlePickFile}
+              openFilePicker={openFilePicker}
+              resetImage={() => {
+                resetImage();
+                setIsImageDeleted(true);
+              }}
+            />
+            <PasswordSection
+              currentPassword={currentPassword}
+              setCurrentPassword={setCurrentPassword}
+              newPassword={newPassword}
+              setNewPassword={setNewPassword}
+              confirmNewPassword={confirmNewPassword}
+              setConfirmNewPassword={setConfirmNewPassword}
+              errors={passwordErrors}
+            />
+          </>
+        )}
       </div>
       <div className="flex justify-end">
         <Button
@@ -201,7 +216,7 @@ export default function Setting() {
           size="big"
           aria-label="개인 설정 변경사항 저장 버튼"
           onClick={handleSave}
-          disabled={!hasChanges}
+          disabled={!hasChanges || isLoading}
         >
           변경사항 저장하기
         </Button>


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #203 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

마이페이지(Setting) 페이지 내에 API로딩상태 분기 하고,
ProfileSection과 PasswordSection의 스켈레톤 UI 추가하였습니다

#### 💻 작업 화면
<img width="1777" height="900" alt="image" src="https://github.com/user-attachments/assets/8f54b2ea-1335-4c77-ac1b-612b12eb5ffa" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 페이지 로딩 시 스켈레톤 UI 표시로 향상된 로딩 상태 피드백 제공
  * 데이터 로드 중 저장 버튼 비활성화로 사용자 경험 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Frontend/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->