### PR TITLE
[Refactor/#240] queryClient 싱글턴 import를 useQueryClient() 훅으로 교체

### DIFF
--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -4,6 +4,7 @@ import {
   type QueryKey,
   useMutation,
   useQuery,
+  useQueryClient,
   type UseQueryResult,
 } from "@tanstack/react-query";
 
@@ -12,8 +13,6 @@ import type {
   TUseMutationCustomOptions,
   TUseQueryCustomOptions,
 } from "@/types/common/common";
-
-import { queryClient } from "@/lib/queryClient";
 
 export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
   keyName: QueryKey,
@@ -43,6 +42,8 @@ export function useCoreMutation<
     TCache
   >,
 ) {
+  const queryClient = useQueryClient();
+
   const {
     optimisticUpdate,
     invalidateKeys,

--- a/src/hooks/dashboard/useAiAnalysisReport.ts
+++ b/src/hooks/dashboard/useAiAnalysisReport.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
@@ -15,7 +16,6 @@ import {
   getAiReportByAccessToken,
   requestAiAnalysis,
 } from "@/api/dashboard/aiAnalysis";
-import { queryClient } from "@/lib/queryClient";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
@@ -33,6 +33,7 @@ export type TRequestAiAnalysisParams = Partial<IAnalysisRequest>;
 
 /** AI 요약: POST 요청 → accessToken → GET 폴링 → reportData */
 export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
+  const queryClient = useQueryClient();
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [pollStartedAt, setPollStartedAt] = useState<number | null>(null);


### PR DESCRIPTION
## 🚨 관련 이슈

#240 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 배경

React Query는 앱 최상단에 QueryClientProvider를 두고, 그 안의 모든 컴포넌트와 훅이 같은 queryClient 인스턴스를 공유하는 구조입니다.
그런데 기존 useCoreMutation과 useAiAnalysisReport는 queryClient를 모듈 레벨에서 직접 import하고 있었습니다. 이렇게 되면 QueryClientProvider가 어떤 인스턴스를 주입하든 무관하게 파일에 박제된 싱글턴만 계속 참조합니다.
테스트 환경에서는 보통 실제 앱과 분리된 testClient를 QueryClientProvider에 주입해 사용하는데, 싱글턴을 직접 import한 훅은 이 testClient를 무시하고 원래 싱글턴을 씁니다. 결국 두 인스턴스가 따로 동작하게 되어 testClient를 아무리 조회해도 mutation 결과나 invalidate 동작이 반영되지 않는 문제가 발생합니다.
useQueryClient() 훅으로 교체하면 컨텍스트에서 주입된 인스턴스를 그대로 참조하므로, 테스트 환경에서도 실제 앱과 동일하게 동작합니다.

### `src/hooks/customQuery.ts`
- `useCoreMutation` 내부에서 `import { queryClient } from "@/lib/queryClient"` 제거
- 함수 상단에 `const queryClient = useQueryClient()` 추가
    - `onMutate` / `onError` / `onSuccess` 콜백은 클로저로 동일하게 참조
    - useQueryClient() 훅으로 교체하면 QueryClientProvider에서 주입된 인스턴스를 참조하므로, 테스트 환경에서도 동일하게 동작

### `src/hooks/dashboard/useAiAnalysisReport.ts`
- 훅 내부에서 `import { queryClient } from "@/lib/queryClient"` 제거
- 훅 상단에 `const queryClient = useQueryClient()` 추가
- `removeQueries` (cleanup), `fetchQuery` (mutation 콜백) 모두 클로저로 동일하게 참조

## 변경 이유
싱글턴 직접 import 방식은 React의 `QueryClientProvider` 컨텍스트를 우회합니다.
테스트 환경에서 `<QueryClientProvider client={testClient}>` 로 인스턴스를 주입해도
해당 훅들은 모듈 고정 싱글턴을 계속 참조하기 때문에 queryClient mocking이 불가능합니다.
`useQueryClient()` 훅으로 교체하면 컨텍스트에서 주입된 인스턴스를 참조하므로
테스트 환경에서도 동일하게 동작합니다.

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항

이번 작업은 공통 훅 내부의 싱글턴 접근 방식만 수정한 범위입니다.
`MemberManagement`, `useCampaignGroup`, `Workspace`, `WorkspaceSwitcher` 등 raw `useQuery` / `useMutation`을 직접 사용 중인 파일들은 노션 회의록에 파일별 수정 가이드를 정리해두었으니, 각 담당자분들께서 리팩토링 시 함께 반영해주시면 감사하겠습니다!


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * React Query 클라이언트 사용 방식을 개선하여 더 나은 상태 관리 구조 적용
  * AI 분석 리포트 폴링 동작을 최적화하여 성능 및 안정성 향상
  * 사용자 대면 에러 메시지 표준화로 일관된 오류 안내 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->