### PR TITLE
[Feature/#225] 사이드바 새 워크스페이스 클릭 시 생성  모달 오픈

### DIFF
--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -160,7 +160,7 @@ function Modal({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="absolute top-4 right-4 rounded-full p-1 transition-colors hover:bg-surface-200"
+                  className="absolute top-4 right-4 z-10 rounded-full p-1 transition-colors hover:bg-surface-200"
                   aria-label="모달 닫기"
                 >
                   <CloseIcon className="h-6 w-6 text-text-muted" />

--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -268,7 +268,7 @@ export function WorkspaceSwitcher({
                 type="button"
                 onClick={() => {
                   setIsOpen(false);
-                  navigate("/workspace");
+                  navigate("/workspace?create=1");
                 }}
                 className="flex w-full items-center gap-3 rounded-2xl px-2 py-1.5 font-body2 text-text-body hover:bg-surface-200 transition-colors"
               >

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -85,15 +92,19 @@ export default function WorkspacePage() {
     });
   }, [filtered, selectedOrgId]);
 
-  const onCloseCreate = () => {
-    setLogoPreview(null);
+  const openedCreateFromQueryRef = useRef(false);
+  const { reset: resetCreateMutation } = createWorkspaceMutation;
+
+  const onCloseCreate = useCallback(() => {
     setLogoPreview((prev) => {
       if (prev) URL.revokeObjectURL(prev);
       return null;
     });
+    setLogoFile(null);
     setCreateOpen(false);
-  };
-  const onOpenCreate = () => {
+  }, []);
+
+  const onOpenCreate = useCallback(() => {
     setNewName("");
     setNewDesc("");
     setLogoFile(null);
@@ -101,16 +112,21 @@ export default function WorkspacePage() {
       if (prev) URL.revokeObjectURL(prev);
       return null;
     });
-    createWorkspaceMutation.reset();
+    resetCreateMutation();
     setCreateOpen(true);
-  };
+  }, [resetCreateMutation]);
 
-  useEffect(() => {
-    if (searchParams.get("create") !== "1") return;
+  useLayoutEffect(() => {
+    if (searchParams.get("create") !== "1") {
+      openedCreateFromQueryRef.current = false;
+      return;
+    }
+    if (openedCreateFromQueryRef.current) return;
 
+    openedCreateFromQueryRef.current = true;
     onOpenCreate();
     setSearchParams({}, { replace: true });
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, onOpenCreate]);
 
   const onPickLogo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -197,7 +213,7 @@ export default function WorkspacePage() {
       {renderWorkspaceContent()}
 
       <Modal isOpen={createOpen} onClose={onCloseCreate} size="md" padding="lg">
-        <div className="flex flex-col items-start px-2 tablet:px-0">
+        <div className="flex flex-col items-start pr-10 px-2 tablet:px-0">
           <h2 className="mb-2 font-heading3 text-text-title">
             워크스페이스 생성
           </h2>

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { IApiErrorResponse } from "@/types/common/common";
@@ -22,6 +22,7 @@ import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export default function WorkspacePage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [query, setQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
@@ -103,6 +104,13 @@ export default function WorkspacePage() {
     createWorkspaceMutation.reset();
     setCreateOpen(true);
   };
+
+  useEffect(() => {
+    if (searchParams.get("create") !== "1") return;
+
+    onOpenCreate();
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const onPickLogo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## 🚨 관련 이슈
close #225 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- 사이드바 워크스페이스 `새 워크스페이스 `클릭 시 `/workspace?create=1`로 이동하도록 변경
- `Workspace` 페이지에서 `useSearchParams`로 `create=1` 감지 후 기존 `onOpenCreate()` 호출 → 생성 모달 자동 오픈

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 워크스페이스 생성 버튼을 통해 쿼리 파라미터 기반 생성 모드로 직접 이동할 수 있습니다.
  * 특정 URL 쿼리 파라미터 감지 시 자동으로 워크스페이스 생성 모달이 열립니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Frontend/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->