### PR TITLE
[Test/#222] Playwright E2E 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ scripts/strip-cursor-attribution.mjs
 scripts/strip-cursor-attribution 2.mjs
 scripts/optimize-landing-images.mjs
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
+    "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -38,6 +39,7 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@eslint/js": "^9.39.2",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-essentials": "8.6.17",
     "@storybook/react": "8.6.17",
     "@storybook/react-vite": "8.6.17",
@@ -49,6 +51,7 @@
     "@typescript-eslint/eslint-plugin": "^8.53.0",
     "@typescript-eslint/parser": "^8.53.0",
     "@vitejs/plugin-react-swc": "^3.11.0",
+    "dotenv": "^17.4.2",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// .env 로드 (PLAYWRIGHT_BASE_URL 등)
+dotenv.config({ path: path.resolve(__dirname, ".env") });
+
+const PORT = 5173; // vite.config.ts 와 동일
+const LOCAL_BASE_URL = `http://localhost:${PORT}`;
+
+// E2E 대상: PLAYWRIGHT_BASE_URL → VITE_APP_URL → 로컬
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL ?? process.env.VITE_APP_URL ?? LOCAL_BASE_URL;
+
+/** localhost 여부 (webServer 켤지 결정) */
+function isLocalBaseUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "localhost" || hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
+const isLocal = isLocalBaseUrl(BASE_URL);
+
+export default defineConfig({
+  testDir: "./tests", // *.spec.ts 위치
+
+  fullyParallel: true, // 파일별 병렬
+  forbidOnly: !!process.env.CI, // CI 에서 test.only 금지
+  retries: process.env.CI ? 2 : 0, // CI 만 재시도
+  workers: process.env.CI ? 1 : undefined, // CI 는 워커 1개
+
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "html",
+
+  timeout: 30_000, // 테스트 1개 제한
+  expect: { timeout: 10_000 }, // assertion 대기
+
+  use: {
+    baseURL: BASE_URL, // page.goto('/') 기준
+    locale: "ko-KR",
+    timezoneId: "Asia/Seoul",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    trace: process.env.CI ? "on-first-retry" : "on", // 로컬: 리포트에서 UI(trace), CI: 재시도 시만
+    ignoreHTTPSErrors: !isLocal, // 배포 HTTPS
+  },
+
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+
+  // 로컬만 Vite 기동, 배포 URL 은 webServer 없음
+  ...(isLocal
+    ? {
+        webServer: {
+          command: "pnpm run dev",
+          url: LOCAL_BASE_URL,
+          reuseExistingServer: !process.env.CI, // 로컬 dev 이미 켜져 있으면 재사용
+          timeout: 120_000,
+        },
+      }
+    : {}),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@storybook/addon-essentials':
         specifier: 8.6.17
         version: 8.6.17(@types/react@19.2.14)(storybook@8.6.17(prettier@3.8.1))
@@ -108,6 +111,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.11.0
         version: 3.11.0(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -574,6 +580,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1689,6 +1700,10 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2014,6 +2029,11 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2827,6 +2847,16 @@ packages:
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
+    hasBin: true
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   polished@4.3.1:
@@ -3940,6 +3970,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -5072,6 +5106,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dotenv@17.4.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5517,6 +5553,9 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -6435,6 +6474,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   polished@4.3.1:
     dependencies:

--- a/tests/auth-guard.spec.ts
+++ b/tests/auth-guard.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+// 기본 격리 컨텍스트(쿠키·스토리지 없음) = 비로그인
+test.describe("AuthGuard", () => {
+  test("비로그인 시 /dashboard 접근은 /login 으로 리다이렉트된다", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible();
+  });
+});

--- a/tests/find-email.spec.ts
+++ b/tests/find-email.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("이메일 찾기 UI", () => {
+  test("로그인에서 이메일 찾기(휴대폰 인증) 화면으로 진입한다", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+
+    await page
+      .getByRole("link", { name: "이메일/비밀번호를 잊어버렸어요" })
+      .click();
+
+    await expect(page).toHaveURL(/\/find-email/);
+
+    const heading = page.getByRole("heading", { level: 1 });
+    await expect(heading.getByText("이메일 찾기를 위해")).toBeVisible();
+    await expect(heading.getByText("휴대폰 인증을 진행할게요")).toBeVisible();
+
+    await expect(page.getByPlaceholder("전화번호를 입력하세요")).toBeVisible();
+  });
+});

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+const email = process.env.E2E_USER_EMAIL;
+const password = process.env.E2E_USER_PASSWORD;
+
+test.describe("로그인 E2E", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !email || !password,
+      "E2E_USER_EMAIL / E2E_USER_PASSWORD 가 .env 에 필요합니다.",
+    );
+  });
+
+  test("이메일 로그인 후 대시보드에 머문다", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible();
+
+    await page.getByPlaceholder("이메일을 입력하세요").fill(email!);
+    await page.getByPlaceholder("비밀번호를 입력하세요").fill(password!);
+    await page.getByRole("button", { name: "로그인하기" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const sidebar = page.getByRole("navigation", {
+      name: "사이드바 내비게이션",
+    });
+    const expandSidebar = page.getByRole("button", { name: "사이드바 펼치기" });
+    if (await expandSidebar.isVisible()) {
+      await expandSidebar.click();
+    }
+    await expect(sidebar.getByText("대시보드", { exact: true })).toBeVisible();
+
+    await expect(
+      page.getByText("로그인에 실패했습니다.", { exact: true }),
+    ).not.toBeVisible();
+
+    const aiSummary = page.getByRole("button", { name: "AI 요약하기" });
+    if (await aiSummary.isVisible()) {
+      await expect(aiSummary).toBeVisible();
+    }
+  });
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,61 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const email = process.env.E2E_USER_EMAIL;
+const password = process.env.E2E_USER_PASSWORD;
+
+async function loginAndReachDashboard(page: Page) {
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible();
+
+  await page.getByPlaceholder("이메일을 입력하세요").fill(email!);
+  await page.getByPlaceholder("비밀번호를 입력하세요").fill(password!);
+  await page.getByRole("button", { name: "로그인하기" }).click();
+
+  await expect(page).toHaveURL(/\/dashboard/);
+}
+
+async function expandSidebarIfCollapsed(page: Page) {
+  const expandSidebar = page.getByRole("button", { name: "사이드바 펼치기" });
+  if (await expandSidebar.isVisible()) {
+    await expandSidebar.click();
+  }
+}
+
+test.describe("로그인 후 사이드바 네비게이션", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !email || !password,
+      "E2E_USER_EMAIL / E2E_USER_PASSWORD 가 .env 에 필요합니다.",
+    );
+  });
+
+  test("통합 대시보드 화면을 확인한다", async ({ page }) => {
+    await loginAndReachDashboard(page);
+    await expandSidebarIfCollapsed(page);
+
+    const nav = page.getByRole("navigation", {
+      name: "사이드바 내비게이션",
+    });
+
+    // 로그인 후 /dashboard 진입 시 대시보드 하위 메뉴가 이미 펼쳐짐
+    await expect(
+      nav.getByRole("link", { name: "통합 대시보드", exact: true }),
+    ).toBeVisible();
+
+    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(page.getByText("실시간 트래픽 변화")).toBeVisible();
+
+    const header = page.locator("main header");
+    await expect(
+      header.getByRole("link", { name: "대시보드", exact: true }),
+    ).toBeVisible();
+    await expect(
+      header.getByRole("link", { name: "통합 대시보드", exact: true }),
+    ).toBeVisible();
+
+    const aiSummary = page.getByRole("button", { name: "AI 요약하기" });
+    if (await aiSummary.isVisible()) {
+      await expect(aiSummary).toBeVisible();
+    }
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "@playwright/test";
+
+// 로그인 없이 확인 가능한 최소 스모크
+test("로그인 페이지가 열린다", async ({ page }) => {
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible();
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -27,5 +27,10 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["vite.config.ts", "svg.d.ts"]
+  "include": [
+    "vite.config.ts",
+    "svg.d.ts",
+    "playwright.config.ts",
+    "tests/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## 🚨 관련 이슈

#222 

## ✨ 변경사항

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [X] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### Playwright E2E 도입
- `@playwright/test`, `dotenv` 추가 및 `pnpm test:e2e` 스크립트 등록
- Cursor MCP로 탐색한 시나리오를 회귀 테스트로 고정하였습니다.
- `.gitignore`에 `test-results/`, `playwright-report/` 등 Playwright 산출물 추가

### E2E
- `smoke.spec.ts` - 로그인 페이지 로드
- `auth-guard.spce.ts` - 비로그인 시 /dashboard -> /login 리다이렉트
- `find-email.spec.ts` - 로그인 -> 이메일 찾기(휴대폰 인증) 화면 진입
- `login.spec.ts` - 이메일 로그인 후 /dashboard 유지
- `navigation.spec.ts` - 로그인 후 통합 대시보드 화면, 사이드바, 헤더 확인

### 참고
- Cursor MCP로 시나리오를 탐색한 뒤 spec으로 옮긴 흐름은 아래 글에 정리해 두었습니다.
https://seojegyeong.tistory.com/5


## 😅 미완성 작업
- CI 파이프라인에 pnpm test:e2e 연동 
- 크로스 브라우저(projects) 확장 -> 현재 Chromium만

## 📢 논의 사항 및 참고 사항
- login, navigation 테스트는 .env에 E2E_USER_EMAIL, E2E_USER_PASSWORD가 있어야 실행됩니다. 없으면 해당 spec은 test.skip 됩니다.
- 로컬 trace가 켜져 있어 test-results/ 용량이 커질 수 있습니다.
- Cursor MCP로 만든 spec은 그대로 쓰기보다, 실제 UI 흐름을 한 번 확인한 뒤 selector·assertion을 다듬는 것을 추천합니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
