### PR TITLE
[Feature/#265] 타임라인 페이지 레이아웃 조립 및 디자인 수정 및 UI 구현

### DIFF
--- a/src/assets/icon/common/plus.svg
+++ b/src/assets/icon/common/plus.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 24 24" width="24px" height="24px" fill-rule="evenodd"><path fill-rule="evenodd" d="M 11 2 L 11 11 L 2 11 L 2 13 L 11 13 L 11 22 L 13 22 L 13 13 L 22 13 L 22 11 L 13 11 L 13 2 Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 24 24" width="24px" height="24px" fill-rule="evenodd"><path fill="currentColor" fill-rule="evenodd" d="M 11 2 L 11 11 L 2 11 L 2 13 L 11 13 L 11 22 L 13 22 L 13 13 L 22 13 L 22 11 L 13 11 L 13 2 Z"/></svg>

--- a/src/components/common/dropdownmenu/DropdownMenu.tsx
+++ b/src/components/common/dropdownmenu/DropdownMenu.tsx
@@ -1,6 +1,14 @@
-import React, { useEffect, useId, useRef, useState } from "react";
+import React, {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { twMerge } from "tailwind-merge";
+
+export type TDropdownPlacement = "bottom" | "top" | "auto";
 
 export type TMenuItem = {
   label: string;
@@ -14,12 +22,61 @@ export type TMenuItem = {
 const easeOut = [0, 0, 0.2, 1] as const;
 const easeIn = [0.4, 0, 1, 1] as const;
 
+const MENU_ITEM_HEIGHT = 52;
+const MENU_VERTICAL_PADDING = 32;
+
+function getClippingBounds(element: HTMLElement) {
+  let bottom = window.innerHeight;
+  let top = 0;
+  let parent = element.parentElement;
+
+  while (parent) {
+    const { overflow, overflowY, overflowX } = getComputedStyle(parent);
+    const clips =
+      overflow === "hidden" ||
+      overflowY === "hidden" ||
+      overflowY === "auto" ||
+      overflowY === "scroll" ||
+      overflowX === "hidden" ||
+      overflowX === "auto" ||
+      overflowX === "scroll";
+
+    if (clips) {
+      const rect = parent.getBoundingClientRect();
+      bottom = Math.min(bottom, rect.bottom);
+      top = Math.max(top, rect.top);
+    }
+
+    parent = parent.parentElement;
+  }
+
+  return { top, bottom };
+}
+
+function resolveAutoPlacement(
+  element: HTMLElement,
+  itemCount: number,
+): "bottom" | "top" {
+  const triggerRect = element.getBoundingClientRect();
+  const { top: containerTop, bottom: containerBottom } =
+    getClippingBounds(element);
+  const estimatedMenuHeight =
+    itemCount * MENU_ITEM_HEIGHT + MENU_VERTICAL_PADDING;
+  const spaceBelow = containerBottom - triggerRect.bottom;
+  const spaceAbove = triggerRect.top - containerTop;
+
+  return spaceBelow < estimatedMenuHeight && spaceAbove > spaceBelow
+    ? "top"
+    : "bottom";
+}
+
 export function DropdownMenu({
   trigger,
   items,
   className,
   menuClassName,
   fullWidth = false,
+  placement = "bottom",
   "aria-label": ariaLabel,
 }: {
   trigger: React.ReactNode | ((open: boolean) => React.ReactNode);
@@ -28,10 +85,15 @@ export function DropdownMenu({
   menuClassName?: string;
   /** 트리거와 동일 너비로 패널을 펼침 (폼 필드용) */
   fullWidth?: boolean;
+  /** bottom: 아래 / top: 위 / auto: 공간에 따라 자동 */
+  placement?: TDropdownPlacement;
   "aria-label"?: string;
 }) {
   const reduceMotion = useReducedMotion();
   const [open, setOpen] = useState(false);
+  const [resolvedPlacement, setResolvedPlacement] = useState<"bottom" | "top">(
+    "bottom",
+  );
   const ref = useRef<HTMLDivElement | null>(null);
   const menuId = useId();
 
@@ -48,6 +110,27 @@ export function DropdownMenu({
       document.removeEventListener("mousedown", onDocClick);
     };
   }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    if (placement === "bottom") {
+      setResolvedPlacement("bottom");
+      return;
+    }
+
+    if (placement === "top") {
+      setResolvedPlacement("top");
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    setResolvedPlacement(resolveAutoPlacement(el, items.length));
+  }, [open, placement, items.length]);
+
+  const isTopPlacement = resolvedPlacement === "top";
 
   return (
     <div
@@ -81,13 +164,20 @@ export function DropdownMenu({
             id={menuId}
             role="menu"
             style={{
-              transformOrigin: fullWidth ? "top center" : "top right",
+              transformOrigin: fullWidth
+                ? isTopPlacement
+                  ? "bottom center"
+                  : "top center"
+                : isTopPlacement
+                  ? "bottom right"
+                  : "top right",
             }}
             className={twMerge(
-              "absolute z-50 mt-2 rounded-2xl border border-surface-300 bg-surface-100 py-3 px-1 shadow-Soft",
+              "absolute z-50 rounded-2xl border border-surface-300 bg-surface-100 py-3 px-1 shadow-Soft",
               fullWidth
-                ? "left-0 right-0 top-full w-full"
-                : "right-0 top-full w-56 max-w-[calc(100vw-40px)]",
+                ? "left-0 right-0 w-full"
+                : "right-0 w-56 max-w-[calc(100vw-40px)]",
+              isTopPlacement ? "bottom-full mb-2" : "top-full mt-2",
               menuClassName,
             )}
             initial={{ opacity: 0, scale: reduceMotion ? 1 : 0.96 }}

--- a/src/components/common/dropdownmenu/DropdownMenu.tsx
+++ b/src/components/common/dropdownmenu/DropdownMenu.tsx
@@ -78,6 +78,7 @@ export function DropdownMenu({
   fullWidth = false,
   placement = "bottom",
   "aria-label": ariaLabel,
+  onOpenChange,
 }: {
   trigger: React.ReactNode | ((open: boolean) => React.ReactNode);
   items: TMenuItem[];
@@ -88,6 +89,7 @@ export function DropdownMenu({
   /** bottom: 아래 / top: 위 / auto: 공간에 따라 자동 */
   placement?: TDropdownPlacement;
   "aria-label"?: string;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const reduceMotion = useReducedMotion();
   const [open, setOpen] = useState(false);
@@ -129,6 +131,10 @@ export function DropdownMenu({
 
     setResolvedPlacement(resolveAutoPlacement(el, items.length));
   }, [open, placement, items.length]);
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [open, onOpenChange]);
 
   const isTopPlacement = resolvedPlacement === "top";
 

--- a/src/components/timeline/TimelineAxis.tsx
+++ b/src/components/timeline/TimelineAxis.tsx
@@ -3,6 +3,7 @@ import { twMerge } from "tailwind-merge";
 import type { ITimelineGridColumn } from "@/types/timeline/ui";
 import {
   TIMELINE_AXIS_HEIGHT,
+  TIMELINE_AXIS_Z_INDEX,
   TIMELINE_COL_WIDTH,
 } from "@/constants/timeline/layout";
 
@@ -20,10 +21,10 @@ export default function TimelineAxis({
   return (
     <div
       className={twMerge(
-        "relative z-20 flex shrink-0 border-b border-surface-400/80 bg-surface-100",
+        "relative flex shrink-0 border-b border-surface-400/80 bg-surface-100",
         className,
       )}
-      style={{ height: TIMELINE_AXIS_HEIGHT }}
+      style={{ height: TIMELINE_AXIS_HEIGHT, zIndex: TIMELINE_AXIS_Z_INDEX }}
     >
       {columns.map((column, index) => (
         <div

--- a/src/components/timeline/TimelineAxis.tsx
+++ b/src/components/timeline/TimelineAxis.tsx
@@ -20,7 +20,7 @@ export default function TimelineAxis({
   return (
     <div
       className={twMerge(
-        "relative z-10 flex shrink-0 border-b border-surface-400/80 bg-surface-100",
+        "relative z-20 flex shrink-0 border-b border-surface-400/80 bg-surface-100",
         className,
       )}
       style={{ height: TIMELINE_AXIS_HEIGHT }}

--- a/src/components/timeline/TimelineBar.tsx
+++ b/src/components/timeline/TimelineBar.tsx
@@ -5,6 +5,7 @@ import type { ITimelineCampaignBar } from "@/types/timeline/ui";
 import { PLATFORM_CIRCLE_LOGO_MAP } from "@/constants/dashboard/platformLogos";
 import {
   TIMELINE_BAR_HEIGHT,
+  TIMELINE_BAR_Z_INDEX,
   TIMELINE_COL_WIDTH,
   TIMELINE_ROW_HEIGHT,
   TIMELINE_ROW_OFFSET,
@@ -52,18 +53,30 @@ export default function TimelineBar({
 
   return (
     <div
+      role="button"
+      tabIndex={0}
       className={twMerge(
-        "group/bar absolute z-20 flex cursor-pointer items-start gap-2 rounded-xl px-3 py-2.5 transition-shadow hover:z-30 hover:shadow-Soft",
+        "group/bar absolute flex cursor-pointer items-start gap-2 rounded-xl px-3 py-2.5 transition-shadow hover:shadow-Soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/40",
         status.barBg,
         isSelected &&
-          twMerge(
-            "z-30 ring-2 ring-offset-1 ring-offset-surface-200",
-            status.ring,
-          ),
+          twMerge("ring-2 ring-offset-1 ring-offset-surface-200", status.ring),
         className,
       )}
       onClick={() => onBarClick?.(bar)}
-      style={{ left, top, width, height: TIMELINE_BAR_HEIGHT }}
+      onKeyDown={(event) => {
+        if (event.currentTarget !== event.target) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onBarClick?.(bar);
+        }
+      }}
+      style={{
+        left,
+        top,
+        width,
+        height: TIMELINE_BAR_HEIGHT,
+        zIndex: TIMELINE_BAR_Z_INDEX,
+      }}
     >
       <div
         className={twMerge(

--- a/src/components/timeline/TimelineBar.tsx
+++ b/src/components/timeline/TimelineBar.tsx
@@ -9,6 +9,8 @@ import {
 } from "@/constants/timeline/layout";
 import { TIMELINE_PERFORMANCE_STATUS_STYLE } from "@/constants/timeline/statusStyle";
 
+import { DropdownMenu } from "../common/dropdownmenu/DropdownMenu";
+
 import KebabIcon from "@/assets/icon/timeline/kebab.svg?react";
 
 interface ITimelineBarProps {
@@ -18,7 +20,8 @@ interface ITimelineBarProps {
   rowOffset?: number;
   className?: string;
   onBarClick?: (bar: ITimelineCampaignBar) => void;
-  onMenuClick?: (bar: ITimelineCampaignBar) => void; //선택, 추후 이슈로 다룰 예정
+  onEdit?: (bar: ITimelineCampaignBar) => void;
+  onDelete?: (bar: ITimelineCampaignBar) => void;
 }
 
 export default function TimelineBar({
@@ -28,7 +31,8 @@ export default function TimelineBar({
   rowOffset = TIMELINE_ROW_OFFSET,
   className,
   onBarClick,
-  onMenuClick,
+  onEdit,
+  onDelete,
 }: ITimelineBarProps) {
   const status = TIMELINE_PERFORMANCE_STATUS_STYLE[bar.performanceStatus];
   const left = (bar.colStart - 1) * colWidth;
@@ -65,17 +69,28 @@ export default function TimelineBar({
         </span>
       </div>
       <div className="ml-auto flex shrink-0 self-center items-center">
-        <button
-          type="button"
+        <DropdownMenu
           aria-label="캠페인 메뉴"
-          className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-text-placeholder transition-colors hover:bg-surface-500/5"
-          onClick={(event) => {
-            event.stopPropagation();
-            onMenuClick?.(bar);
-          }}
-        >
-          <KebabIcon className="h-3.5 w-3.5" />
-        </button>
+          trigger={
+            <button
+              type="button"
+              aria-label="캠페인 메뉴"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-text-placeholder transition-colors hover:bg-surface-500/5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <KebabIcon className="h-4 w-4" />
+            </button>
+          }
+          items={[
+            { label: "수정하기", onClick: () => onEdit?.(bar) },
+            {
+              label: "삭제하기",
+              danger: true,
+              labelClassName: "text-info-red",
+              onClick: () => onDelete?.(bar),
+            },
+          ]}
+        />
       </div>
     </div>
   );

--- a/src/components/timeline/TimelineBar.tsx
+++ b/src/components/timeline/TimelineBar.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 import { PLATFORM_MAP, PROVIDER_TYPES } from "@/types/dashboard/provider";
 import type { ITimelineCampaignBar } from "@/types/timeline/ui";
 import { PLATFORM_CIRCLE_LOGO_MAP } from "@/constants/dashboard/platformLogos";
 import {
+  TIMELINE_BAR_ELEVATED_Z_INDEX,
   TIMELINE_BAR_HEIGHT,
   TIMELINE_BAR_Z_INDEX,
   TIMELINE_COL_WIDTH,
@@ -39,6 +41,7 @@ export default function TimelineBar({
   onEdit,
   onDelete,
 }: ITimelineBarProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const status = TIMELINE_PERFORMANCE_STATUS_STYLE[bar.performanceStatus];
   const left = (bar.colStart - 1) * colWidth;
   const columnSpan = Math.max(bar.colEnd - bar.colStart, 1);
@@ -51,6 +54,8 @@ export default function TimelineBar({
   const providers = PROVIDER_TYPES.filter((provider) =>
     bar.providers?.includes(provider),
   );
+
+  const isElevated = isMenuOpen || isSelected;
 
   return (
     <div
@@ -76,7 +81,9 @@ export default function TimelineBar({
         top,
         width,
         height: TIMELINE_BAR_HEIGHT,
-        zIndex: TIMELINE_BAR_Z_INDEX,
+        zIndex: isElevated
+          ? TIMELINE_BAR_ELEVATED_Z_INDEX
+          : TIMELINE_BAR_Z_INDEX,
       }}
     >
       <div
@@ -127,6 +134,7 @@ export default function TimelineBar({
         <DropdownMenu
           aria-label="캠페인 메뉴"
           placement="auto"
+          onOpenChange={setIsMenuOpen}
           menuClassName="w-40 py-2 [&_[role=menuitem]]:px-4 [&_[role=menuitem]]:py-3"
           trigger={
             <button

--- a/src/components/timeline/TimelineBar.tsx
+++ b/src/components/timeline/TimelineBar.tsx
@@ -68,15 +68,19 @@ export default function TimelineBar({
           {status.label}
         </span>
       </div>
-      <div className="ml-auto flex shrink-0 self-center items-center">
+      <div
+        className="ml-auto flex shrink-0 self-center items-center"
+        onClick={(e) => e.stopPropagation()}
+      >
         <DropdownMenu
           aria-label="캠페인 메뉴"
+          placement="auto"
+          menuClassName="w-40 py-2 [&_[role=menuitem]]:px-4 [&_[role=menuitem]]:py-3"
           trigger={
             <button
               type="button"
               aria-label="캠페인 메뉴"
-              className="flex h-7 w-7 items-center justify-center rounded-md text-text-placeholder transition-colors hover:bg-surface-500/5"
-              onClick={(e) => e.stopPropagation()}
+              className="flex h-10 w-7 items-center justify-center rounded-md text-text-placeholder transition-colors hover:bg-surface-500/5"
             >
               <KebabIcon className="h-4 w-4" />
             </button>

--- a/src/components/timeline/TimelineBar.tsx
+++ b/src/components/timeline/TimelineBar.tsx
@@ -1,6 +1,8 @@
 import { twMerge } from "tailwind-merge";
 
+import { PLATFORM_MAP, PROVIDER_TYPES } from "@/types/dashboard/provider";
 import type { ITimelineCampaignBar } from "@/types/timeline/ui";
+import { PLATFORM_CIRCLE_LOGO_MAP } from "@/constants/dashboard/platformLogos";
 import {
   TIMELINE_BAR_HEIGHT,
   TIMELINE_COL_WIDTH,
@@ -18,6 +20,7 @@ interface ITimelineBarProps {
   colWidth?: number;
   rowHeight?: number;
   rowOffset?: number;
+  isSelected?: boolean;
   className?: string;
   onBarClick?: (bar: ITimelineCampaignBar) => void;
   onEdit?: (bar: ITimelineCampaignBar) => void;
@@ -29,6 +32,7 @@ export default function TimelineBar({
   colWidth = TIMELINE_COL_WIDTH,
   rowHeight = TIMELINE_ROW_HEIGHT,
   rowOffset = TIMELINE_ROW_OFFSET,
+  isSelected = false,
   className,
   onBarClick,
   onEdit,
@@ -41,12 +45,21 @@ export default function TimelineBar({
     rowOffset +
     (bar.row - 1) * rowHeight +
     (rowHeight - TIMELINE_BAR_HEIGHT) / 2;
+
+  const providers = PROVIDER_TYPES.filter((provider) =>
+    bar.providers?.includes(provider),
+  );
+
   return (
-    /*카드 클릭하면 성과요약 패널 나오도록 핸들러 구현 예정 */
     <div
       className={twMerge(
-        "absolute z-20 flex cursor-pointer items-start gap-2.5 rounded-xl px-3 py-2.5 transition-shadow hover:z-30 hover:shadow-Soft",
+        "group/bar absolute z-20 flex cursor-pointer items-start gap-2 rounded-xl px-3 py-2.5 transition-shadow hover:z-30 hover:shadow-Soft",
         status.barBg,
+        isSelected &&
+          twMerge(
+            "z-30 ring-2 ring-offset-1 ring-offset-surface-200",
+            status.ring,
+          ),
         className,
       )}
       onClick={() => onBarClick?.(bar)}
@@ -59,7 +72,28 @@ export default function TimelineBar({
         )}
       />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate font-body2 text-text-title">{bar.title}</span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {providers.length > 0 ? (
+            <div
+              className="flex shrink-0 items-center -space-x-1"
+              aria-label={providers.map((p) => PLATFORM_MAP[p]).join(", ")}
+            >
+              {providers.map((provider) => {
+                const Logo = PLATFORM_CIRCLE_LOGO_MAP[provider];
+                return (
+                  <Logo
+                    key={provider}
+                    className="h-4 w-4 rounded-full ring-2 ring-surface-100"
+                    aria-hidden
+                  />
+                );
+              })}
+            </div>
+          ) : null}
+          <span className="truncate font-body2 text-text-title">
+            {bar.title}
+          </span>
+        </div>
         <span className="truncate font-caption text-text-muted">
           {bar.subtitle}
         </span>
@@ -69,7 +103,11 @@ export default function TimelineBar({
         </span>
       </div>
       <div
-        className="ml-auto flex shrink-0 self-center items-center"
+        className={twMerge(
+          "ml-auto flex shrink-0 self-center items-center opacity-0 transition-opacity",
+          "group-hover/bar:opacity-100 group-focus-within/bar:opacity-100",
+          isSelected && "opacity-100",
+        )}
         onClick={(e) => e.stopPropagation()}
       >
         <DropdownMenu
@@ -80,7 +118,7 @@ export default function TimelineBar({
             <button
               type="button"
               aria-label="캠페인 메뉴"
-              className="flex h-10 w-7 items-center justify-center rounded-md text-text-placeholder transition-colors hover:bg-surface-500/5"
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-text-placeholder transition-colors hover:bg-surface-500/10"
             >
               <KebabIcon className="h-4 w-4" />
             </button>

--- a/src/components/timeline/TimelineCreateModal.tsx
+++ b/src/components/timeline/TimelineCreateModal.tsx
@@ -86,12 +86,13 @@ export default function TimelineCreateModal({
         label: option.label,
         active: option.value === comparisonPeriodType,
         onClick: () => {
+          if (isSubmitting) return;
           setValue("comparisonPeriodType", option.value, {
             shouldValidate: true,
           });
         },
       })),
-    [comparisonPeriodType, setValue],
+    [comparisonPeriodType, isSubmitting, setValue],
   );
 
   useEffect(() => {

--- a/src/components/timeline/TimelineEmptyState.tsx
+++ b/src/components/timeline/TimelineEmptyState.tsx
@@ -1,0 +1,30 @@
+import Button from "@/components/common/button/Button";
+
+import PlusIcon from "@/assets/icon/common/plus.svg?react";
+
+interface ITimelineEmptyStateProps {
+  onCreate: () => void;
+}
+
+export default function TimelineEmptyState({
+  onCreate,
+}: ITimelineEmptyStateProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 px-6 py-16 text-center">
+      <p className="font-heading4 text-text-title">아직 타임라인이 없어요</p>
+      <p className="max-w-sm font-body2 text-text-muted">
+        타임라인 생성으로 첫 기간을 만들어보세요
+      </p>
+      <Button
+        type="button"
+        size="small"
+        variant="primary"
+        onClick={onCreate}
+        leftIcon={<PlusIcon className="h-4 w-4 shrink-0" aria-hidden />}
+        className="mt-1 rounded-2xl px-5"
+      >
+        타임라인 생성
+      </Button>
+    </div>
+  );
+}

--- a/src/components/timeline/TimelineGrid.tsx
+++ b/src/components/timeline/TimelineGrid.tsx
@@ -36,7 +36,7 @@ export default function TimelineGrid({
           <div
             key={`col-${column.isoDate ?? i}`}
             className={twMerge(
-              "absolute top-0 bottom-0 border-r border-surface-400/80",
+              "absolute top-0 bottom-0 border-r border-surface-400/40",
               column.isToday && "bg-primary-400/8",
             )}
             style={{ left: i * colWidth, width: colWidth }}

--- a/src/components/timeline/TimelineGrid.tsx
+++ b/src/components/timeline/TimelineGrid.tsx
@@ -30,13 +30,21 @@ export default function TimelineGrid({
   const bodyHeight = rowOffset + rowCount * rowHeight;
 
   return (
-    <div className={twMerge("relative flex-1 bg-surface-200", className)}>
-      <div className="relative h-full" style={{ minHeight: bodyHeight }}>
+    <div
+      className={twMerge(
+        "relative flex min-h-0 flex-1 flex-col bg-surface-200",
+        className,
+      )}
+    >
+      <div
+        className="relative min-h-0 flex-1"
+        style={{ minHeight: `max(${bodyHeight}px, 100%)` }}
+      >
         {columns.map((column, i) => (
           <div
             key={`col-${column.isoDate ?? i}`}
             className={twMerge(
-              "absolute top-0 bottom-0 border-r border-surface-400/40",
+              "absolute inset-y-0 border-r border-surface-400/40",
               column.isToday && "bg-primary-400/8",
             )}
             style={{ left: i * colWidth, width: colWidth }}

--- a/src/components/timeline/TimelinePeriodSelector.tsx
+++ b/src/components/timeline/TimelinePeriodSelector.tsx
@@ -1,12 +1,114 @@
-import { useEffect, useId, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 import type { TTimelineViewUnit } from "@/types/timeline/ui";
 import { TIMELINE_VIEW_UNIT_OPTIONS } from "@/constants/timeline/viewUnit";
 
 import ChevronLeftIcon from "@/assets/icon/chevron/chervon-left.svg?react";
-import ChevronDownIcon from "@/assets/icon/chevron/chevron-down.svg?react";
 import ChevronRightIcon from "@/assets/icon/chevron/chevron-right.svg?react";
+
+interface ITimelineViewUnitSegmentProps {
+  viewUnit: TTimelineViewUnit;
+  onViewUnitChange: (unit: TTimelineViewUnit) => void;
+  className?: string;
+}
+
+export function TimelineViewUnitSegment({
+  viewUnit,
+  onViewUnitChange,
+  className,
+}: ITimelineViewUnitSegmentProps) {
+  return (
+    <div
+      role="group"
+      aria-label="보기 단위"
+      className={twMerge(
+        "flex items-center rounded-lg border border-surface-400/70 bg-surface-100 p-0.5",
+        className,
+      )}
+    >
+      {TIMELINE_VIEW_UNIT_OPTIONS.map((option) => {
+        const isSelected = viewUnit === option.value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={isSelected}
+            onClick={() => onViewUnitChange(option.value)}
+            className={twMerge(
+              "rounded-md px-3 py-1.5 font-caption transition-ui-smooth",
+              isSelected
+                ? "bg-surface-100 text-text-title shadow-Soft"
+                : "text-text-muted hover:text-text-body",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ITimelinePeriodNavProps {
+  periodLabel: string;
+  onPrevPeriod: () => void;
+  onNextPeriod: () => void;
+  onGoToToday?: () => void;
+  className?: string;
+}
+
+export function TimelinePeriodNav({
+  periodLabel,
+  onPrevPeriod,
+  onNextPeriod,
+  onGoToToday,
+  className,
+}: ITimelinePeriodNavProps) {
+  return (
+    <div
+      className={twMerge(
+        "flex items-center gap-3 font-body2 text-text-title",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-label="이전 기간"
+        onClick={onPrevPeriod}
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-muted transition-ui-smooth hover:bg-surface-200 hover:text-text-title"
+      >
+        <ChevronLeftIcon className="h-3.5 w-3.5" />
+      </button>
+
+      <span aria-live="polite" className="min-w-40 truncate text-center">
+        {periodLabel}
+      </span>
+
+      <button
+        type="button"
+        aria-label="다음 기간"
+        onClick={onNextPeriod}
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-muted transition-ui-smooth hover:bg-surface-200 hover:text-text-title"
+      >
+        <ChevronRightIcon className="h-3.5 w-3.5" />
+      </button>
+
+      {onGoToToday ? (
+        <button
+          type="button"
+          onClick={onGoToToday}
+          className={twMerge(
+            "ml-1 rounded-lg px-3 py-1.5 font-caption text-text-muted",
+            "transition-ui-smooth hover:bg-surface-200 hover:text-text-title",
+          )}
+        >
+          오늘
+        </button>
+      ) : null}
+    </div>
+  );
+}
 
 interface ITimelinePeriodSelectorProps {
   viewUnit: TTimelineViewUnit;
@@ -14,6 +116,7 @@ interface ITimelinePeriodSelectorProps {
   onViewUnitChange: (unit: TTimelineViewUnit) => void;
   onPrevPeriod: () => void;
   onNextPeriod: () => void;
+  onGoToToday?: () => void;
   className?: string;
 }
 
@@ -23,105 +126,21 @@ export default function TimelinePeriodSelector({
   onViewUnitChange,
   onPrevPeriod,
   onNextPeriod,
+  onGoToToday,
   className,
 }: ITimelinePeriodSelectorProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const menuId = useId();
-
-  const selectedLabel =
-    TIMELINE_VIEW_UNIT_OPTIONS.find((option) => option.value === viewUnit)
-      ?.label ?? "주";
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  const handleSelectViewUnit = (unit: TTimelineViewUnit) => {
-    onViewUnitChange(unit);
-    setIsOpen(false);
-  };
-
   return (
-    <div className={twMerge("flex items-center gap-4 justify-end", className)}>
-      {/* 기간 이동 */}
-      <div className="flex items-center gap-3 font-body2 text-text-title">
-        <button
-          type="button"
-          aria-label="이전 기간"
-          onClick={onPrevPeriod}
-          className="transition-colors hover:text-text-muted"
-        >
-          <ChevronLeftIcon className="h-3.5 w-3.5" />
-        </button>
-        <span aria-live="polite">{periodLabel}</span>
-        <button type="button" aria-label="다음 기간" onClick={onNextPeriod}>
-          <ChevronRightIcon className="h-3.5 w-3.5" />
-        </button>
-      </div>
-      <div ref={containerRef} className="relative">
-        <button
-          type="button"
-          aria-haspopup="menu"
-          aria-expanded={isOpen}
-          aria-controls={menuId}
-          aria-label="보기 단위 선택"
-          onClick={() => setIsOpen((prev) => !prev)}
-          className="flex items-center gap-1  px-3 py-2 font-body2 text-text-title transition-colors hover:bg-surface-200/50"
-        >
-          <span>{selectedLabel}</span>
-          <ChevronDownIcon
-            className={twMerge(
-              "h-4 w-4 text-text-muted transition-transform",
-              isOpen && "rotate-180",
-            )}
-          />
-        </button>
-        {isOpen ? (
-          <div
-            id={menuId}
-            role="menu"
-            aria-label="보기 단위"
-            className="absolute right-0 top-full z-50 mt-2 w-30 rounded-2xl border border-surface-300 bg-surface-100 py-3 shadow-Soft"
-          >
-            <p className="px-4 pb-2 font-caption text-text-muted">시간</p>
-            <div
-              role="group"
-              aria-label="보기 단위 옵션"
-              className="space-y-1 px-1"
-            >
-              {TIMELINE_VIEW_UNIT_OPTIONS.map((option) => {
-                const isSelected = viewUnit == option.value;
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    role="menuitem"
-                    onClick={() => handleSelectViewUnit(option.value)}
-                    className={twMerge(
-                      "flex w-full rounded-xl px-4 py-2.5 text-left font-body2 transition-colors",
-                      isSelected
-                        ? "bg-info-blue/10 text-info-blue"
-                        : "text-text-body hover:bg-primary-100/80 hover:text-info-blue",
-                    )}
-                  >
-                    {option.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ) : null}
-      </div>
+    <div className={twMerge("flex flex-wrap items-center gap-4", className)}>
+      <TimelineViewUnitSegment
+        viewUnit={viewUnit}
+        onViewUnitChange={onViewUnitChange}
+      />
+      <TimelinePeriodNav
+        periodLabel={periodLabel}
+        onPrevPeriod={onPrevPeriod}
+        onNextPeriod={onNextPeriod}
+        onGoToToday={onGoToToday}
+      />
     </div>
   );
 }

--- a/src/components/timeline/TimelineStatusLegend.tsx
+++ b/src/components/timeline/TimelineStatusLegend.tsx
@@ -1,0 +1,78 @@
+import { useId } from "react";
+import { twMerge } from "tailwind-merge";
+
+import {
+  TIMELINE_PERFORMANCE_STATUS_STYLE,
+  TIMELINE_STATUS_BASELINE_HELP,
+  TIMELINE_STATUS_LEGEND_ORDER,
+} from "@/constants/timeline/statusStyle";
+
+interface ITimelineStatusLegendProps {
+  className?: string;
+}
+
+export default function TimelineStatusLegend({
+  className,
+}: ITimelineStatusLegendProps) {
+  const helpId = useId();
+
+  return (
+    <div
+      className={twMerge(
+        "flex w-fit max-w-full flex-wrap items-center justify-between gap-4 rounded-2xl bg-surface-200 px-5 py-3",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-12 gap-y-2">
+        {TIMELINE_STATUS_LEGEND_ORDER.map((status) => {
+          const style = TIMELINE_PERFORMANCE_STATUS_STYLE[status];
+
+          return (
+            <div
+              key={status}
+              className="flex min-w-0 items-center gap-2 font-body2"
+            >
+              <span
+                className={twMerge("h-2 w-2 shrink-0 rounded-full", style.dot)}
+                aria-hidden
+              />
+              <span className="shrink-0 text-text-title">{style.label}</span>
+              <span className="text-text-placeholder" aria-hidden>
+                :
+              </span>
+              <span className="text-text-muted">{style.legendDescription}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="group/help relative shrink-0">
+        <button
+          type="button"
+          aria-describedby={helpId}
+          className={twMerge(
+            "flex h-6 w-6 items-center justify-center rounded-full",
+            "border border-surface-400/70 font-caption text-text-muted",
+            "transition-ui-smooth hover:bg-surface-300 hover:text-text-body",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/40",
+          )}
+        >
+          ?
+        </button>
+
+        <div
+          id={helpId}
+          role="tooltip"
+          className={twMerge(
+            "pointer-events-none absolute right-0 top-full z-50 mt-2 w-72",
+            "rounded-2xl border border-surface-300 bg-surface-100 px-4 py-3 shadow-Soft",
+            "font-body2 text-text-body opacity-0 transition-opacity duration-200",
+            "group-hover/help:opacity-100 group-focus-within/help:opacity-100",
+          )}
+        >
+          {TIMELINE_STATUS_BASELINE_HELP}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/timeline/layout.ts
+++ b/src/constants/timeline/layout.ts
@@ -5,3 +5,6 @@ export const TIMELINE_ROW_HEIGHT = 104;
 export const TIMELINE_ROW_OFFSET = 24;
 export const TIMELINE_AXIS_HEIGHT = 56;
 export const TIMELINE_BAR_HEIGHT = 80;
+
+/*페이지 섹션 높이 — MainLayout 헤더(h-14) + 본문 py-6 제외*/
+export const TIMELINE_PAGE_HEIGHT = "calc(100dvh - 6.5rem)";

--- a/src/constants/timeline/layout.ts
+++ b/src/constants/timeline/layout.ts
@@ -5,6 +5,7 @@ export const TIMELINE_ROW_HEIGHT = 104;
 export const TIMELINE_ROW_OFFSET = 24;
 export const TIMELINE_AXIS_HEIGHT = 56;
 export const TIMELINE_BAR_HEIGHT = 80;
+export const TIMELINE_AXIS_Z_INDEX = 30;
+export const TIMELINE_BAR_Z_INDEX = 10;
 
-/*페이지 섹션 높이 — MainLayout 헤더(h-14) + 본문 py-6 제외*/
 export const TIMELINE_PAGE_HEIGHT = "calc(100dvh - 6.5rem)";

--- a/src/constants/timeline/layout.ts
+++ b/src/constants/timeline/layout.ts
@@ -7,5 +7,6 @@ export const TIMELINE_AXIS_HEIGHT = 56;
 export const TIMELINE_BAR_HEIGHT = 80;
 export const TIMELINE_AXIS_Z_INDEX = 30;
 export const TIMELINE_BAR_Z_INDEX = 10;
+export const TIMELINE_BAR_ELEVATED_Z_INDEX = 20;
 
 export const TIMELINE_PAGE_HEIGHT = "calc(100dvh - 6.5rem)";

--- a/src/constants/timeline/layout.ts
+++ b/src/constants/timeline/layout.ts
@@ -1,6 +1,6 @@
 /*하드코딩 숫자 모아두기*/
 
-export const TIMELINE_COL_WIDTH = 72;
+export const TIMELINE_COL_WIDTH = 92;
 export const TIMELINE_ROW_HEIGHT = 104;
 export const TIMELINE_ROW_OFFSET = 24;
 export const TIMELINE_AXIS_HEIGHT = 56;

--- a/src/constants/timeline/statusStyle.ts
+++ b/src/constants/timeline/statusStyle.ts
@@ -3,10 +3,21 @@ import type { TTimelinePerformanceStatus } from "@/types/timeline/api";
 export interface ITimelinePerformanceStatusStyle {
   label: string;
   description: string;
+  legendDescription: string;
   barBg: string;
   accent: string;
   dot: string;
+  ring: string;
 }
+
+export const TIMELINE_STATUS_LEGEND_ORDER = [
+  "ON_TRACK",
+  "ABOVE_AVERAGE",
+  "AT_RISK",
+] as const satisfies readonly TTimelinePerformanceStatus[];
+
+export const TIMELINE_STATUS_BASELINE_HELP =
+  "성과 상태는 타임라인에 설정한 비교 기간의 평균 성과를 기준으로, 현재 기간 성과가 어느 수준인지 보여줍니다.";
 
 export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
   TTimelinePerformanceStatus,
@@ -15,22 +26,28 @@ export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
   ON_TRACK: {
     label: "On Track",
     description: "최근 추세와 비슷한 수준의 성과를 유지하고 있어요.",
+    legendDescription: "성과가 최근 흐름과 유사하게 유지되고 있음",
     barBg: "bg-primary-400/12",
     accent: "bg-primary-400",
     dot: "bg-primary-400",
+    ring: "ring-primary-400",
   },
   ABOVE_AVERAGE: {
     label: "Above Avg",
     description: "최근 평균 대비 눈에 띄게 좋은 성과를 보이고 있어요.",
+    legendDescription: "최근 평균보다 눈에 띄게 좋은 성과",
     barBg: "bg-oauth-naver/12",
     accent: "bg-oauth-naver",
     dot: "bg-oauth-naver",
+    ring: "ring-oauth-naver",
   },
   AT_RISK: {
-    label: "At Risk",
+    label: "Underperform",
     description: "최근 평균 대비 성과가 눈에 띄게 낮아요.",
+    legendDescription: "최근 평균 대비 성과가 눈에 띄게 낮음",
     barBg: "bg-info-red/10",
     accent: "bg-info-red",
     dot: "bg-info-red",
+    ring: "ring-info-red",
   },
 };

--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -101,15 +101,15 @@ export default function Timeline() {
               onClick={() => setIsCreateOpen(true)}
               leftIcon={
                 <PlusIcon
-                  className="h-4 w-4 shrink-0 text-primary-400"
+                  className="h-4 w-4 shrink-0 text-primary-450"
                   aria-hidden
                 />
               }
               className={twMerge(
                 "h-10 rounded-2xl px-4",
-                "bg-primary-400/12 text-primary-400",
+                "bg-primary-400/20 text-primary-500",
                 "font-body2 shadow-Soft",
-                "transition-ui-smooth hover:bg-primary-400/18",
+                "transition-ui-smooth hover:bg-primary-500/30",
               )}
             >
               타임라인 생성

--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -19,23 +19,27 @@ import Button from "@/components/common/button/Button";
 import TimelineAxis from "@/components/timeline/TimelineAxis";
 import TimelineBar from "@/components/timeline/TimelineBar";
 import TimelineCreateModal from "@/components/timeline/TimelineCreateModal";
+import TimelineEmptyState from "@/components/timeline/TimelineEmptyState";
 import TimelineGrid from "@/components/timeline/TimelineGrid";
 import TimelinePerformancePanel from "@/components/timeline/TimelinePerformancePanel";
-import TimelinePeriodSelector from "@/components/timeline/TimelinePeriodSelector";
+import {
+  TimelinePeriodNav,
+  TimelineViewUnitSegment,
+} from "@/components/timeline/TimelinePeriodSelector";
+import TimelineStatusLegend from "@/components/timeline/TimelineStatusLegend";
 
 import PlusIcon from "@/assets/icon/common/plus.svg?react";
 import FilterIcon from "@/assets/icon/timeline/filter.svg?react";
 import SortIcon from "@/assets/icon/timeline/sort.svg?react";
 
 const MOCK_PERIOD_LABELS: Record<TTimelineViewUnit, string[]> = {
-  DAY: ["오늘", "23 Jun", "24 Jun"],
-  WEEK: [
-    TIMELINE_GRID_MOCK.periodLabel,
-    "28 June - 4 July",
-    "5 July - 11 July",
-  ],
-  MONTH: ["오늘", "July 2026", "Auguest 2026"],
+  DAY: ["오늘", "6월 23일", "6월 24일"],
+  WEEK: ["오늘", TIMELINE_GRID_MOCK.periodLabel, "6월 28일 - 7월 4일"],
+  MONTH: ["오늘", "2026년 6월", "2026년 7월"],
 };
+
+const TOOLBAR_ACTION_CLASS =
+  "flex items-center gap-1.5 rounded-lg px-2 py-1.5 font-caption text-text-muted opacity-50 cursor-not-allowed";
 
 export default function Timeline() {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -49,6 +53,7 @@ export default function Timeline() {
   const [selectedBarId, setSelectedBarId] = useState<number | null>(null);
 
   const { columns, bars } = TIMELINE_GRID_MOCK;
+  const isEmpty = bars.length === 0;
 
   const maxRow = useMemo(
     () => (bars.length > 0 ? Math.max(...bars.map((bar) => bar.row)) : 0),
@@ -61,10 +66,11 @@ export default function Timeline() {
   const periodLabel = periodLabels[periodIndex] ?? periodLabels[0];
 
   useEffect(() => {
+    if (isEmpty) return;
     const el = scrollRef.current;
     if (!el) return;
     el.scrollLeft = el.scrollWidth - el.clientWidth;
-  }, [columns]);
+  }, [columns, isEmpty]);
 
   const handleViewUnitChange = (unit: TTimelineViewUnit) => {
     setViewUnit(unit);
@@ -79,9 +85,18 @@ export default function Timeline() {
     setPeriodIndex((prev) => (prev === periodLabels.length - 1 ? 0 : prev + 1));
   };
 
+  const handleGoToToday = () => {
+    setPeriodIndex(0);
+  };
+
   const handleBarClick = (bar: ITimelineCampaignBar) => {
     setSelectedBarId(bar.id);
     setIsPanelOpen(true);
+  };
+
+  const handlePanelClose = () => {
+    setIsPanelOpen(false);
+    setSelectedBarId(null);
   };
 
   return (
@@ -90,16 +105,9 @@ export default function Timeline() {
       style={{ height: TIMELINE_PAGE_HEIGHT }}
     >
       <div className="flex min-h-0 flex-1 w-full min-w-0 flex-col rounded-2xl border border-surface-400/70 bg-surface-100">
-        {/* 툴바 */}
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-surface-400/80 px-5 py-3">
-          <TimelinePeriodSelector
-            viewUnit={viewUnit}
-            periodLabel={periodLabel}
-            onViewUnitChange={handleViewUnitChange}
-            onPrevPeriod={handlePrevPeriod}
-            onNextPeriod={handleNextPeriod}
-          />
-          <div className="flex items-center gap-5 font-caption text-text-muted">
+        <div className="flex shrink-0 flex-col gap-4 border-b border-surface-400/80 px-5 py-5">
+          <div className="flex items-center justify-between gap-12">
+            <TimelineStatusLegend />
             <Button
               type="button"
               size="small"
@@ -107,12 +115,12 @@ export default function Timeline() {
               onClick={() => setIsCreateOpen(true)}
               leftIcon={
                 <PlusIcon
-                  className="h-4 w-4 shrink-0 text-primary-450"
+                  className="h-4 w-4 shrink-0 text-primary-500"
                   aria-hidden
                 />
               }
               className={twMerge(
-                "h-10 rounded-2xl px-4",
+                "h-10 shrink-0 rounded-2xl px-4",
                 "bg-primary-400/20 text-primary-500",
                 "font-body2 shadow-Soft",
                 "transition-ui-smooth hover:bg-primary-500/30",
@@ -120,51 +128,73 @@ export default function Timeline() {
             >
               타임라인 생성
             </Button>
-            <button
-              type="button"
-              aria-label="정렬"
-              onClick={() => toast.info("정렬기능 준비중입니다.")}
-              className="flex items-center gap-1.5 transition-colors hover:text-text-title"
-            >
-              <SortIcon className="h-5 w-5" />
-            </button>
-            <button
-              type="button"
-              aria-label="정렬"
-              onClick={() => toast.info("필터 기능 준비중입니다.")}
-              className="flex items-center gap-1.5 transition-colors hover:text-text-title"
-            >
-              <FilterIcon className="h-5 w-5" />
-            </button>
+          </div>
+
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4">
+            <TimelineViewUnitSegment
+              viewUnit={viewUnit}
+              onViewUnitChange={handleViewUnitChange}
+              className="justify-self-start"
+            />
+            <TimelinePeriodNav
+              periodLabel={periodLabel}
+              onPrevPeriod={handlePrevPeriod}
+              onNextPeriod={handleNextPeriod}
+              onGoToToday={handleGoToToday}
+              className="justify-self-center"
+            />
+            <div className="flex items-center justify-self-end gap-3">
+              <span
+                className={TOOLBAR_ACTION_CLASS}
+                title="준비 중"
+                aria-disabled
+              >
+                <SortIcon className="h-4 w-4" />
+                Sort
+              </span>
+              <span
+                className={TOOLBAR_ACTION_CLASS}
+                title="준비 중"
+                aria-disabled
+              >
+                <FilterIcon className="h-4 w-4" />
+                Filter
+              </span>
+            </div>
           </div>
         </div>
-        {/* 캔버스 — 가로·세로 스크롤, 행이 많아지면 세로로 확장 */}
-        <div
-          ref={scrollRef}
-          className="flex min-h-0 w-full flex-1 flex-col overflow-auto"
-        >
+
+        {isEmpty ? (
+          <TimelineEmptyState onCreate={() => setIsCreateOpen(true)} />
+        ) : (
           <div
-            style={{ width: totalWidth, minHeight: "100%" }}
-            className="flex min-h-full flex-1 flex-col"
+            ref={scrollRef}
+            className="flex min-h-0 w-full flex-1 flex-col overflow-auto"
           >
-            <TimelineAxis columns={columns} />
-            <TimelineGrid columns={columns} rowCount={maxRow}>
-              {bars.map((bar) => (
-                <TimelineBar
-                  key={bar.id}
-                  bar={bar}
-                  onBarClick={handleBarClick}
-                  onEdit={() =>
-                    toast.info("수정기능은 다음 이슈에서 연동됩니다")
-                  }
-                  onDelete={() =>
-                    toast.info("삭제기능은 다음 이슈에서 연동됩니다")
-                  }
-                />
-              ))}
-            </TimelineGrid>
+            <div
+              style={{ width: totalWidth, minHeight: "100%" }}
+              className="flex min-h-full flex-1 flex-col"
+            >
+              <TimelineAxis columns={columns} className="sticky top-0 z-20" />
+              <TimelineGrid columns={columns} rowCount={maxRow}>
+                {bars.map((bar) => (
+                  <TimelineBar
+                    key={bar.id}
+                    bar={bar}
+                    isSelected={selectedBarId === bar.id && isPanelOpen}
+                    onBarClick={handleBarClick}
+                    onEdit={() =>
+                      toast.info("수정기능은 다음 이슈에서 연동됩니다")
+                    }
+                    onDelete={() =>
+                      toast.info("삭제기능은 다음 이슈에서 연동됩니다")
+                    }
+                  />
+                ))}
+              </TimelineGrid>
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       <TimelineCreateModal
@@ -174,7 +204,7 @@ export default function Timeline() {
 
       <TimelinePerformancePanel
         isOpen={isPanelOpen}
-        onClose={() => setIsPanelOpen(false)}
+        onClose={handlePanelClose}
         onEdit={() => toast.info("수정기능은 다음 이슈에서 연동예정")}
         onDelete={() => toast.info("삭제기능은 다음 이슈에서 연동예정")}
         data={{

--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -1,21 +1,183 @@
-import ComingSoonPlaceholder from "@/components/common/ComingSoonPlaceholder";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { twMerge } from "tailwind-merge";
+
+import {
+  TIMELINE_GRID_MOCK,
+  TIMELINE_SUMMARY_PANEL_MOCK,
+} from "@/types/timeline/timeline.mock";
+import type {
+  ITimelineCampaignBar,
+  TTimelineViewUnit,
+} from "@/types/timeline/ui";
+import { TIMELINE_COL_WIDTH } from "@/constants/timeline/layout";
+
+import Button from "@/components/common/button/Button";
+import TimelineAxis from "@/components/timeline/TimelineAxis";
+import TimelineBar from "@/components/timeline/TimelineBar";
+import TimelineCreateModal from "@/components/timeline/TimelineCreateModal";
+import TimelineGrid from "@/components/timeline/TimelineGrid";
+import TimelinePerformancePanel from "@/components/timeline/TimelinePerformancePanel";
+import TimelinePeriodSelector from "@/components/timeline/TimelinePeriodSelector";
+
+import PlusIcon from "@/assets/icon/common/plus.svg?react";
+import FilterIcon from "@/assets/icon/timeline/filter.svg?react";
+import SortIcon from "@/assets/icon/timeline/sort.svg?react";
+
+const MOCK_PERIOD_LABELS: Record<TTimelineViewUnit, string[]> = {
+  DAY: ["오늘", "23 Jun", "24 Jun"],
+  WEEK: [
+    TIMELINE_GRID_MOCK.periodLabel,
+    "28 June - 4 July",
+    "5 July - 11 July",
+  ],
+  MONTH: ["오늘", "July 2026", "Auguest 2026"],
+};
 
 export default function Timeline() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const [viewUnit, setViewUnit] = useState<TTimelineViewUnit>(
+    TIMELINE_GRID_MOCK.viewUnit,
+  );
+  const [periodIndex, setPeriodIndex] = useState(0);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [selectedBarId, setSelectedBarId] = useState<number | null>(null);
+
+  const { columns, bars } = TIMELINE_GRID_MOCK;
+
+  const maxRow = useMemo(
+    () => (bars.length > 0 ? Math.max(...bars.map((bar) => bar.row)) : 0),
+    [bars],
+  );
+
+  const totalWidth = columns.length * TIMELINE_COL_WIDTH;
+
+  const periodLabels = MOCK_PERIOD_LABELS[viewUnit];
+  const periodLabel = periodLabels[periodIndex] ?? periodLabels[0];
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollLeft = el.scrollWidth - el.clientWidth;
+  }, [columns]);
+
+  const handleViewUnitChange = (unit: TTimelineViewUnit) => {
+    setViewUnit(unit);
+    setPeriodIndex(0);
+  };
+
+  const handlePrevPeriod = () => {
+    setPeriodIndex((prev) => (prev === 0 ? periodLabels.length - 1 : prev - 1));
+  };
+
+  const handleNextPeriod = () => {
+    setPeriodIndex((prev) => (prev === periodLabels.length - 1 ? 0 : prev + 1));
+  };
+
+  const handleBarClick = (bar: ITimelineCampaignBar) => {
+    setSelectedBarId(bar.id);
+    setIsPanelOpen(true);
+  };
+
   return (
-    <ComingSoonPlaceholder
-      title={
-        <>
-          <span className="block">성과 타임라인을</span>
-          <span className="block">준비하고 있어요</span>
-        </>
-      }
-      description={
-        <>
-          <span className="block">캠페인 흐름을 한눈에 파악할 수 있도록,</span>
-          <span className="block">더 유용한 기능으로 찾아올게요.</span>
-        </>
-      }
-      footer="조금만 기다려 주시면 감사하겠습니다"
-    />
+    <section className="w-full flex flex-col gap-8 min-w-0">
+      <div className="flex w-full min-w-0 flex-col overflow-hidden rounded-2xl border border-surface-400/70 bg-surface-100">
+        {/* 툴바 */}
+        <div className="flex flex-wrap items-center justify-between gap-4 border-b border-surface-400/80 px-5 py-3">
+          <TimelinePeriodSelector
+            viewUnit={viewUnit}
+            periodLabel={periodLabel}
+            onViewUnitChange={handleViewUnitChange}
+            onPrevPeriod={handlePrevPeriod}
+            onNextPeriod={handleNextPeriod}
+          />
+          <div className="flex items-center gap-5 font-caption text-text-muted">
+            <Button
+              type="button"
+              size="small"
+              variant="custom"
+              onClick={() => setIsCreateOpen(true)}
+              leftIcon={
+                <PlusIcon
+                  className="h-4 w-4 shrink-0 text-primary-400"
+                  aria-hidden
+                />
+              }
+              className={twMerge(
+                "h-10 rounded-2xl px-4",
+                "bg-primary-400/12 text-primary-400",
+                "font-body2 shadow-Soft",
+                "transition-ui-smooth hover:bg-primary-400/18",
+              )}
+            >
+              타임라인 생성
+            </Button>
+            <button
+              type="button"
+              aria-label="정렬"
+              onClick={() => toast.info("정렬기능 준비중입니다.")}
+              className="flex items-center gap-1.5 transition-colors hover:text-text-title"
+            >
+              <SortIcon className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              aria-label="정렬"
+              onClick={() => toast.info("필터 기능 준비중입니다.")}
+              className="flex items-center gap-1.5 transition-colors hover:text-text-title"
+            >
+              <FilterIcon className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+        {/* 캔버스 */}
+        <div
+          ref={scrollRef}
+          className="h-105 w-full overflow-x-auto overflow-y-hidden"
+        >
+          <div
+            style={{ width: totalWidth }}
+            className="flex h-full min-h-0 flex-col"
+          >
+            <TimelineAxis columns={columns} />
+            <TimelineGrid columns={columns} rowCount={maxRow}>
+              {bars.map((bar) => (
+                <TimelineBar
+                  key={bar.id}
+                  bar={bar}
+                  onBarClick={handleBarClick}
+                  onEdit={() =>
+                    toast.info("수정기능은 다음 이슈에서 연동됩니다")
+                  }
+                  onDelete={() =>
+                    toast.info("삭제기능은 다음 이슈에서 연동됩니다")
+                  }
+                />
+              ))}
+            </TimelineGrid>
+          </div>
+        </div>
+      </div>
+
+      <TimelineCreateModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+      />
+
+      <TimelinePerformancePanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        onEdit={() => toast.info("수정기능은 다음 이슈에서 연동예정")}
+        onDelete={() => toast.info("삭제기능은 다음 이슈에서 연동예정")}
+        data={{
+          ...TIMELINE_SUMMARY_PANEL_MOCK,
+          timelineName:
+            bars.find((bar) => bar.id === selectedBarId)?.title ??
+            TIMELINE_SUMMARY_PANEL_MOCK.timelineName,
+        }}
+      />
+    </section>
   );
 }

--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
 
+import type { ITimelineSummaryPanelData } from "@/types/timeline/summary";
 import {
-  TIMELINE_GRID_MOCK,
-  TIMELINE_SUMMARY_PANEL_MOCK,
+  buildTimelineSummaryPanelDataForBar,
+  TIMELINE_GRID_MOCK_BY_VIEW_UNIT,
+  TIMELINE_GRID_MOCK_WEEK,
 } from "@/types/timeline/timeline.mock";
 import type {
   ITimelineCampaignBar,
@@ -34,7 +36,7 @@ import SortIcon from "@/assets/icon/timeline/sort.svg?react";
 
 const MOCK_PERIOD_LABELS: Record<TTimelineViewUnit, string[]> = {
   DAY: ["오늘", "6월 23일", "6월 24일"],
-  WEEK: ["오늘", TIMELINE_GRID_MOCK.periodLabel, "6월 28일 - 7월 4일"],
+  WEEK: ["오늘", TIMELINE_GRID_MOCK_WEEK.periodLabel, "6월 28일 - 7월 4일"],
   MONTH: ["오늘", "2026년 6월", "2026년 7월"],
 };
 
@@ -45,14 +47,18 @@ export default function Timeline() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const [viewUnit, setViewUnit] = useState<TTimelineViewUnit>(
-    TIMELINE_GRID_MOCK.viewUnit,
+    TIMELINE_GRID_MOCK_WEEK.viewUnit,
   );
   const [periodIndex, setPeriodIndex] = useState(0);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [selectedBarId, setSelectedBarId] = useState<number | null>(null);
+  const [panelData, setPanelData] = useState<ITimelineSummaryPanelData | null>(
+    null,
+  );
 
-  const { columns, bars } = TIMELINE_GRID_MOCK;
+  const gridData = TIMELINE_GRID_MOCK_BY_VIEW_UNIT[viewUnit];
+  const { columns, bars } = gridData;
   const isEmpty = bars.length === 0;
 
   const maxRow = useMemo(
@@ -62,15 +68,39 @@ export default function Timeline() {
 
   const totalWidth = columns.length * TIMELINE_COL_WIDTH;
 
-  const periodLabels = MOCK_PERIOD_LABELS[viewUnit];
+  const periodLabels = useMemo(
+    () =>
+      MOCK_PERIOD_LABELS[viewUnit].map((label, index) =>
+        index === 1 ? gridData.periodLabel : label,
+      ),
+    [gridData.periodLabel, viewUnit],
+  );
   const periodLabel = periodLabels[periodIndex] ?? periodLabels[0];
+
+  const selectedBar = useMemo(
+    () => bars.find((bar) => bar.id === selectedBarId) ?? null,
+    [bars, selectedBarId],
+  );
+
+  useEffect(() => {
+    if (!selectedBar) return;
+    setPanelData(buildTimelineSummaryPanelDataForBar(selectedBar));
+  }, [selectedBar]);
 
   useEffect(() => {
     if (isEmpty) return;
     const el = scrollRef.current;
     if (!el) return;
     el.scrollLeft = el.scrollWidth - el.clientWidth;
-  }, [columns, isEmpty]);
+  }, [columns, isEmpty, viewUnit]);
+
+  useEffect(() => {
+    if (selectedBarId === null) return;
+    if (!bars.some((bar) => bar.id === selectedBarId)) {
+      setIsPanelOpen(false);
+      setSelectedBarId(null);
+    }
+  }, [bars, selectedBarId]);
 
   const handleViewUnitChange = (unit: TTimelineViewUnit) => {
     setViewUnit(unit);
@@ -91,6 +121,7 @@ export default function Timeline() {
 
   const handleBarClick = (bar: ITimelineCampaignBar) => {
     setSelectedBarId(bar.id);
+    setPanelData(buildTimelineSummaryPanelDataForBar(bar));
     setIsPanelOpen(true);
   };
 
@@ -175,11 +206,11 @@ export default function Timeline() {
               style={{ width: totalWidth, minHeight: "100%" }}
               className="flex min-h-full flex-1 flex-col"
             >
-              <TimelineAxis columns={columns} className="sticky top-0 z-20" />
+              <TimelineAxis columns={columns} className="sticky top-0" />
               <TimelineGrid columns={columns} rowCount={maxRow}>
                 {bars.map((bar) => (
                   <TimelineBar
-                    key={bar.id}
+                    key={`${viewUnit}-${bar.id}`}
                     bar={bar}
                     isSelected={selectedBarId === bar.id && isPanelOpen}
                     onBarClick={handleBarClick}
@@ -202,18 +233,15 @@ export default function Timeline() {
         onClose={() => setIsCreateOpen(false)}
       />
 
-      <TimelinePerformancePanel
-        isOpen={isPanelOpen}
-        onClose={handlePanelClose}
-        onEdit={() => toast.info("수정기능은 다음 이슈에서 연동예정")}
-        onDelete={() => toast.info("삭제기능은 다음 이슈에서 연동예정")}
-        data={{
-          ...TIMELINE_SUMMARY_PANEL_MOCK,
-          timelineName:
-            bars.find((bar) => bar.id === selectedBarId)?.title ??
-            TIMELINE_SUMMARY_PANEL_MOCK.timelineName,
-        }}
-      />
+      {panelData ? (
+        <TimelinePerformancePanel
+          isOpen={isPanelOpen}
+          onClose={handlePanelClose}
+          onEdit={() => toast.info("수정기능은 다음 이슈에서 연동예정")}
+          onDelete={() => toast.info("삭제기능은 다음 이슈에서 연동예정")}
+          data={panelData}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -10,7 +10,10 @@ import type {
   ITimelineCampaignBar,
   TTimelineViewUnit,
 } from "@/types/timeline/ui";
-import { TIMELINE_COL_WIDTH } from "@/constants/timeline/layout";
+import {
+  TIMELINE_COL_WIDTH,
+  TIMELINE_PAGE_HEIGHT,
+} from "@/constants/timeline/layout";
 
 import Button from "@/components/common/button/Button";
 import TimelineAxis from "@/components/timeline/TimelineAxis";
@@ -82,10 +85,13 @@ export default function Timeline() {
   };
 
   return (
-    <section className="w-full flex flex-col gap-8 min-w-0">
-      <div className="flex w-full min-w-0 flex-col overflow-hidden rounded-2xl border border-surface-400/70 bg-surface-100">
+    <section
+      className="flex w-full min-w-0 flex-col"
+      style={{ height: TIMELINE_PAGE_HEIGHT }}
+    >
+      <div className="flex min-h-0 flex-1 w-full min-w-0 flex-col rounded-2xl border border-surface-400/70 bg-surface-100">
         {/* 툴바 */}
-        <div className="flex flex-wrap items-center justify-between gap-4 border-b border-surface-400/80 px-5 py-3">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-surface-400/80 px-5 py-3">
           <TimelinePeriodSelector
             viewUnit={viewUnit}
             periodLabel={periodLabel}
@@ -132,14 +138,14 @@ export default function Timeline() {
             </button>
           </div>
         </div>
-        {/* 캔버스 */}
+        {/* 캔버스 — 가로·세로 스크롤, 행이 많아지면 세로로 확장 */}
         <div
           ref={scrollRef}
-          className="h-105 w-full overflow-x-auto overflow-y-hidden"
+          className="flex min-h-0 w-full flex-1 flex-col overflow-auto"
         >
           <div
-            style={{ width: totalWidth }}
-            className="flex h-full min-h-0 flex-col"
+            style={{ width: totalWidth, minHeight: "100%" }}
+            className="flex min-h-full flex-1 flex-col"
           >
             <TimelineAxis columns={columns} />
             <TimelineGrid columns={columns} rowCount={maxRow}>

--- a/src/types/timeline/timeline.mock.ts
+++ b/src/types/timeline/timeline.mock.ts
@@ -95,7 +95,7 @@ export const TIMELINE_GRID_MOCK: ITimelineGridData = {
       id: 1,
       title: "평일 성과 요약",
       subtitle: "06.22 - 06.26",
-      provider: "GOOGLE",
+      providers: ["GOOGLE"],
       colStart: 2,
       colEnd: 7,
       row: 1,
@@ -105,13 +105,19 @@ export const TIMELINE_GRID_MOCK: ITimelineGridData = {
       id: 2,
       title: "리타겟팅 캠페인",
       subtitle: "06.25 - 06.27",
-      provider: "META",
+      providers: ["GOOGLE", "META", "NAVER"],
       colStart: 5,
       colEnd: 8,
       row: 2,
       performanceStatus: "ON_TRACK",
     },
   ],
+};
+
+/*UI 그리드 빈 상태 확인용 — Timeline에서 TIMELINE_GRID_MOCK 대신 사용*/
+export const TIMELINE_GRID_EMPTY_MOCK: ITimelineGridData = {
+  ...TIMELINE_GRID_MOCK,
+  bars: [],
 };
 
 /*성과 요약 패널 mock*/

--- a/src/types/timeline/timeline.mock.ts
+++ b/src/types/timeline/timeline.mock.ts
@@ -1,10 +1,39 @@
+import type { TProviderType } from "@/types/dashboard/provider";
 import type {
   ITimelineDetail,
   ITimelineListItem,
   ITimelineMutationResponse,
 } from "@/types/timeline/api";
 import type { ITimelineSummaryPanelData } from "@/types/timeline/summary";
-import type { ITimelineGridData } from "@/types/timeline/ui";
+import type {
+  ITimelineCampaignBar,
+  ITimelineGridColumn,
+  ITimelineGridData,
+  TTimelineViewUnit,
+} from "@/types/timeline/ui";
+
+const WEEKDAY_KO = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+function buildMonthColumns(
+  year: number,
+  month: number,
+  daysInMonth: number,
+  todayDate: number,
+): ITimelineGridColumn[] {
+  const firstDay = new Date(year, month - 1, 1).getDay();
+
+  return Array.from({ length: daysInMonth }, (_, index) => {
+    const date = index + 1;
+    const dayIndex = (firstDay + index) % 7;
+
+    return {
+      day: WEEKDAY_KO[dayIndex],
+      date,
+      isWeekend: dayIndex === 0 || dayIndex === 6,
+      isToday: date === todayDate,
+    };
+  });
+}
 
 /*GET /timeline 목록 mock*/
 export const TIMELINE_LIST_MOCK: ITimelineListItem[] = [
@@ -77,8 +106,8 @@ export const TIMELINE_CREATE_RESPONSE_MOCK: ITimelineMutationResponse = {
   createdAt: "2026-06-20T07:58:24.795Z",
 };
 
-/*UI 그리드 mock*/
-export const TIMELINE_GRID_MOCK: ITimelineGridData = {
+/*UI 그리드 mock — 주간*/
+export const TIMELINE_GRID_MOCK_WEEK: ITimelineGridData = {
   viewUnit: "WEEK",
   periodLabel: "21 June - 27 June",
   columns: [
@@ -114,7 +143,73 @@ export const TIMELINE_GRID_MOCK: ITimelineGridData = {
   ],
 };
 
-/*UI 그리드 빈 상태 확인용 — Timeline에서 TIMELINE_GRID_MOCK 대신 사용*/
+export const TIMELINE_GRID_MOCK = TIMELINE_GRID_MOCK_WEEK;
+
+export const TIMELINE_GRID_MOCK_DAY: ITimelineGridData = {
+  viewUnit: "DAY",
+  periodLabel: "6월 27일",
+  columns: [{ day: "토", date: 27, isWeekend: true, isToday: true }],
+  bars: [
+    {
+      id: 1,
+      title: "평일 성과 요약",
+      subtitle: "06.27",
+      providers: ["GOOGLE"],
+      colStart: 1,
+      colEnd: 2,
+      row: 1,
+      performanceStatus: "ABOVE_AVERAGE",
+    },
+    {
+      id: 2,
+      title: "리타겟팅 캠페인",
+      subtitle: "06.27",
+      providers: ["GOOGLE", "META", "NAVER"],
+      colStart: 1,
+      colEnd: 2,
+      row: 2,
+      performanceStatus: "ON_TRACK",
+    },
+  ],
+};
+
+export const TIMELINE_GRID_MOCK_MONTH: ITimelineGridData = {
+  viewUnit: "MONTH",
+  periodLabel: "2026년 6월",
+  columns: buildMonthColumns(2026, 6, 30, 27),
+  bars: [
+    {
+      id: 1,
+      title: "평일 성과 요약",
+      subtitle: "06.01 - 06.15",
+      providers: ["GOOGLE"],
+      colStart: 1,
+      colEnd: 16,
+      row: 1,
+      performanceStatus: "ABOVE_AVERAGE",
+    },
+    {
+      id: 2,
+      title: "리타겟팅 캠페인",
+      subtitle: "06.16 - 06.30",
+      providers: ["GOOGLE", "META", "NAVER"],
+      colStart: 16,
+      colEnd: 31,
+      row: 2,
+      performanceStatus: "ON_TRACK",
+    },
+  ],
+};
+
+export const TIMELINE_GRID_MOCK_BY_VIEW_UNIT: Record<
+  TTimelineViewUnit,
+  ITimelineGridData
+> = {
+  DAY: TIMELINE_GRID_MOCK_DAY,
+  WEEK: TIMELINE_GRID_MOCK_WEEK,
+  MONTH: TIMELINE_GRID_MOCK_MONTH,
+};
+
 export const TIMELINE_GRID_EMPTY_MOCK: ITimelineGridData = {
   ...TIMELINE_GRID_MOCK,
   bars: [],
@@ -149,3 +244,70 @@ export const TIMELINE_SUMMARY_PANEL_NO_AI_MOCK: ITimelineSummaryPanelData = {
   ...TIMELINE_SUMMARY_PANEL_MOCK,
   aiSummary: "",
 };
+
+const TIMELINE_SUMMARY_PANEL_MOCK_BAR_OVERRIDES: Record<
+  number,
+  Partial<ITimelineSummaryPanelData>
+> = {
+  1: {
+    metrics: [
+      { metric: "CLICK", label: "클릭", value: 2480, changeRate: 0.12 },
+      { metric: "CONVERSION", label: "전환", value: 182, changeRate: 0.09 },
+      { metric: "IMPRESSION", label: "노출", value: 92100, changeRate: 0.04 },
+      {
+        metric: "ROAS",
+        label: "ROAS",
+        value: 3.42,
+        unit: "배",
+        changeRate: 0.06,
+      },
+    ],
+    aiSummary:
+      "평일 구간에서 클릭과 전환이 비교 기간 대비 안정적으로 증가했습니다.",
+  },
+  2: {
+    metrics: [
+      { metric: "CLICK", label: "클릭", value: 1250, changeRate: -0.02 },
+      { metric: "CONVERSION", label: "전환", value: 73, changeRate: -0.05 },
+      { metric: "IMPRESSION", label: "노출", value: 43900, changeRate: 0.01 },
+      {
+        metric: "ROAS",
+        label: "ROAS",
+        value: 2.84,
+        unit: "배",
+        changeRate: -0.04,
+      },
+    ],
+    aiSummary:
+      "리타겟팅 구간은 클릭은 유지됐지만 전환 효율이 비교 기간 대비 다소 낮습니다.",
+  },
+};
+
+function buildPlatformShareFromProviders(
+  providers?: TProviderType[],
+): ITimelineSummaryPanelData["platformShare"] {
+  if (!providers?.length) {
+    return TIMELINE_SUMMARY_PANEL_MOCK.platformShare;
+  }
+
+  const rate = 1 / providers.length;
+  return providers.map((provider) => ({
+    provider,
+    contributionRate: rate,
+  }));
+}
+
+export function buildTimelineSummaryPanelDataForBar(
+  bar: ITimelineCampaignBar,
+): ITimelineSummaryPanelData {
+  const overrides = TIMELINE_SUMMARY_PANEL_MOCK_BAR_OVERRIDES[bar.id] ?? {};
+
+  return {
+    ...TIMELINE_SUMMARY_PANEL_MOCK,
+    ...overrides,
+    timelineName: bar.title,
+    periodLabel: bar.subtitle,
+    performanceStatus: bar.performanceStatus,
+    platformShare: buildPlatformShareFromProviders(bar.providers),
+  };
+}

--- a/src/types/timeline/ui.ts
+++ b/src/types/timeline/ui.ts
@@ -18,7 +18,7 @@ export interface ITimelineCampaignBar {
   id: number;
   title: string;
   subtitle: string;
-  provider?: TProviderType;
+  providers?: TProviderType[];
   colStart: number; //그리드 시작 위치
   colEnd: number;
   row: number;


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #265 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

###  페이지 조립 (`Timeline`)
- `ComingSoonPlaceholder` 제거 후 타임라인 페이지 본문 구현완료했습니다.
- mock데이터 기준으로 그리드/바/모달/패널 연동
- 로컬 상태일때 생성 모달/ 성과 요약 패널/ 기간 보기 단위 제어
- 뷰포트 높이 기준으로 캔버스 레이아웃 및 가로세로 스크롤 적용

### 헤더 영역
- On Track / Above Avg / Underperform로 성과 상태 기준 알리고, `?` hover 시에는 평균 기준 설명 툴팁 첨부하였습니다.
- 타임라인 생성 버튼은 성과 상태 범례와 justify-betwwen` 배치
- 보기 단위는 기존이 드랍다운으로 구현했던 이전 PR 작업보다는 세그먼트 컨트롤로 보여지는게 훨씬 깔끔하고 직관적인 인상을 주는것같아 디자인 수정했습니다.
- 기간 네비게이션은 기존 좌측 정렬에서 중앙정렬로 수정함으로써 사용자가 바로 날짜를 확인할 수 있도록 변경하였습니다. 추가로 [오늘] 버튼을 추가하여 이전 기간갔다가 바로 오늘 날짜로 돌아올수 있도록 수정작업 진행하였습니다.
- Sort/Filter - 타임라인 바 정렬과 필터링을 할수있도록 아이콘을 추가하였고 추후에 API연동작업에서 기능구현 예정입니다.

### 캔버스 /그리드
- `TimelineAxis` sticky 상단 고정
- `TimelineGrid` 세로선 연하게, 캔버스 높이에 맞춰 세로선·오늘 칸 배경 전체 확장
- 날짜 칸 너비 확장하였습니다.

### 타임라인 바
- 클릭시에는 패널이 오픈되도록 하였고,
- 선택할 시에는 상태별 ring 색상이 되도록 디자인 수정했습니다. (On Track: 파랑/Above Avg: 초록/Underperform: 빨강)
- 플랫폼 로고도 같이 타임라인 바 정보에 표시되도록 수정하였습니다. 다중 표시가 가능하도록 하였고, 연결된 플랫폼만 원형 로고로 겹치도록 표시되게 하였습니다.
- Kebab Icon 메뉴를 hover하거나 선택했을때 노출되도록 수정하였고, 해당 메뉴에는 수정/삭제 넣었습니다. (현재는 toast로)
- `DropdownMenu` `placement="auto"` — 하단 공간이 좁아 잘림이 발생할 때에는 위로 펼쳐지도록 수정하였고, 메뉴 너비 축소했습니다.

### 빈 상태
만약 타임라인 바가 없다면, `bars.length === 0`일때 안내 문구 + 생성 CTA
- 테스트용 `TIMELINE_GRID_EMPTY_MOCK` 추가


## 💻 작업 화면 

<img width="1478" height="890" alt="image" src="https://github.com/user-attachments/assets/2f65879f-bb9d-4dd0-aa51-2a4b987e0efe" />
<img width="1478" height="907" alt="image" src="https://github.com/user-attachments/assets/18a50f4b-4072-4339-8010-944b4a3345d0" />
<img width="1478" height="896" alt="image" src="https://github.com/user-attachments/assets/a86f2fb5-b518-4745-84ad-5999077760ff" />
<img width="1789" height="900" alt="image" src="https://github.com/user-attachments/assets/fc22a505-453b-42a9-8e29-bf66108eecf1" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- provider 표시: 타임라인 생성 모달에는 플랫폼 선택이 없습니다. 바의 `providers`는 연결된 캠페인/광고 플랫폼 목록으로 API에서 내려올 예정입니다. (mock: 리타겟팅 캠페인 = Google·Meta·Naver 3개)
- 빈 상태 확인: `TIMELINE_GRID_EMPTY_MOCK`으로 import 교체 후 확인 가능
- 그리드 가로 너비는 `columns.length × COL_WIDTH` — API 연동 시 기간·viewUnit에 따라 칸 수 증가 → 가로 스크롤

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 타임라인 화면이 실제 목록/축/그리드/상세 패널로 구성되어 표시됩니다.
  * 타임라인이 비어 있을 때 생성 안내 화면과 생성 모달이 제공됩니다.
  * 기간 단위 전환, 오늘로 이동, 상태 범례 도움말이 추가되었습니다.
  * 드롭다운 메뉴가 상/하단 자동 배치와 접근성 라벨을 지원합니다.

* **Bug Fixes**
  * 선택된 항목과 메뉴 표시 상태가 더 안정적으로 동기화됩니다.
  * 여러 제공자 로고와 상태 스타일이 더 정확하게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->