### PR TITLE
[Refactor/#238] queryKey 상수 중앙화

### DIFF
--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -11,6 +11,7 @@ import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getMyWorkspaces, saveSelectedWorkspace } from "@/api/workspace/org";
 import ChevronIcon from "@/assets/icon/chevron/chevron-up.svg?react";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export function WorkspaceSwitcher({
@@ -30,7 +31,7 @@ export function WorkspaceSwitcher({
   const setMyRole = useWorkspaceStore((s) => s.setMyRole);
 
   const { data: workspaces, isPending } = useCoreQuery(
-    ["my-workspaces"],
+    QUERY_KEYS.workspace.list(),
     getMyWorkspaces,
   );
 
@@ -64,8 +65,12 @@ export function WorkspaceSwitcher({
       if (workspace) setMyRole(workspace.myRole);
       setIsOpen(false);
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["my-workspaces"] }),
-        queryClient.invalidateQueries({ queryKey: ["savedWorkspace"] }),
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.workspace.list(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.workspace.saved(),
+        }),
       ]);
     },
     onError: (error) => {

--- a/src/components/workspace/InviteMemberModal.tsx
+++ b/src/components/workspace/InviteMemberModal.tsx
@@ -18,6 +18,7 @@ import Modal from "../common/modal/Modal";
 import { postInviteEmail } from "@/api/workspace/org";
 import CopyIcon from "@/assets/icon/common/link.svg?react";
 import UserIcon from "@/assets/icon/common/user.svg?react";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 
 type TInviteMemberModalProps = {
   isOpen: boolean;
@@ -49,13 +50,13 @@ export default function InviteMemberModal({
       setForm({ email: "" });
 
       void queryClient.invalidateQueries({
-        queryKey: ["workspacePendingMembers", orgId],
+        queryKey: QUERY_KEYS.workspace.pendingMembers(orgId),
       });
       void queryClient.invalidateQueries({
-        queryKey: ["workspaceMembers", orgId],
+        queryKey: QUERY_KEYS.workspace.members(orgId),
       });
       void queryClient.invalidateQueries({
-        queryKey: ["workspaceMemberCount", orgId],
+        queryKey: QUERY_KEYS.workspace.memberCount(orgId),
       });
     },
     onError: (error) => {

--- a/src/hooks/ads/useCampaignDetail.ts
+++ b/src/hooks/ads/useCampaignDetail.ts
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getCampaignDetail } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 
 export const useCampaignDetail = () => {
   const { orgId, projectId } = useParams<{
@@ -22,7 +23,7 @@ export const useCampaignDetail = () => {
     parsedProjectId > 0;
 
   return useCoreQuery(
-    ["campaignDetail", parsedOrgId, parsedProjectId],
+    QUERY_KEYS.campaign.detail(parsedOrgId, parsedProjectId),
     () => getCampaignDetail(parsedOrgId, parsedProjectId),
     { enabled: isValid },
   );

--- a/src/hooks/ads/useCampaignGroup.ts
+++ b/src/hooks/ads/useCampaignGroup.ts
@@ -7,6 +7,7 @@ import type { IPlatformCampaign } from "@/types/ads/campaign";
 import type { IApiErrorResponse } from "@/types/common/common";
 
 import { createCampaignGroup, getPlatformCampaigns } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const NONE_OPTION: IPlatformCampaign = {
@@ -36,7 +37,7 @@ export const useCampaignGroup = () => {
     IPlatformCampaign[],
     IApiErrorResponse
   >({
-    queryKey: ["platformCampaigns", orgId, "GOOGLE"],
+    queryKey: QUERY_KEYS.campaign.platformList(orgId, "GOOGLE"),
     queryFn: () => getPlatformCampaigns(orgId!, "GOOGLE"),
     enabled: !!orgId,
   });
@@ -45,7 +46,7 @@ export const useCampaignGroup = () => {
     IPlatformCampaign[],
     IApiErrorResponse
   >({
-    queryKey: ["platformCampaigns", orgId, "NAVER"],
+    queryKey: QUERY_KEYS.campaign.platformList(orgId, "NAVER"),
     queryFn: () => getPlatformCampaigns(orgId!, "NAVER"),
     enabled: !!orgId,
   });
@@ -54,7 +55,7 @@ export const useCampaignGroup = () => {
     IPlatformCampaign[],
     IApiErrorResponse
   >({
-    queryKey: ["platformCampaigns", orgId, "META"],
+    queryKey: QUERY_KEYS.campaign.platformList(orgId, "META"),
     queryFn: () => getPlatformCampaigns(orgId!, "META"),
     enabled: !!orgId,
   });
@@ -91,7 +92,9 @@ export const useCampaignGroup = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["campaigns", orgId] });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.campaign.list(orgId),
+      });
       setIsSuccessModalOpen(true);
     },
     onError: (error) => {

--- a/src/hooks/dashboard/useAiAnalysisReport.ts
+++ b/src/hooks/dashboard/useAiAnalysisReport.ts
@@ -31,10 +31,6 @@ const WORKSPACE_REQUIRED_MESSAGE =
 /** 분석 요청 시 body 일부만 덮어쓸 때 */
 export type TRequestAiAnalysisParams = Partial<IAnalysisRequest>;
 
-function aiReportQueryKey(provider: TAiAnalysisProvider, accessToken: string) {
-  return QUERY_KEYS.ai.report(provider, accessToken);
-}
-
 /** AI 요약: POST 요청 → accessToken → GET 폴링 → reportData */
 export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
@@ -54,15 +50,12 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
   }, [provider, reset]);
 
   useEffect(() => {
-    const token = accessToken;
-    if (!token) return;
-
     return () => {
       void queryClient.removeQueries({
-        queryKey: aiReportQueryKey(provider, token),
+        queryKey: QUERY_KEYS.ai.report(provider, orgId),
       });
     };
-  }, [accessToken, provider]);
+  }, [provider, orgId]);
 
   /** POST /analysis — accessToken 발급 */
   const requestMutation = useCoreMutation(
@@ -81,7 +74,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
         setAccessToken(token);
         setPollStartedAt(Date.now());
         void queryClient.fetchQuery({
-          queryKey: aiReportQueryKey(provider, token),
+          queryKey: QUERY_KEYS.ai.report(provider, orgId),
           queryFn: () => getAiReportByAccessToken(token),
           staleTime: 0,
         });
@@ -94,7 +87,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
 
   /** GET /reports/{token} — PENDING이면 주기적으로 재조회 */
   const reportQuery = useCoreQuery(
-    aiReportQueryKey(provider, accessToken ?? ""),
+    QUERY_KEYS.ai.report(provider, orgId),
     () => getAiReportByAccessToken(accessToken!),
     {
       enabled: !!accessToken,

--- a/src/hooks/dashboard/useAiAnalysisReport.ts
+++ b/src/hooks/dashboard/useAiAnalysisReport.ts
@@ -16,6 +16,7 @@ import {
   requestAiAnalysis,
 } from "@/api/dashboard/aiAnalysis";
 import { queryClient } from "@/lib/queryClient";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 /** 폴링 간격 및 최대 대기(ms) */
@@ -31,7 +32,7 @@ const WORKSPACE_REQUIRED_MESSAGE =
 export type TRequestAiAnalysisParams = Partial<IAnalysisRequest>;
 
 function aiReportQueryKey(provider: TAiAnalysisProvider, accessToken: string) {
-  return ["ai", "report", provider, accessToken] as const;
+  return QUERY_KEYS.ai.report(provider, accessToken);
 }
 
 /** AI 요약: POST 요청 → accessToken → GET 폴링 → reportData */

--- a/src/hooks/dashboard/useBudget.ts
+++ b/src/hooks/dashboard/useBudget.ts
@@ -3,6 +3,7 @@ import type { TProviderType } from "@/types/dashboard/overview";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getBudget } from "@/api/dashboard/overview";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const WARNING_THRESHOLD = 50;
@@ -12,8 +13,8 @@ export function useBudget(provider?: TProviderType) {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   const queryKey = provider
-    ? ["platform", "budget", orgId, provider]
-    : ["overview", "budget", orgId];
+    ? QUERY_KEYS.platform.budget(orgId, provider)
+    : QUERY_KEYS.overview.budget(orgId);
 
   return useCoreQuery(queryKey, () => getBudget(orgId!, provider), {
     enabled: !!orgId && (provider ? !!provider : true),

--- a/src/hooks/dashboard/useOverviewCampaignList.ts
+++ b/src/hooks/dashboard/useOverviewCampaignList.ts
@@ -3,6 +3,7 @@ import type { ICampaign } from "@/types/ads/campaign";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getCampaignList } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 /** 캠페인 목록과 동일 쿼리 키로 캐시 공유 */
@@ -10,7 +11,7 @@ export function useOverviewCampaignList() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery<ICampaign[]>(
-    ["campaigns", orgId],
+    QUERY_KEYS.campaign.list(orgId),
     () => getCampaignList(orgId!),
     { enabled: !!orgId },
   );

--- a/src/hooks/dashboard/useOverviewMetrics.ts
+++ b/src/hooks/dashboard/useOverviewMetrics.ts
@@ -3,13 +3,14 @@ import { metricsToKpis } from "@/utils/dashboard/metricsToKpis";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getOverview } from "@/api/dashboard/overview";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export function useOverviewMetrics() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery(
-    ["overview", "metrics", orgId],
+    QUERY_KEYS.overview.metrics(orgId),
     () => getOverview(orgId!),
     {
       enabled: !!orgId,

--- a/src/hooks/dashboard/useOverviewRoasRankings.ts
+++ b/src/hooks/dashboard/useOverviewRoasRankings.ts
@@ -5,6 +5,7 @@ import { OVERVIEW_DAILY_METRICS_RANGE } from "@/constants/dashboard/overviewMetr
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getOverview, getRoasRankings } from "@/api/dashboard/overview";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const PROVIDERS: readonly TProviderType[] = PROVIDER_TYPES;
@@ -13,7 +14,7 @@ export function useOverviewRoasRankings() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery(
-    ["overview", "roasRankings", orgId],
+    QUERY_KEYS.overview.roasRankings(orgId),
     async (): Promise<IPlatformRankingItem[]> => {
       // ROAS 순위 + 플랫폼별 지표 병렬 조회
       const [rankingsRes, ...metricsResults] = await Promise.all([

--- a/src/hooks/dashboard/usePlatformAdCount.ts
+++ b/src/hooks/dashboard/usePlatformAdCount.ts
@@ -3,6 +3,7 @@ import type { IAdStatusData } from "@/types/dashboard/platform";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getAdCount } from "@/api/dashboard/platform";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 // 광고 소재 현황
@@ -10,7 +11,7 @@ export function usePlatformAdCount() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery<IAdStatusData>(
-    ["platform", "adCount", orgId],
+    QUERY_KEYS.platform.adCount(orgId),
     () => getAdCount(orgId!),
     { enabled: !!orgId },
   );

--- a/src/hooks/dashboard/usePlatformMetricFacts.ts
+++ b/src/hooks/dashboard/usePlatformMetricFacts.ts
@@ -8,6 +8,7 @@ import type {
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getMetricFacts } from "@/api/dashboard/platform";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const DAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"] as const;
@@ -57,7 +58,7 @@ export function usePlatformMetricFacts(provider: TProviderType, days: 7 | 30) {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery<IMetricFactsResponse, TMetricFactsViewModel>(
-    ["platform", "metricFacts", orgId, provider, days],
+    QUERY_KEYS.platform.metricFacts(orgId, provider, days),
     () =>
       getMetricFacts(orgId!, {
         providerType: provider,

--- a/src/hooks/dashboard/usePlatformMetrics.ts
+++ b/src/hooks/dashboard/usePlatformMetrics.ts
@@ -6,6 +6,7 @@ import type {
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getOverview } from "@/api/dashboard/overview";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 // 단일 플랫폼 지표 조회
@@ -13,7 +14,7 @@ export function usePlatformMetrics(provider: TProviderType) {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery<IMetricsResponse>(
-    ["platform", "metrics", orgId, provider],
+    QUERY_KEYS.platform.metrics(orgId, provider),
     () => getOverview(orgId!, provider),
     {
       enabled: !!orgId && !!provider,

--- a/src/hooks/dashboard/usePlatformPerformance.ts
+++ b/src/hooks/dashboard/usePlatformPerformance.ts
@@ -4,6 +4,7 @@ import { PROVIDER_TYPES, type TProviderType } from "@/types/dashboard/provider";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getOverview } from "@/api/dashboard/overview";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const PROVIDERS: readonly TProviderType[] = PROVIDER_TYPES;
@@ -13,7 +14,7 @@ export function usePlatformPerformance() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery(
-    ["platform", "performance", orgId],
+    QUERY_KEYS.platform.performance(orgId),
     async (): Promise<IPlatformPerformance[]> => {
       const settled = await Promise.allSettled(
         PROVIDERS.map((provider) =>

--- a/src/hooks/dashboard/usePlatformRoasRankings.ts
+++ b/src/hooks/dashboard/usePlatformRoasRankings.ts
@@ -4,13 +4,14 @@ import { OVERVIEW_DAILY_METRICS_RANGE } from "@/constants/dashboard/overviewMetr
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getRoasRankings } from "@/api/dashboard/overview";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 // ROAS 성과 순위 (상위 3개)
 export function usePlatformRoasRankings() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
   return useCoreQuery(
-    ["platform", "roasRankings", orgId],
+    QUERY_KEYS.platform.roasRankings(orgId),
     () => getRoasRankings(orgId!, OVERVIEW_DAILY_METRICS_RANGE),
     {
       enabled: !!orgId,

--- a/src/hooks/integration/usePlatformConnections.ts
+++ b/src/hooks/integration/usePlatformConnections.ts
@@ -4,6 +4,7 @@ import { mapPlatformAccountsToConnections } from "@/utils/integration/mapPlatfor
 
 import { useCoreQuery } from "@/hooks/customQuery";
 
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import { platformAccountsApiMock } from "@/pages/integration/platformIntegrations.mock";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
@@ -17,7 +18,7 @@ export function usePlatformConnections() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   return useCoreQuery(
-    ["platform-connections", orgId],
+    QUERY_KEYS.platform.connections(orgId),
     async () => {
       await new Promise((resolve) => {
         setTimeout(resolve, 800);

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -22,6 +22,7 @@ import Sidebar from "@/components/sidebar/Sidebar";
 
 import { getMyInfo } from "@/api/auth/auth";
 import { getMyWorkspaces, getSavedWorkspace } from "@/api/workspace/org";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export type TMainLayoutOutletContext = {
@@ -30,7 +31,7 @@ export type TMainLayoutOutletContext = {
 };
 
 export default function MainLayout() {
-  useCoreQuery(["myInfo"], getMyInfo);
+  useCoreQuery(QUERY_KEYS.auth.myInfo(), getMyInfo);
   const location = useLocation();
   const [headerRight, setHeaderRight] = useState<ReactNode | null>(null);
   const [campaignDetailHeaderTitle, setCampaignDetailHeaderTitle] = useState<
@@ -41,11 +42,14 @@ export default function MainLayout() {
   const setMyRole = useWorkspaceStore((s) => s.setMyRole);
 
   const savedWorkspaceQuery = useCoreQuery(
-    ["savedWorkspace"],
+    QUERY_KEYS.workspace.saved(),
     getSavedWorkspace,
   );
   const { data: savedData } = savedWorkspaceQuery;
-  const { data: workspaces } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
+  const { data: workspaces } = useCoreQuery(
+    QUERY_KEYS.workspace.list(),
+    getMyWorkspaces,
+  );
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   const navForHeader = useMemo(

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,75 @@
+// TanStack Query의 queryKey를 중앙 관리하는 상수 객체
+
+export const QUERY_KEYS = {
+  auth: {
+    /** 내 계정 정보 */
+    myInfo: () => ["myInfo"] as const,
+  },
+
+  workspace: {
+    /** 내 워크스페이스 목록 */
+    list: () => ["my-workspaces"] as const,
+    /** 마지막으로 선택한 워크스페이스 */
+    saved: () => ["savedWorkspace"] as const,
+    /** 워크스페이스 멤버 목록 (invalidate 전용) */
+    members: (orgId: number) => ["workspaceMembers", orgId] as const,
+    /** 워크스페이스 멤버 목록 (페이지 사이즈 포함) */
+    membersWithPageSize: (orgId: number, pageSize: number) =>
+      ["workspaceMembers", orgId, pageSize] as const,
+    /** 워크스페이스 전체 멤버 수 */
+    memberCount: (orgId: number) => ["workspaceMemberCount", orgId] as const,
+    /** 초대 수락 대기 중인 멤버 목록 */
+    pendingMembers: (orgId: number) =>
+      ["workspacePendingMembers", orgId] as const,
+  },
+
+  campaign: {
+    /** 캠페인 목록 (AdsListPage · useOverviewCampaignList 캐시 공유) */
+    list: (orgId: number | null) => ["campaigns", orgId] as const,
+    /** 캠페인 그룹 상세 */
+    detail: (orgId: number, projectId: number) =>
+      ["campaignDetail", orgId, projectId] as const,
+    /** 플랫폼별 연결 가능한 캠페인 목록 */
+    platformList: (orgId: number | null, platform: string) =>
+      ["platformCampaigns", orgId, platform] as const,
+  },
+
+  overview: {
+    /** 전체 플랫폼 통합 지표 */
+    metrics: (orgId: number | null) => ["overview", "metrics", orgId] as const,
+    /** 전체 플랫폼 ROAS 랭킹 */
+    roasRankings: (orgId: number | null) =>
+      ["overview", "roasRankings", orgId] as const,
+    /** 전체 플랫폼 예산 */
+    budget: (orgId: number | null) => ["overview", "budget", orgId] as const,
+  },
+
+  platform: {
+    /** 플랫폼별 지표 */
+    metrics: (orgId: number | null, provider: string) =>
+      ["platform", "metrics", orgId, provider] as const,
+    /** 플랫폼별 광고 상태 수 */
+    adCount: (orgId: number | null) => ["platform", "adCount", orgId] as const,
+    /** 플랫폼별 성과 목록 */
+    performance: (orgId: number | null) =>
+      ["platform", "performance", orgId] as const,
+    /** 플랫폼별 ROAS 랭킹 */
+    roasRankings: (orgId: number | null) =>
+      ["platform", "roasRankings", orgId] as const,
+    /** 플랫폼별 예산 */
+    budget: (orgId: number | null, provider: string) =>
+      ["platform", "budget", orgId, provider] as const,
+    /** 플랫폼별 일별 지표 상세 */
+    metricFacts: (orgId: number | null, provider: string, days: number) =>
+      ["platform", "metricFacts", orgId, provider, days] as const,
+    /** 플랫폼 연동 연결 상태 목록 */
+    connections: (orgId: number | null) =>
+      ["platform-connections", orgId] as const,
+  },
+
+  ai: {
+    /** AI 분석 리포트 폴링 쿼리 */
+    report: (provider: string, accessToken: string) =>
+      ["ai", "report", provider, accessToken] as const,
+  },
+} as const;

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -69,7 +69,7 @@ export const QUERY_KEYS = {
 
   ai: {
     /** AI 분석 리포트 폴링 쿼리 */
-    report: (provider: string, accessToken: string) =>
-      ["ai", "report", provider, accessToken] as const,
+    report: (provider: string, orgId: number | null) =>
+      ["ai", "report", provider, orgId] as const,
   },
 } as const;

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -13,6 +13,7 @@ import ModalContent from "@/components/common/modal/ModalContent";
 
 import { updateAllCampaignStatus, updateCampaignStatus } from "@/api/ads/ads";
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export default function AdsListPage() {
@@ -30,7 +31,9 @@ export default function AdsListPage() {
   const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
 
   const invalidateCampaigns = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ["campaigns", orgId] });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.campaign.list(orgId),
+    });
   }, [queryClient, orgId]);
 
   const clearSelection = useCallback(() => {

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -27,6 +27,7 @@ import {
   getWorkspaceMembers,
   updateWorkspaceMemberPermission,
 } from "@/api/workspace/org";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 
 const PAGE_SIZE = 20;
 
@@ -45,12 +46,12 @@ export default function MemberManagement() {
     Awaited<ReturnType<typeof getWorkspaceMemberCount>>,
     IApiErrorResponse
   >({
-    queryKey: ["workspaceMemberCount", orgId],
+    queryKey: QUERY_KEYS.workspace.memberCount(orgId),
     queryFn: () => getWorkspaceMemberCount(orgId),
     enabled: Number.isFinite(orgId) && orgId > 0,
   });
   const membersQuery = useInfiniteQuery({
-    queryKey: ["workspaceMembers", orgId, PAGE_SIZE],
+    queryKey: QUERY_KEYS.workspace.membersWithPageSize(orgId, PAGE_SIZE),
     queryFn: ({ pageParam }: { pageParam: string | null }) =>
       getWorkspaceMembers(orgId, pageParam, PAGE_SIZE),
     initialPageParam: null,
@@ -75,7 +76,7 @@ export default function MemberManagement() {
     Awaited<ReturnType<typeof getPendingMember>>,
     IApiErrorResponse
   >({
-    queryKey: ["workspacePendingMembers", orgId],
+    queryKey: QUERY_KEYS.workspace.pendingMembers(orgId),
     queryFn: () => getPendingMember(orgId),
     enabled: Number.isFinite(orgId) && orgId > 0,
   });
@@ -98,7 +99,7 @@ export default function MemberManagement() {
       updateWorkspaceMemberPermission(orgId, memberId, body),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["workspaceMembers", orgId],
+        queryKey: QUERY_KEYS.workspace.members(orgId),
       });
     },
     onError: (error) => {
@@ -110,10 +111,10 @@ export default function MemberManagement() {
     mutationFn: (memberId) => deleteWorkspaceMember(orgId, memberId),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["workspaceMembers", orgId],
+        queryKey: QUERY_KEYS.workspace.members(orgId),
       });
       void queryClient.invalidateQueries({
-        queryKey: ["workspaceMemberCount", orgId],
+        queryKey: QUERY_KEYS.workspace.memberCount(orgId),
       });
     },
     onError: (error) => {

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -25,6 +25,7 @@ import { createWorkspace, getMyWorkspaces } from "@/api/workspace/org";
 import PlusIcon from "@/assets/icon/common/plus.svg?react";
 import SearchIcon from "@/assets/icon/common/search.svg?react";
 import UpLoadImgIcon from "@/assets/icon/common/uploadImg.svg?react";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export default function WorkspacePage() {
@@ -42,7 +43,7 @@ export default function WorkspacePage() {
 
   const queryClient = useQueryClient();
   const workspacesQuery = useQuery<TWorkspace[], IApiErrorResponse>({
-    queryKey: ["my-workspaces"],
+    queryKey: QUERY_KEYS.workspace.list(),
     queryFn: getMyWorkspaces,
   });
 
@@ -54,7 +55,9 @@ export default function WorkspacePage() {
     },
 
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["my-workspaces"] });
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.workspace.list(),
+      });
       setCreateOpen(false);
     },
   });

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -23,6 +23,7 @@ import {
 import BuildingIcon from "@/assets/icon/common/building.svg?react";
 import WarnIcon from "@/assets/icon/common/warn-circle.svg?react";
 import { getImageUrl } from "@/lib/getImageUrl";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 
 export default function WorkspaceSetting() {
   const isAdmin = useIsAdmin();
@@ -101,7 +102,9 @@ export default function WorkspaceSetting() {
         imageFile: logoFile,
         isImageDeleted,
       });
-      await queryClient.invalidateQueries({ queryKey: ["my-workspaces"] });
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.workspace.list(),
+      });
       toast.success("변경사항이 저장되었습니다");
       await fetchWorkspaceDetail();
     } catch (e) {
@@ -124,7 +127,9 @@ export default function WorkspaceSetting() {
     setDeleting(true);
     try {
       await deleteWorkspace(orgId);
-      await queryClient.invalidateQueries({ queryKey: ["my-workspaces"] });
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.workspace.list(),
+      });
       toast.success("워크스페이스가 삭제되었습니다");
       setDeleteOpen(false);
       navigate("/workspace", { replace: true });

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -6,6 +6,7 @@ import type { TMemberRole } from "@/types/workspace/workspace";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getMyWorkspaces } from "@/api/workspace/org";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 interface IRoleGuardProps {
@@ -23,7 +24,7 @@ function RoleGuard({
     data: workspaces,
     isPending,
     isError,
-  } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
+  } = useCoreQuery(QUERY_KEYS.workspace.list(), getMyWorkspaces);
 
   //URL에 workspaceId가 있는 경우 -> URL 기준 워크스페이스의 role로 판정
   if (workspaceId) {


### PR DESCRIPTION
## 🚨 관련 이슈

#238 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- TanStack Query의 queryKey를 QUERY_KEYS 상수 객체로 중앙 관리(`src/lib/queryKeys.ts`)
- 기존 분산되어 있던 queryKey를 QUERY_KEYS 참조로 교체
- 도메인별로 키를 분류하고, 파라미터(orgId 등)를 받아 타입 반환하는 팩토리 함수 형태로 정의

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
- 이전에는 같은 캐시 키를 여러 파일에서 문자열로 직접 쓰다 보니 오타나 불일치 가능성이 있었음. 
    -> 이후 키 변경이 필요하면 queryKeys.ts 한 파일만 수정하면 됩니다!
- 이 PR과 연계하여 추후 아래 작업들이 예정되어 있음
#239 
#240 
#241 


## 📝 작업 정리 및 회고

🔗 [작업 내용 정리 및 회고](https://seojegyeong.tistory.com/6)


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 작업공간, 캠페인, 대시보드(overview/플랫폼), AI 리포트 등 주요 데이터의 캐시 식별 키를 중앙 기준으로 일원화했습니다.
  * 조회/저장/생성/수정/삭제 후 캐시 무효화 범위를 동일한 기준으로 정렬해, 관련 데이터가 함께 갱신되도록 개선했습니다.

* **Impact**
  * 일부 화면에서 최신 정보가 늦게 반영되거나 이전 데이터가 잠시 남는 현상이 줄어들 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->