### PR TITLE
[Refactor/#241] invalidateQueries 처리 기준 통일 및 retry 전략 세분화

### DIFF
--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -63,7 +63,6 @@ export function WorkspaceSwitcher({
       const workspace = workspaceList.find((w) => w.orgId === orgId);
       setSelectedOrgId(orgId);
       if (workspace) setMyRole(workspace.myRole);
-      setIsOpen(false);
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.workspace.list(),
@@ -72,6 +71,7 @@ export function WorkspaceSwitcher({
           queryKey: QUERY_KEYS.workspace.saved(),
         }),
       ]);
+      setIsOpen(false);
     },
     onError: (error) => {
       console.error("워크스페이스 저장 실패:", error);

--- a/src/hooks/ads/useCampaignGroup.ts
+++ b/src/hooks/ads/useCampaignGroup.ts
@@ -92,7 +92,7 @@ export const useCampaignGroup = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.campaign.list(orgId),
       });
       setIsSuccessModalOpen(true);

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,9 +1,20 @@
 import { QueryClient } from "@tanstack/react-query";
 
+import type { IApiErrorResponse } from "@/types/common/common";
+
+// 4xx: 클라이언트 오류는 재시도해도 결과가 동일하므로 즉시 실패
+// 5xx: 서버 일시 오류는 1회 재시도 허용
+// axiosInstance 인터셉터가 401 재발급을 별도로 처리하므로 중복 재시도 방지
+const retryPolicy = (failureCount: number, error: unknown): boolean => {
+  const status = Number((error as IApiErrorResponse)?.status);
+  if (Number.isFinite(status) && status >= 400 && status < 500) return false;
+  return failureCount < 1;
+};
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 1,
+      retry: retryPolicy,
       staleTime: 1000 * 60 * 5,
       gcTime: 1000 * 60 * 10,
       refetchOnWindowFocus: false,

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -31,7 +31,7 @@ export default function AdsListPage() {
   const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
 
   const invalidateCampaigns = useCallback(() => {
-    queryClient.invalidateQueries({
+    void queryClient.invalidateQueries({
       queryKey: QUERY_KEYS.campaign.list(orgId),
     });
   }, [queryClient, orgId]);

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -109,13 +109,15 @@ export default function MemberManagement() {
 
   const deleteMemberMutation = useMutation<unknown, IApiErrorResponse, number>({
     mutationFn: (memberId) => deleteWorkspaceMember(orgId, memberId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.members(orgId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.memberCount(orgId),
-      });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.workspace.members(orgId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.workspace.memberCount(orgId),
+        }),
+      ]);
     },
     onError: (error) => {
       toast.error(error.message ?? "멤버 삭제에 실패했습니다.");

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -54,8 +54,8 @@ export default function WorkspacePage() {
       return createWorkspace({ name, description, imageFile: logoFile });
     },
 
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.workspace.list(),
       });
       setCreateOpen(false);


### PR DESCRIPTION
## 🚨 관련 이슈

#241 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

1. retry 전략 세분화 (`src/lib/queryClient.ts`)
      - 기존 `retry: 1`은 4xx 에러에서도 재시도를 유발해, axiosInstance 인터셉터의 401 재발급 재시도와 중복 발생
      -  4xx: 즉시 실패 (클라이언트 오류는 재시도해도 결과 동일)
      - 5xx: 1회 재시도 허용 (서버 일시 오류 대응)

2. `invalidateQueries` 사용 기준 통일
      - `WorkspaceSwitcher`: `await` 순서 교정 — `setIsOpen(false)`를 `await Promise.all` 뒤로 이동
      - `Workspace`: `void` → `await` — 워크스페이스 생성 후 `setCreateOpen(false)` 이전 캐시 갱신 보장
      - `MemberManagement`: 멤버 삭제 `onSuccess` `void` → `await` — 삭제 후 `setIsDeleteModalOpen(false)` 이전 캐시 갱신 보장
      - `useCampaignGroup`, `AdsListPage`: 묵시 버림 → `void` 명시

## 😅 미완성 작업
N/A


## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 네트워크 재시도 정책을 개선하여 서버 오류에만 재시도하고 클라이언트 오류는 즉시 실패 처리하도록 조정
  * 작업공간 및 캠페인 관리 작업 완료 시 데이터 동기화를 더욱 안정적으로 처리

* **개선 사항**
  * UI 업데이트가 서버 데이터 동기화 완료 후 진행되어 데이터 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->