### PR TITLE
[Bugfix#211] 개발환경 refreshToken 쿠키 저장 안 되는 문제 해결

### DIFF
--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -204,7 +204,7 @@ export default function CampaignDetail() {
         <header className="flex w-full flex-col gap-6">
           <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
             <div className="flex min-w-0 flex-wrap items-center gap-3">
-              <h1 className="min-w-0 break-words font-heading2 text-text-title">
+              <h1 className="min-w-0 wrap-break-word font-heading2 text-text-title">
                 {data.name}
               </h1>
               <Badge

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => {
         "/api": {
           target: env.VITE_API_TARGET_URL,
           changeOrigin: true,
+          cookieDomainRewrite: { "*": "" },
           configure(proxy) {
             proxy.on("proxyReq", (proxyReq) => {
               // 백엔드가 Origin 기반으로 CORS 차단하는 경우(예: "Invalid CORS request")


### PR DESCRIPTION
## 🚨 관련 이슈

#211

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 문제 원인
- 서버가 로그인 응답으로 `Set-Cookie: refreshToken=xxx; Domain=whereyouad.com` 이런 식의 쿠키를 보냄.
- 개발 환경에서는 브라우저가 localhost에서 응답을 받는데, 쿠키에는 whereyouad.com이라고 되어있어 개발 환경에서 저장을 거부한다. 

### 배포 환경에서는 동작하는 이유
- 배포환경에서는 브라우저가 whereyouad.com 에서 직접 응답을 받으니까 `Domain=whereyouad.com` 쿠키를 정상 저장한다.

### 해결책
`vite.config.ts` 프록시 설정에 추가: `cookieDomainRewrite: { "*": "" }`
- 도메인 속성을 제거하여 브라우저는 현재 호스트인 localhost 소속 쿠키로 저장될 수 있도록 함
- 배포 환경에서는 cookieDomainRewrite가 적용되지 않음 
     - 배포 환경에서는 프록시 없이 백엔드가 직접 소통하니까 서버 원본 응답 그대로 받음  


## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* **스타일**
  * 캠페인 상세 페이지의 제목 텍스트 줄바꿈이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Frontend/pull/212)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->