### PR TITLE
[Feature/#287] 타임라인 성과 패널 일별 변화 추이 ApexChart 연동

### DIFF
--- a/src/components/timeline/TimelineBar.tsx
+++ b/src/components/timeline/TimelineBar.tsx
@@ -12,7 +12,7 @@ import {
   TIMELINE_ROW_HEIGHT,
   TIMELINE_ROW_OFFSET,
 } from "@/constants/timeline/layout";
-import { TIMELINE_PERFORMANCE_STATUS_STYLE } from "@/constants/timeline/statusStyle";
+import { resolveTimelinePerformanceStatusStyle } from "@/constants/timeline/statusStyle";
 
 import { DropdownMenu } from "../common/dropdownmenu/DropdownMenu";
 
@@ -42,7 +42,7 @@ export default function TimelineBar({
   onDelete,
 }: ITimelineBarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const status = TIMELINE_PERFORMANCE_STATUS_STYLE[bar.performanceStatus];
+  const status = resolveTimelinePerformanceStatusStyle(bar.performanceStatus);
   const left = (bar.colStart - 1) * colWidth;
   const columnSpan = Math.max(bar.colEnd - bar.colStart, 1);
   const width = columnSpan * colWidth;

--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -144,8 +144,8 @@ export default function TimelinePerformancePanel({
   const chartPeriodLabel =
     CHART_PERIOD_LABELS[chartPeriodIndex] ?? CHART_PERIOD_LABELS[0];
 
-  const chartMeric = data.metrics[0]?.metric ?? "CLICK";
-  const chartMetricLabel = getTimelineMetricLabel(chartMeric);
+  const chartMetric = data.metrics[0]?.metric ?? "CLICK";
+  const chartMetricLabel = getTimelineMetricLabel(chartMetric);
 
   const handlePrevChartPeriod = () => {
     setChartPeriodIndex((prev) =>
@@ -340,7 +340,7 @@ export default function TimelinePerformancePanel({
             </div>
             <TimelineDailyTrendChart
               dailyTrend={data.dailyTrend}
-              metric={chartMeric}
+              metric={chartMetric}
             />
           </div>
         </section>

--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 import type { TProviderType } from "@/types/dashboard/provider";
 import type { ITimelineSummaryPanelData } from "@/types/timeline/summary";
 import type { TTimelineViewUnit } from "@/types/timeline/ui";
-import { TIMELINE_PERFORMANCE_STATUS_STYLE } from "@/constants/timeline/statusStyle";
+import { resolveTimelinePerformanceStatusStyle } from "@/constants/timeline/statusStyle";
 
 import Badge from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
@@ -134,7 +134,9 @@ export default function TimelinePerformancePanel({
         ? "done"
         : "idle";
 
-  const statusStyle = TIMELINE_PERFORMANCE_STATUS_STYLE[data.performanceStatus];
+  const statusStyle = resolveTimelinePerformanceStatusStyle(
+    data.performanceStatus,
+  );
   const chartPeriodLabel =
     CHART_PERIOD_LABELS[chartPeriodIndex] ?? CHART_PERIOD_LABELS[0];
 

--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -7,6 +7,8 @@ import type { ITimelineSummaryPanelData } from "@/types/timeline/summary";
 import type { TTimelineViewUnit } from "@/types/timeline/ui";
 import { resolveTimelinePerformanceStatusStyle } from "@/constants/timeline/statusStyle";
 
+import { getTimelineMetricLabel } from "@/utils/timeline/buildTimelineChartSeries";
+
 import Badge from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
 import ChartLegend from "@/components/common/chart/ChartLegend";
@@ -14,6 +16,8 @@ import Drawer from "@/components/common/drawer/Drawer";
 import { DropdownMenu } from "@/components/common/dropdownmenu/DropdownMenu";
 import { Skeleton } from "@/components/common/skeleton/Skeleton";
 import TimelinePeriodSelector from "@/components/timeline/TimelinePeriodSelector";
+
+import TimelineDailyTrendChart from "./charts/TimelineDailyTrendChart";
 
 import ChevronRightIcon from "@/assets/icon/chevron/chevron-right.svg?react";
 import MoreIcon from "@/assets/icon/common/more.svg?react";
@@ -139,6 +143,9 @@ export default function TimelinePerformancePanel({
   );
   const chartPeriodLabel =
     CHART_PERIOD_LABELS[chartPeriodIndex] ?? CHART_PERIOD_LABELS[0];
+
+  const chartMeric = data.metrics[0]?.metric ?? "CLICK";
+  const chartMetricLabel = getTimelineMetricLabel(chartMeric);
 
   const handlePrevChartPeriod = () => {
     setChartPeriodIndex((prev) =>
@@ -317,8 +324,9 @@ export default function TimelinePerformancePanel({
                 <ChartLegend
                   className="[&_span]:text-text-body"
                   items={[
-                    { label: "클릭수", colorClass: "bg-primary-400" },
-                    { label: "예산 수정 시점", colorClass: "bg-info-red" },
+                    { label: chartMetricLabel, colorClass: "bg-primary-400" },
+                    // 예산 수정 시점은 일시 제외
+                    // { label: "예산 수정 시점", colorClass: "bg-info-red" },
                   ]}
                 />
               </div>
@@ -330,11 +338,10 @@ export default function TimelinePerformancePanel({
                 onNextPeriod={handleNextChartPeriod}
               />
             </div>
-            <div className="flex h-48 items-center justify-center rounded-2xl border border-dashed border-surface-300/70 bg-surface-200/30 px-4 py-6">
-              <span className="font-caption text-text-muted">
-                차트 영역 (ApexChart 연동예정)
-              </span>
-            </div>
+            <TimelineDailyTrendChart
+              dailyTrend={data.dailyTrend}
+              metric={chartMeric}
+            />
           </div>
         </section>
 

--- a/src/components/timeline/charts/TimelineDailyTrendChart.tsx
+++ b/src/components/timeline/charts/TimelineDailyTrendChart.tsx
@@ -1,0 +1,69 @@
+import { lazy, memo, Suspense, useMemo } from "react";
+
+import type {
+  ITimelineDailyTrend,
+  TTimelineMetric,
+} from "@/types/timeline/api";
+
+import { buildTimelineChartSeries } from "@/utils/timeline/buildTimelineChartSeries";
+
+import { Skeleton } from "@/components/common/skeleton/Skeleton";
+
+import { buildTimelineDailyTrendChartOptions } from "./timelineDailyTrendChart.config";
+
+const ReactApexChart = lazy(() => import("react-apexcharts"));
+
+interface ITimelineDailyTrendChartProps {
+  dailyTrend: ITimelineDailyTrend[];
+  metric: TTimelineMetric;
+  isLoading?: boolean;
+}
+
+const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
+  dailyTrend,
+  metric,
+  isLoading = false,
+}: ITimelineDailyTrendChartProps) {
+  const { series, yMax, xMin, xMax } = useMemo(
+    () => buildTimelineChartSeries(dailyTrend, metric),
+    [dailyTrend, metric],
+  );
+
+  const chartOptions = useMemo(
+    () => buildTimelineDailyTrendChartOptions({ metric, yMax, xMin, xMax }),
+    [metric, yMax, xMin, xMax],
+  );
+
+  if (isLoading) {
+    return <Skeleton className="h-48 w-full rounded-2xl" />;
+  }
+
+  if (dailyTrend.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-2xl border border-dashed border-surface-300/70 bg-surface-200/30 px-4 py-6">
+        <span className="font-caption text-text-muted">
+          표시할 일별 데이터가 없습니다
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-label="일별 변화 추이 차트"
+      role="img"
+      className="w-full [&_.apexcharts-toolbar]:hidden"
+    >
+      <Suspense fallback={<Skeleton className="h-48 w-full rounded-2xl" />}>
+        <ReactApexChart
+          type="area"
+          options={chartOptions}
+          series={series}
+          height={192}
+        />
+      </Suspense>
+    </div>
+  );
+});
+
+export default TimelineDailyTrendChart;

--- a/src/components/timeline/charts/timelineDailyTrendChart.config.ts
+++ b/src/components/timeline/charts/timelineDailyTrendChart.config.ts
@@ -1,0 +1,112 @@
+import type { ApexOptions } from "apexcharts";
+
+import type { TTimelineMetric } from "@/types/timeline/api";
+
+import {
+  formatCountChartAxis,
+  formatCountChartTooltip,
+} from "@/utils/dashboard/metricRegistry";
+
+// 차트 고유 ID
+export const TIMELINE_DAILY_TREND_CHART_ID = "timeline-daily-trend-chart";
+
+function formatDateAxisLabel(ts: number): string {
+  const d = new Date(ts);
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  return `${month}/${day}`;
+}
+
+function formatRoasAxis(val: number): string {
+  if (val <= 0) return "";
+  return `${val.toFixed(1)}`;
+}
+
+function formatRoasTooltop(val: number): string {
+  return `${val.toFixed(2)}배`;
+}
+
+export function buildTimelineDailyTrendChartOptions(params: {
+  metric: TTimelineMetric;
+  yMax: number;
+  xMin?: number;
+  xMax?: number;
+}): ApexOptions {
+  const { metric, yMax, xMin, xMax } = params;
+  const isRoas = metric === "ROAS";
+
+  return {
+    chart: {
+      id: TIMELINE_DAILY_TREND_CHART_ID,
+      type: "area",
+      toolbar: { show: false },
+      zoom: { enabled: false },
+      fontFamily: "Pretendard",
+      animations: { enabled: true, speed: 600 },
+    },
+    dataLabels: { enabled: false },
+
+    stroke: {
+      curve: "smooth",
+      width: 2,
+    },
+    fill: {
+      type: "gradient",
+      gradient: {
+        shadeIntensity: 1,
+        opacityFrom: 0.35,
+        opacityTo: 0.05,
+        stops: [20, 100],
+      },
+    },
+    colors: ["var(--color-primary-400)"],
+
+    markers: {
+      size: 0,
+      hover: { size: 5 },
+    },
+
+    xaxis: {
+      type: "numeric",
+      min: xMin,
+      max: xMax,
+      tickAmount: Math.min(6, 4),
+      labels: {
+        formatter: (val: string | number) => formatDateAxisLabel(Number(val)),
+        style: { colors: "var(--color-text-muted)", fontSize: "12px" },
+        rotate: 0,
+      },
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+      tooltip: { enabled: false },
+    },
+    yaxis: {
+      min: 0,
+      max: yMax,
+      tickAmount: 5,
+      labels: {
+        formatter: isRoas ? formatRoasAxis : formatCountChartAxis,
+        style: { colors: "var(--color-text-muted)", fontSize: "12px" },
+      },
+    },
+
+    grid: {
+      borderColor: "var(--color-surface-200)",
+      xaxis: { lines: { show: false } },
+      yaxis: { lines: { show: true } },
+      padding: { left: 8, right: 16 },
+    },
+
+    tooltip: {
+      x: {
+        formatter: (val: number) => formatDateAxisLabel(val),
+      },
+      y: {
+        formatter: (val: number) =>
+          isRoas ? formatRoasTooltop(val) : formatCountChartTooltip(val),
+      },
+      style: { fontFamily: "Pretendard" },
+    },
+    legend: { show: false },
+  };
+}

--- a/src/constants/timeline/statusStyle.ts
+++ b/src/constants/timeline/statusStyle.ts
@@ -1,4 +1,7 @@
-import type { TTimelinePerformanceStatus } from "@/types/timeline/api";
+import {
+  TIMELINE_PERFORMANCE_STATUS,
+  type TTimelinePerformanceStatus,
+} from "@/types/timeline/api";
 
 export interface ITimelinePerformanceStatusStyle {
   label: string;
@@ -51,3 +54,25 @@ export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
     ring: "ring-info-red",
   },
 };
+
+/** API가 null/미정의/알 수 없는 값을 줄 때 ON_TRACK으로 정규화 */
+export function resolveTimelinePerformanceStatus(
+  status: string | null | undefined,
+): TTimelinePerformanceStatus {
+  if (
+    status != null &&
+    (TIMELINE_PERFORMANCE_STATUS as readonly string[]).includes(status)
+  ) {
+    return status as TTimelinePerformanceStatus;
+  }
+  return "ON_TRACK";
+}
+
+/** 성과 상태 → 바/패널 스타일 (미정의 시 기본 스타일) */
+export function resolveTimelinePerformanceStatusStyle(
+  status: string | null | undefined,
+): ITimelinePerformanceStatusStyle {
+  return TIMELINE_PERFORMANCE_STATUS_STYLE[
+    resolveTimelinePerformanceStatus(status)
+  ];
+}

--- a/src/types/timeline/api.ts
+++ b/src/types/timeline/api.ts
@@ -36,7 +36,8 @@ export interface ITimelineListItem {
   name: string;
   startDate: string;
   endDate: string;
-  performanceStatus: TTimelinePerformanceStatus;
+  /** 성과 미산출 시 null일 수 있음 */
+  performanceStatus: TTimelinePerformanceStatus | null;
 }
 
 export interface ITimelineDailyTrend {
@@ -57,7 +58,8 @@ export interface ITimelineDetail {
   name: string;
   startDate: string;
   endDate: string;
-  performanceStatus: TTimelinePerformanceStatus;
+  /** 성과 미산출 시 null일 수 있음 */
+  performanceStatus: TTimelinePerformanceStatus | null;
   metrics: TTimelineMetric[];
   comparisonPeriodType: TTimelineComparisonPeriodType;
   summary: string;
@@ -82,7 +84,8 @@ export interface ITimelineMutationResponse {
   metrics: TTimelineMetric[];
   comparisonStartDate: string;
   comparisonEndDate: string;
-  performanceStatus: TTimelinePerformanceStatus;
+  /** 성과 미산출 시 null일 수 있음 */
+  performanceStatus: TTimelinePerformanceStatus | null;
   createdAt: string;
 }
 

--- a/src/types/timeline/summary.ts
+++ b/src/types/timeline/summary.ts
@@ -1,5 +1,6 @@
 import type { TProviderType } from "@/types/dashboard/provider";
 import type {
+  ITimelineDailyTrend,
   TTimelineMetric,
   TTimelinePerformanceStatus,
 } from "@/types/timeline/api";
@@ -27,4 +28,8 @@ export interface ITimelineSummaryPanelData {
   aiSummary: string;
   metrics: ITimelineSummaryMetric[];
   platformShare: ITimelineSummaryPlatformShare[];
+  /*일별 추이 차트용*/
+  dailyTrend: ITimelineDailyTrend[];
+  startDate: string;
+  endDate: string;
 }

--- a/src/types/timeline/timeline.mock.ts
+++ b/src/types/timeline/timeline.mock.ts
@@ -239,6 +239,9 @@ export const TIMELINE_SUMMARY_PANEL_MOCK: ITimelineSummaryPanelData = {
     { provider: "META", contributionRate: 0.31 },
     { provider: "NAVER", contributionRate: 0.17 },
   ],
+  dailyTrend: TIMELINE_DETAIL_MOCK.dailyTrend,
+  startDate: TIMELINE_DETAIL_MOCK.startDate,
+  endDate: TIMELINE_DETAIL_MOCK.endDate,
 };
 
 export const TIMELINE_SUMMARY_PANEL_NO_AI_MOCK: ITimelineSummaryPanelData = {

--- a/src/utils/timeline/buildTimelineChartSeries.ts
+++ b/src/utils/timeline/buildTimelineChartSeries.ts
@@ -49,7 +49,7 @@ export function calcChartYMax(values: number[], isRoas: boolean): number {
 
   if (max <= 0) return 1000;
   const magnitude = Math.pow(10, Math.floor(Math.log10(max)));
-  const unit = magnitude >= 1000 ? magnitude : 1000;
+  const unit = magnitude >= 1 ? magnitude : 1;
   return Math.ceil((max * 1.2) / unit) * unit;
 }
 

--- a/src/utils/timeline/buildTimelineChartSeries.ts
+++ b/src/utils/timeline/buildTimelineChartSeries.ts
@@ -1,0 +1,98 @@
+import type {
+  ITimelineDailyTrend,
+  TTimelineMetric,
+} from "@/types/timeline/api";
+import { TIMELINE_METRIC_OPTIONS } from "@/constants/timeline/formOptions";
+
+import { parseIsoDate } from "./period";
+
+const METRIC_FIELD_MAP: Record<
+  TTimelineMetric,
+  keyof Pick<
+    ITimelineDailyTrend,
+    "clicks" | "conversions" | "impressions" | "roas"
+  >
+> = {
+  CLICK: "clicks",
+  CONVERSION: "conversions",
+  IMPRESSION: "impressions",
+  ROAS: "roas",
+};
+
+export function getTimelineMetricLabel(metric: TTimelineMetric): string {
+  return (
+    TIMELINE_METRIC_OPTIONS.find((option) => option.value === metric)?.label ??
+    metric
+  );
+}
+
+function toChartTimestamp(isoDate: string): number {
+  return parseIsoDate(isoDate).getTime();
+}
+
+export function getMetricValueFromTrend(
+  row: ITimelineDailyTrend,
+  metric: TTimelineMetric,
+): number {
+  return row[METRIC_FIELD_MAP[metric]];
+}
+
+export function calcChartYMax(values: number[], isRoas: boolean): number {
+  const max = values.length > 0 ? Math.max(...values) : 0;
+
+  if (isRoas) {
+    if (max <= 0) return 1;
+    //ROAS는 소스 스케일 -> 0.5단위로 올림 + 20%여유
+    const padded = max * 1.2;
+    return Math.ceil(padded * 2) / 2;
+  }
+
+  if (max <= 0) return 1000;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(max)));
+  const unit = magnitude >= 1000 ? magnitude : 1000;
+  return Math.ceil((max * 1.2) / unit) * unit;
+}
+
+export interface ITimelineChartPoint {
+  x: number;
+  y: number;
+}
+
+export interface ITimelineChartSeriesItem {
+  name: string;
+  data: ITimelineChartPoint[];
+}
+
+export interface ITimelineChartSeriesResult {
+  series: ITimelineChartSeriesItem[];
+  yMax: number;
+  xMin: number | undefined;
+  xMax: number | undefined;
+  metricLabel: string;
+}
+
+export function buildTimelineChartSeries(
+  dailyTrend: ITimelineDailyTrend[],
+  metric: TTimelineMetric,
+): ITimelineChartSeriesResult {
+  const metricLabel = getTimelineMetricLabel(metric);
+  const points = dailyTrend.map((row) => ({
+    x: toChartTimestamp(row.date),
+    y: getMetricValueFromTrend(row, metric),
+  }));
+  const ys = points.map((p) => p.y);
+  const xs = points.map((p) => p.x);
+
+  return {
+    series: [
+      {
+        name: metricLabel,
+        data: points,
+      },
+    ],
+    yMax: calcChartYMax(ys, metric === "ROAS"),
+    xMin: xs.length > 0 ? Math.min(...xs) : undefined,
+    xMax: xs.length > 0 ? Math.max(...xs) : undefined,
+    metricLabel,
+  };
+}

--- a/src/utils/timeline/buildTimelineGrid.ts
+++ b/src/utils/timeline/buildTimelineGrid.ts
@@ -5,6 +5,7 @@ import type {
   ITimelineGridData,
   TTimelineViewUnit,
 } from "@/types/timeline/ui";
+import { resolveTimelinePerformanceStatus } from "@/constants/timeline/statusStyle";
 
 import {
   formatRange,
@@ -99,7 +100,9 @@ function layoutBars(
       id: item.timelineId,
       title: item.name,
       subtitle: formatRange(item.startDate, item.endDate),
-      performanceStatus: item.performanceStatus,
+      performanceStatus: resolveTimelinePerformanceStatus(
+        item.performanceStatus,
+      ),
       colStart,
       colEnd,
       row,

--- a/src/utils/timeline/buildTimelineSummaryPanel.ts
+++ b/src/utils/timeline/buildTimelineSummaryPanel.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/types/timeline/api";
 import type { ITimelineSummaryPanelData } from "@/types/timeline/summary";
 import { TIMELINE_METRIC_OPTIONS } from "@/constants/timeline/formOptions";
+import { resolveTimelinePerformanceStatus } from "@/constants/timeline/statusStyle";
 
 import { formatDot } from "./period";
 
@@ -54,7 +55,9 @@ export function buildTimelineSummaryPanel(
   return {
     timelineName: detail.name,
     periodLabel: `${formatDot(detail.startDate)} ~ ${formatDot(detail.endDate)}`,
-    performanceStatus: detail.performanceStatus,
+    performanceStatus: resolveTimelinePerformanceStatus(
+      detail.performanceStatus,
+    ),
     aiSummary: detail.summary ?? "",
     metrics,
     platformShare: detail.platformContributions.map((item) => ({

--- a/src/utils/timeline/buildTimelineSummaryPanel.ts
+++ b/src/utils/timeline/buildTimelineSummaryPanel.ts
@@ -64,5 +64,8 @@ export function buildTimelineSummaryPanel(
       provider: item.platform,
       contributionRate: item.contributionRate,
     })),
+    dailyTrend: detail.dailyTrend,
+    startDate: detail.startDate,
+    endDate: detail.endDate,
   };
 }


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #287 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `ITimelineSummaryPanelData`에 `dailyTrend`/`endDate`/`startDate` 추가하여 `buildTimelineSummaryPanel`에서 상세 API dailyTrend를 패널 props로 전달
- `buildtimelineChartSeries` util 함수로 `dailyTrend`를 Apex series(`{x, y}`)로 변환함
- `timelineDailyTrendChart.config.ts`, `TimelineDailyTrendChart` 추가하여 lazy Apex과 option 분리
- `TimelinePerformancePanel`에 기존에 placeholder로 구현되어있던 부분을 일별 추이 차트로 교체
- 대표 지표는 `metrics[0]`으로 설정하였고, 없으면 CLICK(클릭수)로. legend는 선택 지표 라벨과 동기화
- 예산 수정 시점은 현재 작업일정에 제외함. 해당 API에 대해서 BE와 추후 논의 필요함.
- 스토리북과 mock데이터에 dailyTrend도 반영했습니다.


## 😅 미완성 작업

- 패널 내 일/주/월 `TimelinePeriodSelector`와 차트 데이터 slice/집계 연동 (현재는 UI만 유지)

## 📢 논의 사항 및 참고 사항

- 예산 수정 시점 부분은 BE와 논의가 필요합니다!
- 현재는 일/주/월 선택이 아닌 일별로 연동만 했습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 타임라인 성과 패널에 일별 추이 차트를 추가했습니다.
  * 클릭수, 전환수, 노출수, ROAS 등 선택한 지표에 맞춰 차트 라벨과 값이 표시됩니다.
  * 데이터 로딩 중 및 데이터가 없을 때 안내 화면을 제공합니다.

* **개선 사항**
  * 성과 상태가 누락된 경우에도 기본 상태로 안정적으로 표시됩니다.
  * 성과가 아직 산출되지 않은 타임라인을 지원합니다.
  * 차트 범례와 날짜·수치 형식을 지표에 맞게 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->