### PR TITLE
[Feature/#232] 워크스페이스 역할 기반 접근 제어(RBAC) 도입

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -3,6 +3,8 @@ import { useCallback, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { twMerge } from "tailwind-merge";
 
+import type { INavItem } from "@/types/navigation/navItem";
+import type { TMemberRole } from "@/types/workspace/workspace";
 import { footerNav, mainNav } from "@/constants/sidebarNav";
 
 import { mainNavSidebar } from "@/utils/navigation/mainNavSidebar";
@@ -19,6 +21,20 @@ import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import CollapseIcon from "@/assets/icon/chevron/chervon-left.svg?react";
 import ChevronIcon from "@/assets/icon/chevron/chevron-up.svg?react";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+function filterNavByRole(
+  items: INavItem[],
+  myRole: TMemberRole | null,
+): INavItem[] {
+  return items
+    .filter((item) => !item.requiredRole || item.requiredRole === myRole)
+    .map((item) => ({
+      ...item,
+      children: item.children
+        ? filterNavByRole(item.children, myRole)
+        : undefined,
+    }));
+}
 
 function getMainItemClass(isActive: boolean, isCollapsed: boolean) {
   return twMerge(
@@ -71,9 +87,11 @@ export default function Sidebar() {
   const { showComingSoon } = useComingSoon();
 
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
+  const myRole = useWorkspaceStore((s) => s.myRole);
   const mainNavWithWorkspace = useMemo(
-    () => applyWorkspacePathsToNav(mainNav, selectedOrgId),
-    [selectedOrgId],
+    () =>
+      filterNavByRole(applyWorkspacePathsToNav(mainNav, selectedOrgId), myRole),
+    [selectedOrgId, myRole],
   );
 
   const handleFooterItemClick = useCallback(

--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -27,6 +27,7 @@ export function WorkspaceSwitcher({
 
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
+  const setMyRole = useWorkspaceStore((s) => s.setMyRole);
 
   const { data: workspaces, isPending } = useCoreQuery(
     ["my-workspaces"],
@@ -52,12 +53,15 @@ export function WorkspaceSwitcher({
     const fallback =
       workspaceList.find((w) => w.isCurrentWorkspace) || workspaceList[0];
     setSelectedOrgId(fallback.orgId);
-  }, [selectedOrgId, workspaceList, setSelectedOrgId]);
+    setMyRole(fallback.myRole);
+  }, [selectedOrgId, workspaceList, setSelectedOrgId, setMyRole]);
 
   const { mutate: saveWorkspace } = useMutation({
     mutationFn: (orgId: number) => saveSelectedWorkspace(orgId),
     onSuccess: async (_data, orgId) => {
+      const workspace = workspaceList.find((w) => w.orgId === orgId);
       setSelectedOrgId(orgId);
+      if (workspace) setMyRole(workspace.myRole);
       setIsOpen(false);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["my-workspaces"] }),

--- a/src/constants/sidebarNav.ts
+++ b/src/constants/sidebarNav.ts
@@ -69,11 +69,13 @@ export const mainNav: INavItem[] = [
         id: "workspace-members",
         label: "멤버 관리",
         workspaceSubpath: "members",
+        requiredRole: "ADMIN",
       },
       {
         id: "workspace-billing",
         label: "플랜 및 결제",
         workspaceSubpath: "billing",
+        requiredRole: "ADMIN",
       },
     ],
   },

--- a/src/hooks/auth/useIsAdmin.ts
+++ b/src/hooks/auth/useIsAdmin.ts
@@ -1,0 +1,9 @@
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+/*useWorkspaceStore에서 myRole을 읽어서 booelan으로 반환하는 훅*/
+function useIsAdmin(): boolean {
+  const myRole = useWorkspaceStore((s) => s.myRole);
+  return myRole === "ADMIN";
+}
+
+export default useIsAdmin;

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -38,6 +38,7 @@ export default function MainLayout() {
   >(null);
 
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
+  const setMyRole = useWorkspaceStore((s) => s.setMyRole);
 
   const savedWorkspaceQuery = useCoreQuery(
     ["savedWorkspace"],
@@ -59,20 +60,25 @@ export default function MainLayout() {
     const savedId = savedData?.orgId;
     const isExist = workspaces.some((w) => w.orgId === savedId);
 
-    // 1. 현재 워크스페이스 조회 API 데이터
+    // 1. 현재 워크스페이스 조회 API 데이터 (저장된 워크스페이스가 있는 경우)
     if (savedId !== undefined && isExist) {
+      const workspace = workspaces.find((w) => w.orgId === savedId);
       setSelectedOrgId(savedId);
+      if (workspace) setMyRole(workspace.myRole);
     }
     // 2. isCurrentWorkspace 또는 첫 번째
     else {
-      const currentOrg = workspaces.find((w) => w.isCurrentWorkspace);
-      setSelectedOrgId(currentOrg?.orgId || workspaces[0].orgId);
+      const currentOrg =
+        workspaces.find((w) => w.isCurrentWorkspace) ?? workspaces[0];
+      setSelectedOrgId(currentOrg.orgId);
+      setMyRole(currentOrg.myRole);
     }
   }, [
     workspaces,
     savedWorkspaceQuery.isFetched,
     savedData,
     setSelectedOrgId,
+    setMyRole,
     selectedOrgId,
   ]);
 

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
 
+import useIsAdmin from "@/hooks/auth/useIsAdmin";
+
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
 import Input from "@/components/common/input/Input";
@@ -23,6 +25,7 @@ import WarnIcon from "@/assets/icon/common/warn-circle.svg?react";
 import { getImageUrl } from "@/lib/getImageUrl";
 
 export default function WorkspaceSetting() {
+  const isAdmin = useIsAdmin();
   const navigate = useNavigate();
   const { workspaceId } = useParams();
   const queryClient = useQueryClient();
@@ -221,7 +224,7 @@ export default function WorkspaceSetting() {
                 <button
                   type="button"
                   onClick={openFilePicker}
-                  disabled={saving || deleting}
+                  disabled={!isAdmin || saving || deleting}
                   aria-label="로고 이미지 업로드 또는 변경"
                   className="flex h-60 w-60 cursor-pointer items-center justify-center overflow-hidden rounded-lg border border-surface-400 bg-surface-200 outline-none transition-colors hover:bg-surface-300/70 focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:cursor-not-allowed disabled:opacity-50 tablet:h-46 tablet:w-46"
                 >
@@ -254,7 +257,7 @@ export default function WorkspaceSetting() {
                     className="h-7! rounded-3xl border border-surface-400 bg-surface-100 px-4 font-body2 text-text-auth-sub transition-colors duration-200 ease-in-out hover:bg-surface-200"
                     onClick={openFilePicker}
                     aria-label="로고 이미지 업로드 버튼"
-                    disabled={saving || deleting}
+                    disabled={!isAdmin || saving || deleting}
                   >
                     업로드
                   </Button>
@@ -264,7 +267,7 @@ export default function WorkspaceSetting() {
                     className="h-7! rounded-3xl border border-surface-400 bg-surface-100 px-4 font-body2 text-text-auth-sub transition-colors duration-200 ease-in-out hover:bg-surface-200"
                     onClick={onResetLogo}
                     aria-label="로고 이미지 초기화 버튼"
-                    disabled={saving || deleting}
+                    disabled={!isAdmin || saving || deleting}
                   >
                     초기화
                   </Button>
@@ -276,7 +279,7 @@ export default function WorkspaceSetting() {
                   value={name}
                   placeholder="조직의 이름 또는 워크스페이스 이름을 입력해주세요"
                   onChange={(e) => setName(e.target.value)}
-                  disabled={saving || deleting}
+                  disabled={!isAdmin || saving || deleting}
                 />
                 <TextareaField
                   id="workspace-setting-desc"
@@ -286,33 +289,35 @@ export default function WorkspaceSetting() {
                   onChange={(e) => setDesc(e.target.value)}
                   minRows={4}
                   className="min-h-90"
-                  disabled={saving || deleting}
+                  disabled={!isAdmin || saving || deleting}
                 />
               </div>
             </div>
-            <div className="mt-6 flex flex-wrap items-center justify-end gap-3 tablet:flex-col tablet:items-stretch">
-              <Button
-                type="button"
-                variant="dangerSoft"
-                size="big"
-                onClick={openDeleteModal}
-                disabled={saving || deleting}
-                className="w-auto tablet:w-full"
-              >
-                워크스페이스 삭제
-              </Button>
-              <Button
-                size="big"
-                variant="primary"
-                type="button"
-                onClick={onSave}
-                disabled={!name.trim() || saving || deleting}
-                aria-label="변경사항 저장하기"
-                className="w-auto tablet:w-full"
-              >
-                {saving ? "저장 중.." : "변경사항 저장하기"}
-              </Button>
-            </div>
+            {isAdmin && (
+              <div className="mt-6 flex flex-wrap items-center justify-end gap-3 tablet:flex-col tablet:items-stretch">
+                <Button
+                  type="button"
+                  variant="dangerSoft"
+                  size="big"
+                  onClick={openDeleteModal}
+                  disabled={saving || deleting}
+                  className="w-auto tablet:w-full"
+                >
+                  워크스페이스 삭제
+                </Button>
+                <Button
+                  size="big"
+                  variant="primary"
+                  type="button"
+                  onClick={onSave}
+                  disabled={!name.trim() || saving || deleting}
+                  aria-label="변경사항 저장하기"
+                  className="w-auto tablet:w-full"
+                >
+                  {saving ? "저장 중.." : "변경사항 저장하기"}
+                </Button>
+              </div>
+            )}
           </Card>
 
           <Modal

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -5,6 +5,8 @@ import { loadable } from "@/utils/loadable";
 
 import WorkspaceListLoading from "@/components/workspace/WorkspaceListLoading";
 
+import RoleGuard from "./RoleGuard";
+
 import WorkspaceBillingRedirect from "@/pages/workspace/WorkspaceBillingRedirect";
 
 const OverviewDashboard = loadable(
@@ -74,7 +76,11 @@ const MainRoutes: RouteObject[] = [
   },
   {
     path: "workspace/billing",
-    element: <WorkspaceBillingRedirect />,
+    element: (
+      <RoleGuard allowedRoles={["ADMIN"]}>
+        <WorkspaceBillingRedirect />
+      </RoleGuard>
+    ),
   },
   {
     path: "workspace/:workspaceId",
@@ -82,8 +88,22 @@ const MainRoutes: RouteObject[] = [
     children: [
       { index: true, element: <Navigate to="settings" replace /> },
       { path: "settings", element: <WorkspaceSetting /> },
-      { path: "members", element: <MemberManagement /> },
-      { path: "billing", element: <Billing /> },
+      {
+        path: "members",
+        element: (
+          <RoleGuard allowedRoles={["ADMIN"]}>
+            <MemberManagement />
+          </RoleGuard>
+        ),
+      },
+      {
+        path: "billing",
+        element: (
+          <RoleGuard allowedRoles={["ADMIN"]}>
+            <Billing />
+          </RoleGuard>
+        ),
+      },
     ],
   },
   {

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
+import type { ReactElement, ReactNode } from "react";
+import { Navigate } from "react-router-dom";
 
 import type { TMemberRole } from "@/types/workspace/workspace";
 
@@ -10,8 +10,10 @@ interface IRoleGuardProps {
   allowedRoles: TMemberRole[];
 }
 
-function RoleGuard({ children, allowedRoles }: IRoleGuardProps) {
-  const navigate = useNavigate();
+function RoleGuard({
+  children,
+  allowedRoles,
+}: IRoleGuardProps): ReactElement | null {
   const myRole = useWorkspaceStore((s) => s.myRole);
 
   //워크스페이스 초기화 전(null)에 랜더 보류
@@ -21,7 +23,7 @@ function RoleGuard({ children, allowedRoles }: IRoleGuardProps) {
 
   //허용되지 않는 역할 -> 대시보드로 리다이렉트
   if (!allowedRoles.includes(myRole)) {
-    return navigate("/dashboard", { replace: true });
+    return <Navigate to="/dashboard" replace />;
   }
   return <>{children}</>;
 }

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+
+import type { TMemberRole } from "@/types/workspace/workspace";
+
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+interface IRoleGuardProps {
+  children: ReactNode;
+  allowedRoles: TMemberRole[];
+}
+
+function RoleGuard({ children, allowedRoles }: IRoleGuardProps) {
+  const navigate = useNavigate();
+  const myRole = useWorkspaceStore((s) => s.myRole);
+
+  //워크스페이스 초기화 전(null)에 랜더 보류
+  if (myRole === null) {
+    return null;
+  }
+
+  //허용되지 않는 역할 -> 대시보드로 리다이렉트
+  if (!allowedRoles.includes(myRole)) {
+    return navigate("/dashboard", { replace: true });
+  }
+  return <>{children}</>;
+}
+
+export default RoleGuard;

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -19,15 +19,21 @@ function RoleGuard({
 }: IRoleGuardProps): ReactElement | null {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
   const myRole = useWorkspaceStore((s) => s.myRole);
-  const { data: workspaces } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
+  const {
+    data: workspaces,
+    isPending,
+    isError,
+  } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
 
   //URL에 workspaceId가 있는 경우 -> URL 기준 워크스페이스의 role로 판정
   if (workspaceId) {
     //워크스페이스 목록 로드 전 -> 랜더 보류
-    if (!workspaces) {
+    if (isPending) {
       return null;
     }
-
+    if (isError || !workspaces) {
+      return <Navigate to="/dashboard" replace />;
+    }
     const targetWorkspace = workspaces.find(
       (w) => w.orgId === Number(workspaceId),
     );

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -1,8 +1,11 @@
 import type { ReactElement, ReactNode } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useParams } from "react-router-dom";
 
 import type { TMemberRole } from "@/types/workspace/workspace";
 
+import { useCoreQuery } from "@/hooks/customQuery";
+
+import { getMyWorkspaces } from "@/api/workspace/org";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 interface IRoleGuardProps {
@@ -14,14 +17,36 @@ function RoleGuard({
   children,
   allowedRoles,
 }: IRoleGuardProps): ReactElement | null {
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
   const myRole = useWorkspaceStore((s) => s.myRole);
+  const { data: workspaces } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
+
+  //URL에 workspaceId가 있는 경우 -> URL 기준 워크스페이스의 role로 판정
+  if (workspaceId) {
+    //워크스페이스 목록 로드 전 -> 랜더 보류
+    if (!workspaces) {
+      return null;
+    }
+
+    const targetWorkspace = workspaces.find(
+      (w) => w.orgId === Number(workspaceId),
+    );
+
+    //URL의 workspaceId가 내 워크스페이스 목록에 없는 경우 -> 대시보드로
+    if (!targetWorkspace) {
+      return <Navigate to="/dashboard" replace />;
+    }
+
+    if (!allowedRoles.includes(targetWorkspace.myRole)) {
+      return <Navigate to="/dashboard" replace />;
+    }
+    return <>{children}</>;
+  }
 
   //워크스페이스 초기화 전(null)에 랜더 보류
   if (myRole === null) {
     return null;
   }
-
-  //허용되지 않는 역할 -> 대시보드로 리다이렉트
   if (!allowedRoles.includes(myRole)) {
     return <Navigate to="/dashboard" replace />;
   }

--- a/src/store/useWorkspaceStore.ts
+++ b/src/store/useWorkspaceStore.ts
@@ -1,13 +1,19 @@
 import { create } from "zustand";
 
+import type { TMemberRole } from "@/types/workspace/workspace";
+
 interface IWorkspaceState {
   selectedOrgId: number | null;
+  myRole: TMemberRole | null;
   setSelectedOrgId: (orgId: number) => void;
+  setMyRole: (role: TMemberRole) => void;
 }
 
 const useWorkspaceStore = create<IWorkspaceState>((set) => ({
   selectedOrgId: null,
+  myRole: null,
   setSelectedOrgId: (orgId) => set({ selectedOrgId: orgId }),
+  setMyRole: (role) => set({ myRole: role }),
 }));
 
 export default useWorkspaceStore;

--- a/src/store/useWorkspaceStore.ts
+++ b/src/store/useWorkspaceStore.ts
@@ -6,7 +6,7 @@ interface IWorkspaceState {
   selectedOrgId: number | null;
   myRole: TMemberRole | null;
   setSelectedOrgId: (orgId: number) => void;
-  setMyRole: (role: TMemberRole) => void;
+  setMyRole: (role: TMemberRole | null) => void;
 }
 
 const useWorkspaceStore = create<IWorkspaceState>((set) => ({

--- a/src/types/navigation/navItem.ts
+++ b/src/types/navigation/navItem.ts
@@ -1,5 +1,7 @@
 import type { ComponentType, SVGProps } from "react";
 
+import type { TMemberRole } from "../workspace/workspace";
+
 export interface INavItem {
   id: string;
   label: string;
@@ -10,4 +12,9 @@ export interface INavItem {
   /** true면 `path`와 pathname이 정확히 일치할 때만 매칭 (워크스페이스 목록 등) */
   pathExact?: boolean;
   children?: INavItem[];
+  /**
+   * 이 필드가 있으면 -> 해당 역할만 메뉴표시
+   * 이 필드가 없으면 -> 역할 상관없이 모두에게 표시
+   */
+  requiredRole?: TMemberRole;
 }


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #232 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

워크스페이스 Role에 따라 접근 가능한 라우트/메뉴/UI를 제한하는 역할 기반 접근 제어를 도입했습니다. (ADMIN/MEMBER)
**Role-Based Access Control**
- ADMIN 역할 -> 멤버 관리, 플랜/결제, 설정 편집 가능
- MEMBER 역할 -> 대시보드, 캠페인만 접근 가능

### 1. 전역 역할 상태 관리
- `useWorkspaceStore`에 `myRole`, `setMyRole` 추가
- `MainLayout` 초기 로드 시 및 `WorkspaceSwitcher` 전환 시 현재 워크스페이스의 `myRole` 자동 갱신
- 조직마다 역할이 다를 수 있기때문에 워크스페이스 전환시에 권한 상태도 같이 갱신되도록 구현

### 2. RoleGuard 컴포넌트 구현
- 기존 `AuthGuard`와 동일한 패턴으로 구현
- `myRole === null` (초기화 중) 이면 랜더링 보류, 허용되지 않은 역할이면 `/dashboard`로 리다이렉트

### 3. ADMIN 전용 라우트 접근 제한
- 멤버 관리, 플랜 및 결제 라우트에 `RoleGuard` 적용
- URL 직접 입력시에도 동일하게 차단됨

### 4. 사이드바 메뉴 필터링
- `INavItem` 타입에 `requiredRole?: TMemberRole` 필드 추가
- 멤버 관리, 플랜 및 결제 항목에 `requiredRole: "ADMIN"` 마킹
- `Sidebar`에서 `myRole` 기준으로 랜더링 전 필터링 처리 실행

### 5. 페이지 내 UI 읽기전용 처리

- `useIsAdmin()` 훅 추가
- `WorkspaceSetting`페이지에서 Role이 MEMBER일 경우에는 입력 필드 비활성화처리하고, 저장/삭제 버튼은 숨기 처리 구현

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

멤버관리, 플랜 및 결제는 MEMBER에서 접근이 불가능 하게 처리하였고,
WorkspaceSetting(워크스페이스 정보)에서는 접근은 가능하지만, 읽기전용으로 보이도록 설정했습니다. 추후에 완전 차단이 필요하다면 라우트에 `RoleGuard` 추가하면 됩니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 역할 기반 메뉴 필터링 추가 — 사이드바에서 현재 역할에 맞는 항목만 표시됩니다.
  * 역할 기반 접근 제어 적용 — 멤버 관리·청구 관리 등 관리자 전용 페이지 접근이 제한됩니다.
  * 워크스페이스 전환 시 역할 자동 동기화 — 선택된 워크스페이스에 맞춰 역할 상태가 업데이트됩니다.
  * 관리자 감지 훅 추가 — UI 요소(설정/삭제/업로드 등) 노출이 역할에 따라 제어됩니다.
  * 일부 워크스페이스 메뉴 항목에 ADMIN 요구 역할 지정.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Frontend/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->