### PR TITLE
[Feature/#296] 타임라인 성과 패널 차트 일/주/월 기간 연동 

### DIFF
--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -1,5 +1,5 @@
 import type { FC, SVGProps } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 import type { TProviderType } from "@/types/dashboard/provider";
@@ -8,6 +8,7 @@ import type { TTimelineViewUnit } from "@/types/timeline/ui";
 import { resolveTimelinePerformanceStatusStyle } from "@/constants/timeline/statusStyle";
 
 import { getTimelineMetricLabel } from "@/utils/timeline/buildTimelineChartSeries";
+import { sliceDailyTrendByPeriod } from "@/utils/timeline/sliceDailyTrendByPeriod";
 
 import Badge from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
@@ -27,8 +28,6 @@ import MetaWordmark from "@/assets/logo/social-logo/wordmark/meta-wordmark.svg?r
 import NaverWordmark from "@/assets/logo/social-logo/wordmark/naver-wordmark.svg?react";
 
 type TAiSummaryUiState = "idle" | "loading" | "done";
-
-const CHART_PERIOD_LABELS = ["오늘", "1월 21일 → 25일", "1월 14일 → 20일"];
 
 const SECTION_SHELL_CLASS =
   "rounded-3xl border border-surface-300/70 bg-surface-100";
@@ -141,22 +140,33 @@ export default function TimelinePerformancePanel({
   const statusStyle = resolveTimelinePerformanceStatusStyle(
     data.performanceStatus,
   );
-  const chartPeriodLabel =
-    CHART_PERIOD_LABELS[chartPeriodIndex] ?? CHART_PERIOD_LABELS[0];
 
   const chartMetric = data.metrics[0]?.metric ?? "CLICK";
   const chartMetricLabel = getTimelineMetricLabel(chartMetric);
 
+  const { periodLabel: chartPeriodLabel, slicedTrend } = useMemo(
+    () =>
+      sliceDailyTrendByPeriod({
+        dailyTrend: data.dailyTrend,
+        viewUnit,
+        periodIndex: chartPeriodIndex,
+        timelineStartDate: data.startDate,
+        timelineEndDate: data.endDate,
+      }),
+    [data.dailyTrend, data.startDate, data.endDate, viewUnit, chartPeriodIndex],
+  );
+
+  const handleViewUnitChange = (unit: TTimelineViewUnit) => {
+    setViewUnit(unit);
+    setChartPeriodIndex(0); //단위 바꾸면 현재로 리셋되도록
+  };
+
   const handlePrevChartPeriod = () => {
-    setChartPeriodIndex((prev) =>
-      prev === 0 ? CHART_PERIOD_LABELS.length - 1 : prev - 1,
-    );
+    setChartPeriodIndex((prev) => prev + 1);
   };
 
   const handleNextChartPeriod = () => {
-    setChartPeriodIndex((prev) =>
-      prev === CHART_PERIOD_LABELS.length - 1 ? 0 : prev + 1,
-    );
+    setChartPeriodIndex((prev) => Math.max(0, prev - 1));
   };
 
   const menuItems = [
@@ -333,13 +343,13 @@ export default function TimelinePerformancePanel({
               <TimelinePeriodSelector
                 viewUnit={viewUnit}
                 periodLabel={chartPeriodLabel}
-                onViewUnitChange={setViewUnit}
+                onViewUnitChange={handleViewUnitChange}
                 onPrevPeriod={handlePrevChartPeriod}
                 onNextPeriod={handleNextChartPeriod}
               />
             </div>
             <TimelineDailyTrendChart
-              dailyTrend={data.dailyTrend}
+              dailyTrend={slicedTrend}
               metric={chartMetric}
             />
           </div>

--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -8,7 +8,10 @@ import type { TTimelineViewUnit } from "@/types/timeline/ui";
 import { resolveTimelinePerformanceStatusStyle } from "@/constants/timeline/statusStyle";
 
 import { getTimelineMetricLabel } from "@/utils/timeline/buildTimelineChartSeries";
-import { sliceDailyTrendByPeriod } from "@/utils/timeline/sliceDailyTrendByPeriod";
+import {
+  canGoToPrevChartPeriod,
+  sliceDailyTrendByPeriod,
+} from "@/utils/timeline/sliceDailyTrendByPeriod";
 
 import Badge from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
@@ -161,12 +164,21 @@ export default function TimelinePerformancePanel({
     [data.dailyTrend, data.startDate, data.endDate, viewUnit, chartPeriodIndex],
   );
 
+  const canGoPrev = canGoToPrevChartPeriod({
+    viewUnit,
+    periodIndex: chartPeriodIndex,
+    timelineStartDate: data.startDate,
+  });
+
+  const canGoNext = chartPeriodIndex > 0;
+
   const handleViewUnitChange = (unit: TTimelineViewUnit) => {
     setViewUnit(unit);
     setChartPeriodIndex(0); //단위 바꾸면 현재로 리셋되도록
   };
 
   const handlePrevChartPeriod = () => {
+    if (!canGoPrev) return;
     setChartPeriodIndex((prev) => prev + 1);
   };
 
@@ -351,6 +363,8 @@ export default function TimelinePerformancePanel({
                 onViewUnitChange={handleViewUnitChange}
                 onPrevPeriod={handlePrevChartPeriod}
                 onNextPeriod={handleNextChartPeriod}
+                disablePrev={!canGoPrev}
+                disableNext={!canGoNext}
               />
             </div>
             <TimelineDailyTrendChart

--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -356,6 +356,7 @@ export default function TimelinePerformancePanel({
             <TimelineDailyTrendChart
               dailyTrend={slicedTrend}
               metric={chartMetric}
+              viewUnit={viewUnit}
               rangeStart={chartRangeStart}
               rangeEnd={chartRangeEnd}
             />

--- a/src/components/timeline/TimelinePerformancePanel.tsx
+++ b/src/components/timeline/TimelinePerformancePanel.tsx
@@ -144,7 +144,12 @@ export default function TimelinePerformancePanel({
   const chartMetric = data.metrics[0]?.metric ?? "CLICK";
   const chartMetricLabel = getTimelineMetricLabel(chartMetric);
 
-  const { periodLabel: chartPeriodLabel, slicedTrend } = useMemo(
+  const {
+    periodLabel: chartPeriodLabel,
+    slicedTrend,
+    rangeStart: chartRangeStart,
+    rangeEnd: chartRangeEnd,
+  } = useMemo(
     () =>
       sliceDailyTrendByPeriod({
         dailyTrend: data.dailyTrend,
@@ -351,6 +356,8 @@ export default function TimelinePerformancePanel({
             <TimelineDailyTrendChart
               dailyTrend={slicedTrend}
               metric={chartMetric}
+              rangeStart={chartRangeStart}
+              rangeEnd={chartRangeEnd}
             />
           </div>
         </section>

--- a/src/components/timeline/TimelinePeriodSelector.tsx
+++ b/src/components/timeline/TimelinePeriodSelector.tsx
@@ -55,6 +55,8 @@ interface ITimelinePeriodNavProps {
   onPrevPeriod: () => void;
   onNextPeriod: () => void;
   onGoToToday?: () => void;
+  disablePrev?: boolean;
+  disableNext?: boolean;
   className?: string;
 }
 
@@ -63,6 +65,8 @@ export function TimelinePeriodNav({
   onPrevPeriod,
   onNextPeriod,
   onGoToToday,
+  disablePrev = false,
+  disableNext = false,
   className,
 }: ITimelinePeriodNavProps) {
   return (
@@ -75,6 +79,7 @@ export function TimelinePeriodNav({
       <button
         type="button"
         aria-label="이전 기간"
+        disabled={disablePrev}
         onClick={onPrevPeriod}
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-muted transition-ui-smooth hover:bg-surface-200 hover:text-text-title"
       >
@@ -88,6 +93,7 @@ export function TimelinePeriodNav({
       <button
         type="button"
         aria-label="다음 기간"
+        disabled={disableNext}
         onClick={onNextPeriod}
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-muted transition-ui-smooth hover:bg-surface-200 hover:text-text-title"
       >
@@ -117,6 +123,8 @@ interface ITimelinePeriodSelectorProps {
   onPrevPeriod: () => void;
   onNextPeriod: () => void;
   onGoToToday?: () => void;
+  disablePrev?: boolean;
+  disableNext?: boolean;
   className?: string;
 }
 
@@ -127,6 +135,8 @@ export default function TimelinePeriodSelector({
   onPrevPeriod,
   onNextPeriod,
   onGoToToday,
+  disablePrev,
+  disableNext,
   className,
 }: ITimelinePeriodSelectorProps) {
   return (
@@ -140,6 +150,8 @@ export default function TimelinePeriodSelector({
         onPrevPeriod={onPrevPeriod}
         onNextPeriod={onNextPeriod}
         onGoToToday={onGoToToday}
+        disablePrev={disablePrev}
+        disableNext={disableNext}
       />
     </div>
   );

--- a/src/components/timeline/charts/TimelineDailyTrendChart.tsx
+++ b/src/components/timeline/charts/TimelineDailyTrendChart.tsx
@@ -24,14 +24,21 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
   metric,
   isLoading = false,
 }: ITimelineDailyTrendChartProps) {
-  const { series, yMax, xMin, xMax } = useMemo(
+  const { series, yMax, xMin, xMax, pointCount } = useMemo(
     () => buildTimelineChartSeries(dailyTrend, metric),
     [dailyTrend, metric],
   );
 
   const chartOptions = useMemo(
-    () => buildTimelineDailyTrendChartOptions({ metric, yMax, xMin, xMax }),
-    [metric, yMax, xMin, xMax],
+    () =>
+      buildTimelineDailyTrendChartOptions({
+        metric,
+        yMax,
+        xMin,
+        xMax,
+        pointCount,
+      }),
+    [metric, yMax, xMin, xMax, pointCount],
   );
 
   if (isLoading) {

--- a/src/components/timeline/charts/TimelineDailyTrendChart.tsx
+++ b/src/components/timeline/charts/TimelineDailyTrendChart.tsx
@@ -4,6 +4,7 @@ import type {
   ITimelineDailyTrend,
   TTimelineMetric,
 } from "@/types/timeline/api";
+import type { TTimelineViewUnit } from "@/types/timeline/ui";
 
 import { buildTimelineChartSeries } from "@/utils/timeline/buildTimelineChartSeries";
 import { fillDailyTrendRange } from "@/utils/timeline/fillDailyTrendRange";
@@ -17,6 +18,7 @@ const ReactApexChart = lazy(() => import("react-apexcharts"));
 interface ITimelineDailyTrendChartProps {
   dailyTrend: ITimelineDailyTrend[];
   metric: TTimelineMetric;
+  viewUnit?: TTimelineViewUnit;
   /** 선택 구간 시작 — 있으면 구간 전체 날짜를 채움 */
   rangeStart?: Date | null;
   /** 선택 구간 끝 */
@@ -27,6 +29,7 @@ interface ITimelineDailyTrendChartProps {
 const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
   dailyTrend,
   metric,
+  viewUnit = "WEEK",
   rangeStart = null,
   rangeEnd = null,
   isLoading = false,
@@ -38,9 +41,9 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
     return dailyTrend;
   }, [dailyTrend, rangeStart, rangeEnd]);
 
-  const { series, categories, yMax, pointCount } = useMemo(
-    () => buildTimelineChartSeries(filledRows, metric),
-    [filledRows, metric],
+  const { series, categories, tooltipCategories, yMax, pointCount } = useMemo(
+    () => buildTimelineChartSeries(filledRows, metric, viewUnit),
+    [filledRows, metric, viewUnit],
   );
 
   const chartOptions = useMemo(
@@ -49,9 +52,10 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
         metric,
         yMax,
         categories,
+        tooltipCategories,
         pointCount,
       }),
-    [metric, yMax, categories, pointCount],
+    [metric, yMax, categories, tooltipCategories, pointCount],
   );
 
   if (isLoading) {

--- a/src/components/timeline/charts/TimelineDailyTrendChart.tsx
+++ b/src/components/timeline/charts/TimelineDailyTrendChart.tsx
@@ -34,12 +34,14 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
   rangeEnd = null,
   isLoading = false,
 }: ITimelineDailyTrendChartProps) {
+  const hasRange = rangeStart != null && rangeEnd != null;
+
   const filledRows = useMemo(() => {
-    if (rangeStart && rangeEnd) {
+    if (hasRange) {
       return fillDailyTrendRange(dailyTrend, rangeStart, rangeEnd);
     }
     return dailyTrend;
-  }, [dailyTrend, rangeStart, rangeEnd]);
+  }, [dailyTrend, rangeStart, rangeEnd, hasRange]);
 
   const { series, categories, tooltipCategories, yMax, pointCount } = useMemo(
     () => buildTimelineChartSeries(filledRows, metric, viewUnit),
@@ -62,7 +64,7 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
     return <Skeleton className="h-48 w-full rounded-2xl" />;
   }
 
-  if (dailyTrend.length === 0 || pointCount === 0) {
+  if (!hasRange && (dailyTrend.length === 0 || pointCount === 0)) {
     return (
       <div className="flex h-48 items-center justify-center rounded-2xl border border-dashed border-surface-300/70 bg-surface-200/30 px-4 py-6">
         <span className="font-caption text-text-muted">
@@ -84,6 +86,7 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
           options={chartOptions}
           series={series}
           height={192}
+          key={`${viewUnit}-${rangeStart?.getTime()} - ${rangeEnd?.getTime()}`}
         />
       </Suspense>
     </div>

--- a/src/components/timeline/charts/TimelineDailyTrendChart.tsx
+++ b/src/components/timeline/charts/TimelineDailyTrendChart.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@/types/timeline/api";
 
 import { buildTimelineChartSeries } from "@/utils/timeline/buildTimelineChartSeries";
+import { fillDailyTrendRange } from "@/utils/timeline/fillDailyTrendRange";
 
 import { Skeleton } from "@/components/common/skeleton/Skeleton";
 
@@ -16,17 +17,30 @@ const ReactApexChart = lazy(() => import("react-apexcharts"));
 interface ITimelineDailyTrendChartProps {
   dailyTrend: ITimelineDailyTrend[];
   metric: TTimelineMetric;
+  /** 선택 구간 시작 — 있으면 구간 전체 날짜를 채움 */
+  rangeStart?: Date | null;
+  /** 선택 구간 끝 */
+  rangeEnd?: Date | null;
   isLoading?: boolean;
 }
 
 const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
   dailyTrend,
   metric,
+  rangeStart = null,
+  rangeEnd = null,
   isLoading = false,
 }: ITimelineDailyTrendChartProps) {
-  const { series, yMax, xMin, xMax, pointCount } = useMemo(
-    () => buildTimelineChartSeries(dailyTrend, metric),
-    [dailyTrend, metric],
+  const filledRows = useMemo(() => {
+    if (rangeStart && rangeEnd) {
+      return fillDailyTrendRange(dailyTrend, rangeStart, rangeEnd);
+    }
+    return dailyTrend;
+  }, [dailyTrend, rangeStart, rangeEnd]);
+
+  const { series, categories, yMax, pointCount } = useMemo(
+    () => buildTimelineChartSeries(filledRows, metric),
+    [filledRows, metric],
   );
 
   const chartOptions = useMemo(
@@ -34,18 +48,17 @@ const TimelineDailyTrendChart = memo(function TimelineDailyTrendChart({
       buildTimelineDailyTrendChartOptions({
         metric,
         yMax,
-        xMin,
-        xMax,
+        categories,
         pointCount,
       }),
-    [metric, yMax, xMin, xMax, pointCount],
+    [metric, yMax, categories, pointCount],
   );
 
   if (isLoading) {
     return <Skeleton className="h-48 w-full rounded-2xl" />;
   }
 
-  if (dailyTrend.length === 0) {
+  if (dailyTrend.length === 0 || pointCount === 0) {
     return (
       <div className="flex h-48 items-center justify-center rounded-2xl border border-dashed border-surface-300/70 bg-surface-200/30 px-4 py-6">
         <span className="font-caption text-text-muted">

--- a/src/components/timeline/charts/timelineDailyTrendChart.config.ts
+++ b/src/components/timeline/charts/timelineDailyTrendChart.config.ts
@@ -31,9 +31,12 @@ export function buildTimelineDailyTrendChartOptions(params: {
   yMax: number;
   xMin?: number;
   xMax?: number;
+  /** 1점이면 선이 없으므로 마커를 항상 표시 */
+  pointCount?: number;
 }): ApexOptions {
-  const { metric, yMax, xMin, xMax } = params;
+  const { metric, yMax, xMin, xMax, pointCount = 0 } = params;
   const isRoas = metric === "ROAS";
+  const isSinglePoint = pointCount === 1;
 
   return {
     chart: {
@@ -62,8 +65,9 @@ export function buildTimelineDailyTrendChartOptions(params: {
     colors: ["var(--color-primary-400)"],
 
     markers: {
-      size: 0,
-      hover: { size: 5 },
+      // 기본은 선만, 단일 점은 선이 없어 마커를 항상 보이게
+      size: isSinglePoint ? 5 : 0,
+      hover: { size: isSinglePoint ? 7 : 5 },
     },
 
     xaxis: {

--- a/src/components/timeline/charts/timelineDailyTrendChart.config.ts
+++ b/src/components/timeline/charts/timelineDailyTrendChart.config.ts
@@ -23,10 +23,18 @@ export function buildTimelineDailyTrendChartOptions(params: {
   metric: TTimelineMetric;
   yMax: number;
   categories: string[];
+  /** 미전달 시 categories와 동일 */
+  tooltipCategories?: string[];
   /** 1점이면 선이 없으므로 마커를 항상 표시 */
   pointCount?: number;
 }): ApexOptions {
-  const { metric, yMax, categories, pointCount = 0 } = params;
+  const {
+    metric,
+    yMax,
+    categories,
+    tooltipCategories = categories,
+    pointCount = 0,
+  } = params;
   const isRoas = metric === "ROAS";
   const isSinglePoint = pointCount === 1;
 
@@ -92,7 +100,8 @@ export function buildTimelineDailyTrendChartOptions(params: {
 
     tooltip: {
       x: {
-        formatter: (_val, opts) => categories[opts?.dataPointIndex ?? 0] ?? "",
+        formatter: (_val, opts) =>
+          tooltipCategories[opts?.dataPointIndex ?? 0] ?? "",
       },
       y: {
         formatter: (val: number) => {

--- a/src/components/timeline/charts/timelineDailyTrendChart.config.ts
+++ b/src/components/timeline/charts/timelineDailyTrendChart.config.ts
@@ -10,31 +10,23 @@ import {
 // 차트 고유 ID
 export const TIMELINE_DAILY_TREND_CHART_ID = "timeline-daily-trend-chart";
 
-function formatDateAxisLabel(ts: number): string {
-  const d = new Date(ts);
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  return `${month}/${day}`;
-}
-
 function formatRoasAxis(val: number): string {
   if (val <= 0) return "";
   return `${val.toFixed(1)}`;
 }
 
-function formatRoasTooltop(val: number): string {
+function formatRoasTooltip(val: number): string {
   return `${val.toFixed(2)}배`;
 }
 
 export function buildTimelineDailyTrendChartOptions(params: {
   metric: TTimelineMetric;
   yMax: number;
-  xMin?: number;
-  xMax?: number;
+  categories: string[];
   /** 1점이면 선이 없으므로 마커를 항상 표시 */
   pointCount?: number;
 }): ApexOptions {
-  const { metric, yMax, xMin, xMax, pointCount = 0 } = params;
+  const { metric, yMax, categories, pointCount = 0 } = params;
   const isRoas = metric === "ROAS";
   const isSinglePoint = pointCount === 1;
 
@@ -65,20 +57,17 @@ export function buildTimelineDailyTrendChartOptions(params: {
     colors: ["var(--color-primary-400)"],
 
     markers: {
-      // 기본은 선만, 단일 점은 선이 없어 마커를 항상 보이게
       size: isSinglePoint ? 5 : 0,
       hover: { size: isSinglePoint ? 7 : 5 },
     },
 
     xaxis: {
-      type: "numeric",
-      min: xMin,
-      max: xMax,
-      tickAmount: Math.min(6, 4),
+      type: "category",
+      categories,
       labels: {
-        formatter: (val: string | number) => formatDateAxisLabel(Number(val)),
         style: { colors: "var(--color-text-muted)", fontSize: "12px" },
         rotate: 0,
+        hideOverlappingLabels: true,
       },
       axisBorder: { show: false },
       axisTicks: { show: false },
@@ -98,16 +87,18 @@ export function buildTimelineDailyTrendChartOptions(params: {
       borderColor: "var(--color-surface-200)",
       xaxis: { lines: { show: false } },
       yaxis: { lines: { show: true } },
-      padding: { left: 8, right: 16 },
+      padding: { left: 20, right: 16 },
     },
 
     tooltip: {
       x: {
-        formatter: (val: number) => formatDateAxisLabel(val),
+        formatter: (_val, opts) => categories[opts?.dataPointIndex ?? 0] ?? "",
       },
       y: {
-        formatter: (val: number) =>
-          isRoas ? formatRoasTooltop(val) : formatCountChartTooltip(val),
+        formatter: (val: number) => {
+          if (val == null || Number.isNaN(val)) return "데이터 없음";
+          return isRoas ? formatRoasTooltip(val) : formatCountChartTooltip(val);
+        },
       },
       style: { fontFamily: "Pretendard" },
     },

--- a/src/utils/timeline/aggregateTimelineMetric.ts
+++ b/src/utils/timeline/aggregateTimelineMetric.ts
@@ -1,0 +1,43 @@
+import type {
+  ITimelineDailyTrend,
+  TTimelineMetric,
+} from "@/types/timeline/api";
+
+/*dailyTrend 행들을 metric별로 하나의 숫자로 합치기
+- 카운트(CLICK, CONVERSION, IMPRESSION)는 평균
+- ROAS는 일별 roas 산술 평균*/
+
+export function aggregateTimelineMetric(
+  dailyTrend: ITimelineDailyTrend[],
+  metric: TTimelineMetric,
+): number {
+  if (dailyTrend.length === 0) return 0;
+  switch (metric) {
+    case "CLICK":
+      return dailyTrend.reduce((sum, row) => sum + row.clicks, 0);
+    case "CONVERSION":
+      return dailyTrend.reduce((sum, row) => sum + row.conversions, 0);
+    case "IMPRESSION":
+      return dailyTrend.reduce((sum, row) => sum + row.impressions, 0);
+    case "ROAS": {
+      const total = dailyTrend.reduce((sum, row) => sum + row.roas, 0);
+      return total / dailyTrend.length;
+    }
+    default:
+      return 0;
+  }
+}
+
+export function mergeDailyTrendRows(
+  rows: ITimelineDailyTrend[],
+  bucketDateIso: string,
+): ITimelineDailyTrend | null {
+  if (rows.length === 0) return null;
+  return {
+    date: bucketDateIso,
+    clicks: aggregateTimelineMetric(rows, "CLICK"),
+    conversions: aggregateTimelineMetric(rows, "CONVERSION"),
+    impressions: aggregateTimelineMetric(rows, "IMPRESSION"),
+    roas: aggregateTimelineMetric(rows, "ROAS"),
+  };
+}

--- a/src/utils/timeline/buildTimelineChartSeries.ts
+++ b/src/utils/timeline/buildTimelineChartSeries.ts
@@ -4,7 +4,10 @@ import type {
 } from "@/types/timeline/api";
 import { TIMELINE_METRIC_OPTIONS } from "@/constants/timeline/formOptions";
 
-import { parseIsoDate } from "./period";
+import {
+  isMissingDailyTrendRow,
+  type TFilledDailyTrendRow,
+} from "./fillDailyTrendRange";
 
 const METRIC_FIELD_MAP: Record<
   TTimelineMetric,
@@ -24,10 +27,6 @@ export function getTimelineMetricLabel(metric: TTimelineMetric): string {
     TIMELINE_METRIC_OPTIONS.find((option) => option.value === metric)?.label ??
     metric
   );
-}
-
-function toChartTimestamp(isoDate: string): number {
-  return parseIsoDate(isoDate).getTime();
 }
 
 export function getMetricValueFromTrend(
@@ -53,58 +52,50 @@ export function calcChartYMax(values: number[], isRoas: boolean): number {
   return Math.ceil((max * 1.2) / unit) * unit;
 }
 
-export interface ITimelineChartPoint {
-  x: number;
-  y: number;
+function formatCategoryLabel(isoDate: string): string {
+  const [, month, day] = isoDate.split("-");
+  return `${Number(month)}/${Number(day)}`;
 }
 
 export interface ITimelineChartSeriesItem {
   name: string;
-  data: ITimelineChartPoint[];
+  data: (number | null)[];
 }
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface ITimelineChartSeriesResult {
   series: ITimelineChartSeriesItem[];
+  categories: string[];
   yMax: number;
-  xMin: number | undefined;
-  xMax: number | undefined;
   metricLabel: string;
+  /** null이 아닌 실제 값 개수 (단일 점 마커 표시용) */
   pointCount: number;
 }
 
+/*missing 날짜는 null로 해서 선이 끊기고 ROAS에 가짜 0을 넣지 않음 */
 export function buildTimelineChartSeries(
-  dailyTrend: ITimelineDailyTrend[],
+  filledRows: readonly TFilledDailyTrendRow[],
   metric: TTimelineMetric,
 ): ITimelineChartSeriesResult {
   const metricLabel = getTimelineMetricLabel(metric);
-  const points = dailyTrend.map((row) => ({
-    x: toChartTimestamp(row.date),
-    y: getMetricValueFromTrend(row, metric),
-  }));
-  const ys = points.map((p) => p.y);
-  const xs = points.map((p) => p.x);
 
-  let xMin = xs.length > 0 ? Math.min(...xs) : undefined;
-  let xMax = xs.length > 0 ? Math.max(...xs) : undefined;
+  const categories = filledRows.map((row) => formatCategoryLabel(row.date));
+  const data = filledRows.map((row) => {
+    if (isMissingDailyTrendRow(row)) return null;
+    return getMetricValueFromTrend(row, metric);
+  });
 
-  if (xs.length === 1 && xMin != null && xMax != null) {
-    xMin -= DAY_MS / 2;
-    xMax += DAY_MS / 2;
-  }
+  const numericValues = data.filter((value): value is number => value != null);
 
   return {
     series: [
       {
         name: metricLabel,
-        data: points,
+        data,
       },
     ],
-    yMax: calcChartYMax(ys, metric === "ROAS"),
-    xMin,
-    xMax,
+    categories,
+    yMax: calcChartYMax(numericValues, metric === "ROAS"),
     metricLabel,
-    pointCount: points.length,
+    pointCount: numericValues.length,
   };
 }

--- a/src/utils/timeline/buildTimelineChartSeries.ts
+++ b/src/utils/timeline/buildTimelineChartSeries.ts
@@ -2,6 +2,7 @@ import type {
   ITimelineDailyTrend,
   TTimelineMetric,
 } from "@/types/timeline/api";
+import type { TTimelineViewUnit } from "@/types/timeline/ui";
 import { TIMELINE_METRIC_OPTIONS } from "@/constants/timeline/formOptions";
 
 import {
@@ -52,7 +53,22 @@ export function calcChartYMax(values: number[], isRoas: boolean): number {
   return Math.ceil((max * 1.2) / unit) * unit;
 }
 
-function formatCategoryLabel(isoDate: string): string {
+/** X축: MONTH는 홀수 일자만(1,3,5…), DAY/WEEK는 M/D */
+function formatAxisCategoryLabel(
+  isoDate: string,
+  viewUnit: TTimelineViewUnit,
+): string {
+  const [, month, day] = isoDate.split("-");
+  const dayNum = Number(day);
+
+  if (viewUnit === "MONTH") {
+    return dayNum % 2 === 1 ? `${dayNum}` : "";
+  }
+
+  return `${Number(month)}/${dayNum}`;
+}
+
+function formatTooltipCategoryLabel(isoDate: string): string {
   const [, month, day] = isoDate.split("-");
   return `${Number(month)}/${Number(day)}`;
 }
@@ -65,6 +81,8 @@ export interface ITimelineChartSeriesItem {
 export interface ITimelineChartSeriesResult {
   series: ITimelineChartSeriesItem[];
   categories: string[];
+  /** 툴팁용 — 항상 M/D (월 보기에서도 날짜 혼동 방지) */
+  tooltipCategories: string[];
   yMax: number;
   metricLabel: string;
   /** null이 아닌 실제 값 개수 (단일 점 마커 표시용) */
@@ -75,10 +93,16 @@ export interface ITimelineChartSeriesResult {
 export function buildTimelineChartSeries(
   filledRows: readonly TFilledDailyTrendRow[],
   metric: TTimelineMetric,
+  viewUnit: TTimelineViewUnit = "WEEK",
 ): ITimelineChartSeriesResult {
   const metricLabel = getTimelineMetricLabel(metric);
 
-  const categories = filledRows.map((row) => formatCategoryLabel(row.date));
+  const categories = filledRows.map((row) =>
+    formatAxisCategoryLabel(row.date, viewUnit),
+  );
+  const tooltipCategories = filledRows.map((row) =>
+    formatTooltipCategoryLabel(row.date),
+  );
   const data = filledRows.map((row) => {
     if (isMissingDailyTrendRow(row)) return null;
     return getMetricValueFromTrend(row, metric);
@@ -94,6 +118,7 @@ export function buildTimelineChartSeries(
       },
     ],
     categories,
+    tooltipCategories,
     yMax: calcChartYMax(numericValues, metric === "ROAS"),
     metricLabel,
     pointCount: numericValues.length,

--- a/src/utils/timeline/buildTimelineChartSeries.ts
+++ b/src/utils/timeline/buildTimelineChartSeries.ts
@@ -63,12 +63,15 @@ export interface ITimelineChartSeriesItem {
   data: ITimelineChartPoint[];
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 export interface ITimelineChartSeriesResult {
   series: ITimelineChartSeriesItem[];
   yMax: number;
   xMin: number | undefined;
   xMax: number | undefined;
   metricLabel: string;
+  pointCount: number;
 }
 
 export function buildTimelineChartSeries(
@@ -83,6 +86,14 @@ export function buildTimelineChartSeries(
   const ys = points.map((p) => p.y);
   const xs = points.map((p) => p.x);
 
+  let xMin = xs.length > 0 ? Math.min(...xs) : undefined;
+  let xMax = xs.length > 0 ? Math.max(...xs) : undefined;
+
+  if (xs.length === 1 && xMin != null && xMax != null) {
+    xMin -= DAY_MS / 2;
+    xMax += DAY_MS / 2;
+  }
+
   return {
     series: [
       {
@@ -91,8 +102,9 @@ export function buildTimelineChartSeries(
       },
     ],
     yMax: calcChartYMax(ys, metric === "ROAS"),
-    xMin: xs.length > 0 ? Math.min(...xs) : undefined,
-    xMax: xs.length > 0 ? Math.max(...xs) : undefined,
+    xMin,
+    xMax,
     metricLabel,
+    pointCount: points.length,
   };
 }

--- a/src/utils/timeline/buildTimelineSummaryPanel.ts
+++ b/src/utils/timeline/buildTimelineSummaryPanel.ts
@@ -1,36 +1,10 @@
-import type {
-  ITimelineDailyTrend,
-  ITimelineDetail,
-  TTimelineMetric,
-} from "@/types/timeline/api";
+import type { ITimelineDetail } from "@/types/timeline/api";
 import type { ITimelineSummaryPanelData } from "@/types/timeline/summary";
 import { TIMELINE_METRIC_OPTIONS } from "@/constants/timeline/formOptions";
 import { resolveTimelinePerformanceStatus } from "@/constants/timeline/statusStyle";
 
+import { aggregateTimelineMetric } from "./aggregateTimelineMetric";
 import { formatDot } from "./period";
-
-/** dailyTrend 배열에서 metric별 집계값 계산 */
-function aggregateMetric(
-  dailyTrend: ITimelineDailyTrend[],
-  metric: TTimelineMetric,
-): number {
-  if (dailyTrend.length === 0) return 0;
-
-  switch (metric) {
-    case "CLICK":
-      return dailyTrend.reduce((sum, row) => sum + row.clicks, 0);
-    case "CONVERSION":
-      return dailyTrend.reduce((sum, row) => sum + row.conversions, 0);
-    case "IMPRESSION":
-      return dailyTrend.reduce((sum, row) => sum + row.impressions, 0);
-    case "ROAS": {
-      const total = dailyTrend.reduce((sum, row) => sum + row.roas, 0);
-      return total / dailyTrend.length;
-    }
-    default:
-      return 0;
-  }
-}
 
 /** 상세 API → 성과 패널 props */
 export function buildTimelineSummaryPanel(
@@ -41,7 +15,7 @@ export function buildTimelineSummaryPanel(
       TIMELINE_METRIC_OPTIONS.find((option) => option.value === metricKey)
         ?.label ?? metricKey;
 
-    const value = aggregateMetric(detail.dailyTrend, metricKey);
+    const value = aggregateTimelineMetric(detail.dailyTrend, metricKey);
 
     return {
       metric: metricKey,

--- a/src/utils/timeline/fillDailyTrendRange.ts
+++ b/src/utils/timeline/fillDailyTrendRange.ts
@@ -1,0 +1,41 @@
+import type { ITimelineDailyTrend } from "@/types/timeline/api";
+
+import { startOfDay, toIsoDate } from "./period";
+
+export type TFilledDailyTrendRow =
+  | ITimelineDailyTrend
+  | { date: string; missing: true };
+
+export function isMissingDailyTrendRow(
+  row: TFilledDailyTrendRow,
+): row is { date: string; missing: true } {
+  return "missing" in row && row.missing;
+}
+
+export function enumerateIsoDates(start: Date, end: Date): string[] {
+  const dates: string[] = [];
+  const cur = startOfDay(start);
+  const last = startOfDay(end);
+
+  while (cur.getTime() <= last.getTime()) {
+    dates.push(toIsoDate(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+
+  return dates;
+}
+
+/*선택 구간의 모든 날짜 채우기 (차트에서는 null로 그려 가짜 0을 피함)*/
+export function fillDailyTrendRange(
+  dailyTrend: ITimelineDailyTrend[],
+  rangeStart: Date,
+  rangeEnd: Date,
+): TFilledDailyTrendRow[] {
+  const byDate = new Map(dailyTrend.map((row) => [row.date, row]));
+
+  return enumerateIsoDates(rangeStart, rangeEnd).map((date) => {
+    const row = byDate.get(date);
+    if (row) return row;
+    return { date, missing: true };
+  });
+}

--- a/src/utils/timeline/period.ts
+++ b/src/utils/timeline/period.ts
@@ -65,15 +65,10 @@ function formatDayLabel(date: Date, today: Date): string {
 }
 
 function formatWeekLabel(start: Date, end: Date): string {
-  const startDay = start.getDate();
-  const endDay = end.getDate();
-  const startMonth = MONTH[start.getMonth()];
-  const endMonth = MONTH[end.getMonth()];
+  const startLabel = `${start.getMonth() + 1}월 ${start.getDate()}일`;
+  const endLabel = `${end.getMonth() + 1}월 ${end.getDate()}일`;
 
-  if (start.getMonth() === end.getMonth()) {
-    return `${startDay} ${startMonth} - ${endDay} ${endMonth}`;
-  }
-  return `${startDay} ${startMonth} - ${endDay} ${endMonth}`;
+  return `${startLabel} - ${endLabel}`;
 }
 
 function formatMonthLabel(date: Date): string {

--- a/src/utils/timeline/period.ts
+++ b/src/utils/timeline/period.ts
@@ -107,7 +107,7 @@ export function resolveVisiblePeriod(
         periodIndex === 0 &&
         weekStart <= normalizedToday &&
         normalizedToday <= weekEnd
-          ? "오늘"
+          ? "이번 주"
           : formatWeekLabel(weekStart, weekEnd),
     };
   }

--- a/src/utils/timeline/period.ts
+++ b/src/utils/timeline/period.ts
@@ -1,20 +1,5 @@
 import type { TTimelineViewUnit } from "@/types/timeline/ui";
 
-const MONTH = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-] as const;
-
 export interface ITimelineVisiblePeriod {
   start: Date;
   end: Date;

--- a/src/utils/timeline/sliceDailyTrendByPeriod.ts
+++ b/src/utils/timeline/sliceDailyTrendByPeriod.ts
@@ -22,6 +22,9 @@ export interface ISliceDailyTrendByPeriodResult {
   periodLabel: string;
   visiblePeriod: ITimelineVisiblePeriod;
   slicedTrend: ITimelineDailyTrend[];
+  /** 차트 X축 채우기용 — 선택 구간 전체. 타임라인과 안 겹치면 null */
+  rangeStart: Date | null;
+  rangeEnd: Date | null;
 }
 
 function clampRangeToTimeline(
@@ -72,6 +75,8 @@ export function sliceDailyTrendByPeriod({
       periodLabel: visiblePeriod.periodLabel,
       visiblePeriod,
       slicedTrend: [],
+      rangeStart: null,
+      rangeEnd: null,
     };
   }
 
@@ -84,6 +89,9 @@ export function sliceDailyTrendByPeriod({
     periodLabel: visiblePeriod.periodLabel,
     visiblePeriod,
     slicedTrend,
+    // X축은 선택 구간 전체. 데이터 없는 날은 fill 시 missing 처리
+    rangeStart: visiblePeriod.start,
+    rangeEnd: visiblePeriod.end,
   };
 }
 

--- a/src/utils/timeline/sliceDailyTrendByPeriod.ts
+++ b/src/utils/timeline/sliceDailyTrendByPeriod.ts
@@ -1,0 +1,108 @@
+import type { ITimelineDailyTrend } from "@/types/timeline/api";
+import type { TTimelineViewUnit } from "@/types/timeline/ui";
+
+import {
+  type ITimelineVisiblePeriod,
+  parseIsoDate,
+  resolveVisiblePeriod,
+  startOfDay,
+  toIsoDate,
+} from "./period";
+
+export interface ISliceDailyTrendByPeriodParams {
+  dailyTrend: ITimelineDailyTrend[];
+  viewUnit: TTimelineViewUnit;
+  periodIndex: number;
+  timelineStartDate: string;
+  timelineEndDate: string;
+  today?: Date;
+}
+
+export interface ISliceDailyTrendByPeriodResult {
+  periodLabel: string;
+  visiblePeriod: ITimelineVisiblePeriod;
+  slicedTrend: ITimelineDailyTrend[];
+}
+
+function clampRangeToTimeline(
+  visible: ITimelineVisiblePeriod,
+  timelineStartDate: string,
+  timelineEndDate: string,
+): { start: Date; end: Date } | null {
+  const timelineStart = startOfDay(parseIsoDate(timelineStartDate));
+  const timelineEnd = startOfDay(parseIsoDate(timelineEndDate));
+
+  const start =
+    visible.start.getTime() > timelineStart.getTime()
+      ? visible.start
+      : timelineStart;
+
+  const end =
+    visible.end.getTime() < timelineEnd.getTime() ? visible.end : timelineEnd;
+
+  // 선택 구간이 타임라인과 안겹치면 null
+  if (start.getTime() > end.getTime()) return null;
+
+  return { start, end };
+}
+
+function isDateInRange(isoDate: string, start: Date, end: Date): boolean {
+  const t = startOfDay(parseIsoDate(isoDate)).getTime();
+  return t >= startOfDay(start).getTime() && t <= startOfDay(end).getTime();
+}
+
+/*viewUnit과 periodIndex로 보이는 기간 정하고, dailyTend에서 그 기간을 자른다. 그리고 잘린건 일별 배열을 그대로 그릴예정*/
+export function sliceDailyTrendByPeriod({
+  dailyTrend,
+  viewUnit,
+  periodIndex,
+  timelineStartDate,
+  timelineEndDate,
+  today = new Date(),
+}: ISliceDailyTrendByPeriodParams): ISliceDailyTrendByPeriodResult {
+  const visiblePeriod = resolveVisiblePeriod(viewUnit, periodIndex, today);
+  const clamped = clampRangeToTimeline(
+    visiblePeriod,
+    timelineStartDate,
+    timelineEndDate,
+  );
+
+  if (!clamped) {
+    return {
+      periodLabel: visiblePeriod.periodLabel,
+      visiblePeriod,
+      slicedTrend: [],
+    };
+  }
+
+  const slicedTrend = dailyTrend
+    .filter((row) => isDateInRange(row.date, clamped.start, clamped.end))
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    periodLabel: visiblePeriod.periodLabel,
+    visiblePeriod,
+    slicedTrend,
+  };
+}
+
+export function getClampedPeriodIsoRange(
+  params: ISliceDailyTrendByPeriodParams,
+): { startIso: string; endIso: string } | null {
+  const visible = resolveVisiblePeriod(
+    params.viewUnit,
+    params.periodIndex,
+    params.today,
+  );
+  const clamped = clampRangeToTimeline(
+    visible,
+    params.timelineStartDate,
+    params.timelineEndDate,
+  );
+  if (!clamped) return null;
+  return {
+    startIso: toIsoDate(clamped.start),
+    endIso: toIsoDate(clamped.end),
+  };
+}

--- a/src/utils/timeline/sliceDailyTrendByPeriod.ts
+++ b/src/utils/timeline/sliceDailyTrendByPeriod.ts
@@ -114,3 +114,17 @@ export function getClampedPeriodIsoRange(
     endIso: toIsoDate(clamped.end),
   };
 }
+
+export function canGoToPrevChartPeriod(params: {
+  viewUnit: TTimelineViewUnit;
+  periodIndex: number;
+  timelineStartDate: string;
+  today?: Date;
+}): boolean {
+  const { viewUnit, periodIndex, timelineStartDate, today } = params;
+
+  const nextOlder = resolveVisiblePeriod(viewUnit, periodIndex + 1, today);
+  const timelineStart = startOfDay(parseIsoDate(timelineStartDate));
+
+  return startOfDay(nextOlder.end).getTime() >= timelineStart.getTime();
+}


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #296 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 성과 패널 `TimelinePeriodSelector` (일/주/월 + 이전/다음)와 일별 변화 추이 차트 연동
- `CHART_PERIOD_LABELS` mock 제거후, `resolveVisiblePeriod` 기반으로 실제 기간 라벨 표시 되도록 구현
- `sliceDailyTrendByPeriod`로 `viewUnit`과 `periodIndex`에 맞춰서 `dailyTrend` slice (타임라인 기간과 교집합)
- 선택 구간 날짜를 `fillDailyTrendRange`로 채우고, 없는 날은 null 처리해서 가짜 0 방지하도록 구현완료
- x축을 category 축으로 변경해서 날짜 라벨 중복 제거
- DAY 단일 점 마커 표시되도록 수정
- Y축과 차트간의 간격 조정

## 💻 작업 화면
<img width="1895" height="900" alt="image" src="https://github.com/user-attachments/assets/c6c3b1ef-ffa9-4a40-8592-ebf6fbaabdda" />
<img width="1896" height="895" alt="image" src="https://github.com/user-attachments/assets/10358e12-dd06-42bf-8654-2d0b2154e03d" />
<img width="1892" height="897" alt="image" src="https://github.com/user-attachments/assets/f8961276-ea01-4ba2-8eac-a5603baefb13" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

차트 기간 변화할때 KPI도 같이 수정하는 또다른 아이디어가 있는데, 이부분은 추가 사항이라 다른 기능구현 완료하고, 추가로 기능구현 가능할때 논의한번 해보면 좋을것같아요!
> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **개선 사항**
  * 일별 추이 차트가 선택한 표시 기간 기준으로 범위를 정확히 반영합니다.
  * 기간 내 누락 날짜를 자동으로 보강해 추세가 끊기지 않고 더 선명하게 보입니다.
  * 데이터가 1건이어도 마커가 표시되며, 데이터가 없을 땐 안내가 노출됩니다.
  * 클릭·전환·노출 및 ROAS가 선택 기간에 맞춰 집계됩니다.
  * 차트 축 라벨/툴팁 포맷이 정돈되고, 범위 선택에 따른 이전/다음 이동 상태가 반영됩니다.
  * 주간 표기가 “이번 주”로 표시되는 경우가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->