### PR TITLE
[Refactor/#268] 워크스페이스·캠페인 그룹 useCoreQuery/useCoreMutation 패턴 통일

### DIFF
--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -23,6 +23,7 @@ export function WorkspaceSwitcher({
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const latestSaveOrgIdRef = useRef<number | null>(null);
 
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
@@ -55,19 +56,39 @@ export function WorkspaceSwitcher({
     setMyRole(fallback.myRole);
   }, [selectedOrgId, workspaceList, setSelectedOrgId, setMyRole]);
 
-  const { mutate: saveWorkspace } = useCoreMutation(saveSelectedWorkspace, {
-    invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
-    userOnSuccess: (_data, orgId) => {
-      const workspace = workspaceList.find((w) => w.orgId === orgId);
-      setSelectedOrgId(orgId);
-      if (workspace) setMyRole(workspace.myRole);
+  const { mutate: saveWorkspace, isPending: isSavingWorkspace } =
+    useCoreMutation(saveSelectedWorkspace, {
+      invalidateKeys: [
+        QUERY_KEYS.workspace.list(),
+        QUERY_KEYS.workspace.saved(),
+      ],
+      userOnSuccess: (_data, orgId) => {
+        if (latestSaveOrgIdRef.current !== orgId) return;
+
+        latestSaveOrgIdRef.current = null;
+        const workspace = workspaceList.find((w) => w.orgId === orgId);
+        setSelectedOrgId(orgId);
+        if (workspace) setMyRole(workspace.myRole);
+      },
+      userOnError: (error, orgId) => {
+        if (latestSaveOrgIdRef.current === orgId) {
+          latestSaveOrgIdRef.current = null;
+        }
+        console.error("워크스페이스 저장 실패:", error);
+        toast.error("워크스페이스 변경에 실패했습니다. 다시 시도해 주세요.");
+      },
+    });
+
+  const handleSelectWorkspace = useCallback(
+    (orgId: number) => {
+      if (isSavingWorkspace) return;
+
+      latestSaveOrgIdRef.current = orgId;
       setIsOpen(false);
+      saveWorkspace(orgId);
     },
-    userOnError: (error) => {
-      console.error("워크스페이스 저장 실패:", error);
-      toast.error("워크스페이스 변경에 실패했습니다. 다시 시도해 주세요.");
-    },
-  });
+    [isSavingWorkspace, saveWorkspace],
+  );
 
   useEffect(() => {
     if (isCollapsed) {
@@ -243,10 +264,9 @@ export function WorkspaceSwitcher({
                   )}
                   <button
                     type="button"
-                    onClick={() => {
-                      saveWorkspace(org.orgId);
-                    }}
-                    className="group flex w-full items-center gap-3 rounded-2xl px-2 py-1.5 font-body2 text-text-title hover:bg-surface-200 transition-colors"
+                    disabled={isSavingWorkspace}
+                    onClick={() => handleSelectWorkspace(org.orgId)}
+                    className="group flex w-full items-center gap-3 rounded-2xl px-2 py-1.5 font-body2 text-text-title hover:bg-surface-200 transition-colors disabled:pointer-events-none disabled:opacity-50"
                   >
                     {renderImage(org)}
                     <div className="flex flex-col flex-1 min-w-0 items-start">

--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
 import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
 
 import type { TWorkspace } from "@/types/workspace/workspace";
 
-import { useCoreQuery } from "@/hooks/customQuery";
+import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import { getMyWorkspaces, saveSelectedWorkspace } from "@/api/workspace/org";
 import ChevronIcon from "@/assets/icon/chevron/chevron-up.svg?react";
@@ -24,7 +23,6 @@ export function WorkspaceSwitcher({
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const queryClient = useQueryClient();
 
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
@@ -57,23 +55,15 @@ export function WorkspaceSwitcher({
     setMyRole(fallback.myRole);
   }, [selectedOrgId, workspaceList, setSelectedOrgId, setMyRole]);
 
-  const { mutate: saveWorkspace } = useMutation({
-    mutationFn: (orgId: number) => saveSelectedWorkspace(orgId),
-    onSuccess: async (_data, orgId) => {
+  const { mutate: saveWorkspace } = useCoreMutation(saveSelectedWorkspace, {
+    invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
+    userOnSuccess: (_data, orgId) => {
       const workspace = workspaceList.find((w) => w.orgId === orgId);
       setSelectedOrgId(orgId);
       if (workspace) setMyRole(workspace.myRole);
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.workspace.list(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.workspace.saved(),
-        }),
-      ]);
       setIsOpen(false);
     },
-    onError: (error) => {
+    userOnError: (error) => {
       console.error("워크스페이스 저장 실패:", error);
       toast.error("워크스페이스 변경에 실패했습니다. 다시 시도해 주세요.");
     },

--- a/src/hooks/ads/useCampaignGroup.ts
+++ b/src/hooks/ads/useCampaignGroup.ts
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IPlatformCampaign } from "@/types/ads/campaign";
-import type { IApiErrorResponse } from "@/types/common/common";
+
+import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import { createCampaignGroup, getPlatformCampaigns } from "@/api/ads/ads";
 import { QUERY_KEYS } from "@/lib/queryKeys";
@@ -18,7 +18,6 @@ const NONE_OPTION: IPlatformCampaign = {
 
 export const useCampaignGroup = () => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   const [name, setName] = useState("");
@@ -33,32 +32,23 @@ export const useCampaignGroup = () => {
     null,
   );
 
-  const { data: googleData = [] } = useQuery<
-    IPlatformCampaign[],
-    IApiErrorResponse
-  >({
-    queryKey: QUERY_KEYS.campaign.platformList(orgId, "GOOGLE"),
-    queryFn: () => getPlatformCampaigns(orgId!, "GOOGLE"),
-    enabled: !!orgId,
-  });
+  const { data: googleData = [] } = useCoreQuery(
+    QUERY_KEYS.campaign.platformList(orgId, "GOOGLE"),
+    () => getPlatformCampaigns(orgId!, "GOOGLE"),
+    { enabled: !!orgId },
+  );
 
-  const { data: naverData = [] } = useQuery<
-    IPlatformCampaign[],
-    IApiErrorResponse
-  >({
-    queryKey: QUERY_KEYS.campaign.platformList(orgId, "NAVER"),
-    queryFn: () => getPlatformCampaigns(orgId!, "NAVER"),
-    enabled: !!orgId,
-  });
+  const { data: naverData = [] } = useCoreQuery(
+    QUERY_KEYS.campaign.platformList(orgId, "NAVER"),
+    () => getPlatformCampaigns(orgId!, "NAVER"),
+    { enabled: !!orgId },
+  );
 
-  const { data: metaData = [] } = useQuery<
-    IPlatformCampaign[],
-    IApiErrorResponse
-  >({
-    queryKey: QUERY_KEYS.campaign.platformList(orgId, "META"),
-    queryFn: () => getPlatformCampaigns(orgId!, "META"),
-    enabled: !!orgId,
-  });
+  const { data: metaData = [] } = useCoreQuery(
+    QUERY_KEYS.campaign.platformList(orgId, "META"),
+    () => getPlatformCampaigns(orgId!, "META"),
+    { enabled: !!orgId },
+  );
 
   const googleCampaigns = [NONE_OPTION, ...googleData];
   const naverCampaigns = [NONE_OPTION, ...naverData];
@@ -72,11 +62,11 @@ export const useCampaignGroup = () => {
 
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
 
-  const { mutate: createGroup, isPending: isCreating } = useMutation<
-    unknown,
-    IApiErrorResponse
-  >({
-    mutationFn: () => {
+  const { mutate: createGroup, isPending: isCreating } = useCoreMutation<
+    void,
+    void
+  >(
+    () => {
       const campaignIds: number[] = [
         googleSelected?.adCampaignId,
         naverSelected?.adCampaignId,
@@ -91,16 +81,16 @@ export const useCampaignGroup = () => {
         campaignIds,
       });
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.campaign.list(orgId),
-      });
-      setIsSuccessModalOpen(true);
+    {
+      invalidateKeys: [QUERY_KEYS.campaign.list(orgId)],
+      userOnSuccess: () => {
+        setIsSuccessModalOpen(true);
+      },
+      userOnError: (error) => {
+        toast.error(error.message ?? "그룹 생성에 실패했습니다.");
+      },
     },
-    onError: (error) => {
-      toast.error(error.message ?? "그룹 생성에 실패했습니다.");
-    },
-  });
+  );
 
   const handleComplete = () => {
     if (!isFormValid) return;


### PR DESCRIPTION
## 🚨 관련 이슈

close #268 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

팀 공통 추상화 훅(`useCoreQuery`, `useCoreMutation`) 도입에 따라 담당 파일의 raw `useQuery` / `useMutation`을 교체했습니다.
### `WorkspaceSwitcher.tsx`
- `saveWorkspace` mutation → `useCoreMutation(saveSelectedWorkspace, …)` 적용
- `invalidateQueries` 수동 호출 → `invalidateKeys`로 이전
- Zustand 상태 업데이트·드롭다운 닫기 → `userOnSuccess`로 이전
- 불필요한 `useQueryClient` import 제거
### `useCampaignGroup.ts`
- Google / Naver / Meta 플랫폼 캠페인 목록 `useQuery` 3개 → `useCoreQuery` 교체
- `createGroup` mutation → `useCoreMutation<void, void>` 교체
- 캠페인 목록 invalidate → `invalidateKeys: [QUERY_KEYS.campaign.list(orgId)]`
- 성공 모달·에러 toast → `userOnSuccess` / `userOnError`로 이전
- 불필요한 `useQueryClient`, `IApiErrorResponse` import 제거

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 워크스페이스 전환/저장 흐름이 개선되어, 저장 중 상태 반영이 더 안정적으로 동작합니다.
  * 캠페인 그룹 목록 조회 및 그룹 생성 후 성공 안내와 데이터 갱신이 더 정확히 처리됩니다.
* **버그 수정**
  * 요청 응답 경합 상황에서 최신 결과만 반영되도록 하여, 잘못된 선택 정보나 UI 갱신 오류를 줄였습니다.
  * 캐시 갱신이 정리되어 생성/저장 후 관련 정보가 즉시 반영됩니다.
* **UI 개선**
  * 워크스페이스 저장 중 선택 버튼이 비활성화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->