### PR TITLE
[Feature/#292] DISCONNECTED 계정 재연동 및 해제 UI 정리

### DIFF
--- a/src/api/integration/platformAccounts.ts
+++ b/src/api/integration/platformAccounts.ts
@@ -18,3 +18,12 @@ export async function disconnectPlatformAccount(
 ): Promise<void> {
   await axiosInstance.delete(`/api/platform/${orgId}/accounts/${accountId}`);
 }
+
+export async function reconnectPlatformAccount(
+  orgId: number,
+  accountId: number,
+): Promise<void> {
+  await axiosInstance.patch(
+    `/api/platform/${orgId}/accounts/${accountId}/reconnect`,
+  );
+}

--- a/src/components/integration/PlatformDisconnectModal.tsx
+++ b/src/components/integration/PlatformDisconnectModal.tsx
@@ -60,9 +60,13 @@ export default function PlatformDisconnectModal({
               연동 계정 ·{" "}
               <span className="text-text-title">{externalAccountId}</span>
               <br />
+              <br />
             </>
           ) : null}
-          연동 해제 시 관련 데이터가 삭제되며 복구할 수 없습니다.
+          해제 후에도 기존 계정을 다시 연동할 수 있으며, 계정은 매일 새벽 4시에
+          삭제됩니다.
+          <br />
+          다른 계정으로 바꾸려면 계정 삭제가 완료된 후 새로 연동해 주세요.
         </p>
 
         <div className="flex gap-4">

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -60,18 +60,37 @@ function PlatformConnectionMeta({
   status,
   syncedAt,
   externalAccountId,
+  platformAccountId,
   tokenExpireAt,
 }: Pick<
   IPlatformConnectionItem,
-  "status" | "syncedAt" | "externalAccountId" | "tokenExpireAt"
+  | "status"
+  | "syncedAt"
+  | "externalAccountId"
+  | "platformAccountId"
+  | "tokenExpireAt"
 >) {
   const syncedLabel = formatConnectionDateTime(syncedAt);
   const expireLabel = formatConnectionDate(tokenExpireAt);
   const expireTone = getTokenExpireTone(tokenExpireAt);
+  const isSoftDisconnected =
+    status === "disconnected" && platformAccountId != null;
 
   return (
     <div className="flex w-full flex-col gap-2">
-      {status === "disconnected" ? (
+      {isSoftDisconnected ? (
+        externalAccountId ? (
+          <p className="min-w-0 font-body2 text-text-muted">
+            <span>연동 계정 · </span>
+            <span
+              className="truncate text-text-title"
+              title={externalAccountId}
+            >
+              {externalAccountId}
+            </span>
+          </p>
+        ) : null
+      ) : status === "disconnected" ? (
         <>
           <p className="font-body2 text-text-muted/60">
             <span>마지막 동기화 · </span>
@@ -156,6 +175,7 @@ function PlatformIntegrationCard({
         status={status}
         syncedAt={syncedAt}
         externalAccountId={externalAccountId}
+        platformAccountId={platformAccountId}
         tokenExpireAt={tokenExpireAt}
       />
 

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -126,6 +126,7 @@ function PlatformIntegrationCard({
   status,
   syncedAt,
   externalAccountId,
+  platformAccountId,
   tokenExpireAt,
   errorMessage,
   onConnect,
@@ -169,8 +170,20 @@ function PlatformIntegrationCard({
       <div className="mt-auto flex w-full flex-col gap-4">
         {status === "disconnected" ? (
           <p className="font-body2 text-text-muted/80">
-            광고 계정을 연동하면 대시보드와 캠페인에서 데이터를 확인할 수
-            있습니다.
+            {platformAccountId != null ? (
+              <>
+                기존 계정을 다시 연동하면 대시보드와 캠페인에서 데이터를 확인할
+                수 있습니다.
+                <br />
+                계정이 완전히 삭제되기 전까지는 기존 계정 복구가 가능하며,
+                현재는 다른 계정 연동이 불가능합니다.
+              </>
+            ) : (
+              <>
+                광고 계정을 연동하면 대시보드와 캠페인에서 데이터를 확인할 수
+                있습니다.
+              </>
+            )}
           </p>
         ) : null}
 
@@ -199,7 +212,7 @@ function PlatformIntegrationCard({
                 className="min-w-0 flex-1"
                 onClick={onDisconnect}
               >
-                연결 해제
+                연동 해제
               </Button>
             </>
           ) : null}

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -153,6 +153,10 @@ function PlatformIntegrationCard({
   onDisconnect,
 }: TProps) {
   const label = PLATFORM_MAP[provider] ?? provider;
+  const statusLabel =
+    status === "disconnected" && platformAccountId != null
+      ? "연동 해제"
+      : STATUS_LABEL[status];
 
   return (
     <div className="flex h-full min-h-70 w-full flex-col gap-5 rounded-3xl bg-surface-100 p-8 shadow-Soft">
@@ -167,7 +171,7 @@ function PlatformIntegrationCard({
           variant={CONNECTION_STATUS_BADGE[status]}
           className="h-8 shrink-0 font-body2"
         >
-          {STATUS_LABEL[status]}
+          {statusLabel}
         </Badge>
       </div>
 

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -54,6 +54,7 @@ type TProps = IPlatformConnectionItem & {
   onConnect?: () => void;
   onReconnect?: () => void;
   onDisconnect?: () => void;
+  isConnectLoading?: boolean;
 };
 
 function PlatformConnectionMeta({
@@ -168,6 +169,7 @@ function PlatformIntegrationCard({
   onConnect,
   onReconnect,
   onDisconnect,
+  isConnectLoading = false,
 }: TProps) {
   const label = PLATFORM_MAP[provider] ?? provider;
   const statusLabel =
@@ -230,8 +232,15 @@ function PlatformIntegrationCard({
 
         <div className="flex w-full flex-wrap gap-4">
           {status === "disconnected" ? (
-            <Button type="button" size="big" fullWidth onClick={onConnect}>
-              연동하기
+            <Button
+              type="button"
+              size="big"
+              fullWidth
+              onClick={onConnect}
+              isLoading={isConnectLoading}
+              disabled={isConnectLoading}
+            >
+              {isConnectLoading ? "연동 중..." : "연동하기"}
             </Button>
           ) : null}
 

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -79,17 +79,29 @@ function PlatformConnectionMeta({
   return (
     <div className="flex w-full flex-col gap-2">
       {isSoftDisconnected ? (
-        externalAccountId ? (
-          <p className="min-w-0 font-body2 text-text-muted">
-            <span>연동 계정 · </span>
-            <span
-              className="truncate text-text-title"
-              title={externalAccountId}
-            >
-              {externalAccountId}
-            </span>
+        <>
+          {externalAccountId ? (
+            <p className="min-w-0 font-body2 text-text-muted">
+              <span>연동 계정 · </span>
+              <span
+                className="truncate text-text-title"
+                title={externalAccountId}
+              >
+                {externalAccountId}
+              </span>
+            </p>
+          ) : null}
+          <p className="font-body2 text-text-muted">
+            <span>토큰 만료 예정 · </span>
+            {expireLabel ? (
+              <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
+                {expireLabel}
+              </span>
+            ) : (
+              <span className="text-text-muted/60">—</span>
+            )}
           </p>
-        ) : null
+        </>
       ) : status === "disconnected" ? (
         <>
           <p className="font-body2 text-text-muted/60">
@@ -133,7 +145,12 @@ function PlatformConnectionMeta({
                 {expireLabel}
               </span>
             </p>
-          ) : null}
+          ) : (
+            <p className="font-body2 text-text-muted">
+              <span>토큰 만료 예정 · </span>
+              <span className="text-text-muted/60">—</span>
+            </p>
+          )}
         </>
       )}
     </div>

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -97,6 +97,31 @@ export default function PlatformIntegrationsPage() {
 
   useIntegrationOAuthReturn(orgId);
 
+  const startNewConnect = async (provider: TIntegrationProvider) => {
+    if (orgId == null) {
+      toast.error("워크스페이스를 선택해 주세요.");
+      return;
+    }
+
+    if (provider === "NAVER") {
+      setNaverModalMode("connect");
+      setNaverCustomerId(undefined);
+      setIsNaverModalOpen(true);
+      return;
+    }
+
+    try {
+      await startPlatformConnect(provider, orgId);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : ((err as IApiErrorResponse)?.message ??
+            "플랫폼 연동을 시작하지 못했습니다. 다시 시도해 주세요.");
+      toast.error(message);
+    }
+  };
+
   const handleConnect = async (provider: TIntegrationProvider) => {
     if (orgId == null) {
       toast.error("워크스페이스를 선택해 주세요.");
@@ -104,7 +129,6 @@ export default function PlatformIntegrationsPage() {
     }
 
     const item = platformConnections.find((p) => p.provider === provider);
-    // DISCONNECTED
     if (item?.status === "disconnected" && item.platformAccountId != null) {
       if (reconnectMutation.isPending) return;
       reconnectMutation.mutate({
@@ -120,23 +144,12 @@ export default function PlatformIntegrationsPage() {
       if (naverItem?.platformAccountId != null) {
         setNaverModalMode("reconnect");
         setNaverCustomerId(naverItem.externalAccountId);
-      } else {
-        setNaverModalMode("connect");
-        setNaverCustomerId(undefined);
+        setIsNaverModalOpen(true);
+        return;
       }
-      setIsNaverModalOpen(true);
-      return;
     }
-    try {
-      await startPlatformConnect(provider, orgId);
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : ((err as IApiErrorResponse)?.message ??
-            "플랫폼 연동을 시작하지 못했습니다. 다시 시도해 주세요.");
-      toast.error(message);
-    }
+
+    await startNewConnect(provider);
   };
 
   const handleDisconnect = (item: IPlatformConnectionItem) => {

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -202,6 +202,11 @@ export default function PlatformIntegrationsPage() {
                   onConnect={() => handleConnect(item.provider)}
                   onReconnect={() => handleConnect(item.provider)}
                   onDisconnect={() => handleDisconnect(item)}
+                  isConnectLoading={
+                    reconnectMutation.isPending &&
+                    reconnectMutation.variables?.accountId ===
+                      item.platformAccountId
+                  }
                 />
               </li>
             ))}

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -23,7 +23,10 @@ import {
   KakaoUpcomingCard,
 } from "@/components/integration/UpcomingPlatformCard";
 
-import { disconnectPlatformAccount } from "@/api/integration/platformAccounts";
+import {
+  disconnectPlatformAccount,
+  reconnectPlatformAccount,
+} from "@/api/integration/platformAccounts";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
@@ -73,6 +76,25 @@ export default function PlatformIntegrationsPage() {
     },
   );
 
+  const reconnectMutation = useCoreMutation<
+    void,
+    { orgId: number; accountId: number }
+  >(
+    ({ orgId: requestOrgId, accountId }) =>
+      reconnectPlatformAccount(requestOrgId, accountId),
+    {
+      userOnSuccess: async (_, { orgId: requestOrgId }) => {
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.platform.connections(requestOrgId),
+        });
+        toast.success("광고 계정을 다시 연동했습니다.");
+      },
+      userOnError: (apiError) => {
+        toast.error(apiError.message ?? "재연동에 실패했습니다.");
+      },
+    },
+  );
+
   useIntegrationOAuthReturn(orgId);
 
   const handleConnect = async (provider: TIntegrationProvider) => {
@@ -80,6 +102,18 @@ export default function PlatformIntegrationsPage() {
       toast.error("워크스페이스를 선택해 주세요.");
       return;
     }
+
+    const item = platformConnections.find((p) => p.provider === provider);
+    // DISCONNECTED
+    if (item?.status === "disconnected" && item.platformAccountId != null) {
+      if (reconnectMutation.isPending) return;
+      reconnectMutation.mutate({
+        orgId,
+        accountId: item.platformAccountId,
+      });
+      return;
+    }
+
     if (provider === "NAVER") {
       const naverItem = platformConnections.find((p) => p.provider === "NAVER");
 

--- a/src/types/integration/platformConnection.ts
+++ b/src/types/integration/platformConnection.ts
@@ -3,7 +3,11 @@ import type { TProvider } from "@/types/ads/campaign";
 export type TIntegrationProvider = TProvider;
 
 /** 목록 API `platformAccounts[].status` */
-export type TPlatformAccountApiStatus = "ACTIVE" | "EXPIRED" | "INACTIVE";
+export type TPlatformAccountApiStatus =
+  | "ACTIVE"
+  | "EXPIRED"
+  | "INACTIVE"
+  | "DISCONNECTED";
 
 export type TPlatformAuthType = "OAUTH";
 

--- a/src/utils/integration/mapPlatformAccounts.ts
+++ b/src/utils/integration/mapPlatformAccounts.ts
@@ -106,7 +106,7 @@ function mapApiStatusToUi(
   if (account.status === "ACTIVE") {
     return "connected";
   }
-  return "disconnected";
+  return "disconnected"; // DISCONNECTED, INACTIVE 포함
 }
 
 function mapAccountToConnection(


### PR DESCRIPTION
## 🚨 관련 이슈

close #292 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [X] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- **재연동 API**
  - 목록 API status에 `DISCONNECTED` 반영
  - PATCH `/api/platform/{orgId}/accounts/{accountId}/reconnect` 추가·연동

- **연동 플로우**
  - 해제(`DISCONNECTED`) 계정에서 「연동하기」 → OAuth/키 입력 없이 reconnect로 기존 계정 복구
  - 계정 없음 → 기존처럼 신규 연동 (`startNewConnect`)
  - 다른 계정 교체는 BE 정책상 삭제 완료 후 신규 연동으로만 가능

- **안내 UI**
  - 연동 해제 모달: 복구 가능, 새벽 4시 삭제, 다른 계정은 삭제 후 연동 안내
  - 해제 카드: 복구 가능 / 다른 계정 연동 불가 문구

- **카드 표시**
  - 뱃지: `미연동`, `연동 해제` 구분 (색상 동일)
  - 해제 계정: 연동 계정·토큰 만료 예정 표시
  - tokenExpireAt null이면 —로 표시

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
- Google OAuth 복귀 URL은 BE에 수정 요청해 두었습니다.
- 토큰 만료 후 재연동에 관한 내용은 문의 예정입니다. 


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 연결이 해제된 플랫폼 계정을 같은 계정으로 다시 “재연동”할 수 있습니다.
  - 재연동 진행 중 상태가 반영되며, 성공/실패 결과를 알림으로 확인할 수 있습니다.

- **개선 사항**
  - 연결 해제 상태에서 기존 계정 복구 가능 여부와 계정 삭제/재연동 가능 시점 안내 문구가 더 명확해졌습니다.
  - 연결 상태 및 토큰 만료 정보 표시가 조건에 따라 더 일관되게 렌더링됩니다(예: 값이 없으면 `—` 표시).
  - 버튼 라벨이 “연결 해제”에서 “연동 해제”로 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->