### PR TITLE
[Refactor/#302] 워크스페이스/설정/목록/타임라인 useCoreQuery, useCoreMutation 패턴 통일 

### DIFF
--- a/src/components/workspace/InviteMemberModal.tsx
+++ b/src/components/workspace/InviteMemberModal.tsx
@@ -1,14 +1,14 @@
 import { useMemo, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import type { IApiErrorResponse } from "@/types/common/common";
 import type {
   TInviteMemberItem,
   TInviteMemberRequest,
 } from "@/types/workspace/workspace";
 
 import { emailSchema } from "@/utils/auth/validation";
+
+import { useCoreMutation } from "@/hooks/customQuery";
 
 import Badge from "../common/badge/Badge";
 import Button from "../common/button/Button";
@@ -33,36 +33,28 @@ export default function InviteMemberModal({
   orgId,
   inviteItems,
 }: TInviteMemberModalProps) {
-  const queryClient = useQueryClient();
   const [form, setForm] = useState<TInviteMemberRequest>({ email: "" });
   const trimmedEmail = form.email.trim();
   const emailValidation = emailSchema.safeParse(trimmedEmail);
   const isValidEmail = emailValidation.success;
 
-  const inviteMutation = useMutation<
-    unknown,
-    IApiErrorResponse,
-    TInviteMemberRequest
-  >({
-    mutationFn: (body) => postInviteEmail(orgId, body),
-    onSuccess: () => {
-      toast.success("초대 이메일을 발송했습니다");
-      setForm({ email: "" });
-
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.pendingMembers(orgId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.members(orgId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.memberCount(orgId),
-      });
+  const inviteMutation = useCoreMutation(
+    (body: TInviteMemberRequest) => postInviteEmail(orgId, body),
+    {
+      invalidateKeys: [
+        QUERY_KEYS.workspace.pendingMembers(orgId),
+        QUERY_KEYS.workspace.members(orgId),
+        QUERY_KEYS.workspace.memberCount(orgId),
+      ],
+      userOnSuccess: () => {
+        toast.success("초대 이메일을 발송했습니다");
+        setForm({ email: "" });
+      },
+      userOnError: (error) => {
+        toast.error(error.message ?? "초대 이메일 발송에 실패했습니다");
+      },
     },
-    onError: (error) => {
-      toast.error(error.message ?? "초대 이메일 발송에 실패했습니다.");
-    },
-  });
+  );
 
   const isInviteDisabled = !isValidEmail || inviteMutation.isPending;
 

--- a/src/hooks/timeline/useUpdateTimeline.ts
+++ b/src/hooks/timeline/useUpdateTimeline.ts
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
@@ -12,7 +11,7 @@ import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export function useUpdateTimeline() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
-  const queryClient = useQueryClient();
+
   return useCoreMutation(
     ({ timelineId, body }: IUpdateTimelineVariables) => {
       if (orgId == null) {
@@ -21,13 +20,14 @@ export function useUpdateTimeline() {
       return updateTimeline(orgId, timelineId, body);
     },
     {
-      invalidateKeys: orgId != null ? [QUERY_KEYS.timeline.list(orgId)] : [],
-      userOnSuccess: (data, { timelineId }) => {
-        if (orgId != null) {
-          void queryClient.invalidateQueries({
-            queryKey: QUERY_KEYS.timeline.detail(orgId, timelineId),
-          });
-        }
+      invalidateKeys:
+        orgId != null
+          ? [
+              QUERY_KEYS.timeline.list(orgId),
+              ["timeline", "detail", orgId] as const,
+            ]
+          : [],
+      userOnSuccess: (data) => {
         toast.success("타임라인이 수정되었습니다", {
           description: `"${data.name}" 타임라인의 변경내용을 저장했습니다`,
         });

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -11,6 +11,8 @@ export const QUERY_KEYS = {
     list: () => ["my-workspaces"] as const,
     /** 마지막으로 선택한 워크스페이스 */
     saved: () => ["savedWorkspace"] as const,
+    /** 워크스페이스 상세(기본정보) */
+    detail: (orgId: number) => ["workspaceDetail", orgId] as const,
     /** 워크스페이스 멤버 목록 (invalidate 전용) */
     members: (orgId: number) => ["workspaceMembers", orgId] as const,
     /** 워크스페이스 멤버 목록 (페이지 사이즈 포함) */

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
@@ -14,6 +9,8 @@ import {
   type TUpdateMemberRoleRequest,
   type TWorkspaceMember,
 } from "@/types/workspace/workspace";
+
+import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import DeleteMemberModal from "@/components/workspace/DeleteMemberModal";
 import MemberList from "@/components/workspace/MemberList";
@@ -34,7 +31,6 @@ const PAGE_SIZE = 20;
 export default function MemberManagement() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const orgId = Number(workspaceId);
-  const queryClient = useQueryClient();
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedDeleteMember, setSelectedDeleteMember] =
@@ -42,14 +38,12 @@ export default function MemberManagement() {
 
   const observerRef = useRef<HTMLDivElement | null>(null);
 
-  const memberCountQuery = useQuery<
-    Awaited<ReturnType<typeof getWorkspaceMemberCount>>,
-    IApiErrorResponse
-  >({
-    queryKey: QUERY_KEYS.workspace.memberCount(orgId),
-    queryFn: () => getWorkspaceMemberCount(orgId),
-    enabled: Number.isFinite(orgId) && orgId > 0,
-  });
+  const memberCountQuery = useCoreQuery(
+    QUERY_KEYS.workspace.memberCount(orgId),
+    () => getWorkspaceMemberCount(orgId),
+    { enabled: Number.isFinite(orgId) && orgId > 0 },
+  );
+
   const membersQuery = useInfiniteQuery({
     queryKey: QUERY_KEYS.workspace.membersWithPageSize(orgId, PAGE_SIZE),
     queryFn: ({ pageParam }: { pageParam: string | null }) =>
@@ -72,14 +66,11 @@ export default function MemberManagement() {
     return members.filter((member) => member.role === "ADMIN").length;
   }, [members]);
 
-  const pendingMembersQuery = useQuery<
-    Awaited<ReturnType<typeof getPendingMember>>,
-    IApiErrorResponse
-  >({
-    queryKey: QUERY_KEYS.workspace.pendingMembers(orgId),
-    queryFn: () => getPendingMember(orgId),
-    enabled: Number.isFinite(orgId) && orgId > 0,
-  });
+  const pendingMembersQuery = useCoreQuery(
+    QUERY_KEYS.workspace.pendingMembers(orgId),
+    () => getPendingMember(orgId),
+    { enabled: Number.isFinite(orgId) && orgId > 0 },
+  );
 
   const pendingMembers = useMemo(() => {
     const items = pendingMembersQuery.data?.pendingMembers ?? [];
@@ -90,39 +81,34 @@ export default function MemberManagement() {
     );
   }, [pendingMembersQuery.data]);
 
-  const updateMemberRoleMutation = useMutation<
-    unknown,
-    IApiErrorResponse,
-    { memberId: number; body: TUpdateMemberRoleRequest }
-  >({
-    mutationFn: ({ memberId, body }) =>
-      updateWorkspaceMemberPermission(orgId, memberId, body),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.members(orgId),
-      });
+  const updateMemberRoleMutation = useCoreMutation(
+    ({
+      memberId,
+      body,
+    }: {
+      memberId: number;
+      body: TUpdateMemberRoleRequest;
+    }) => updateWorkspaceMemberPermission(orgId, memberId, body),
+    {
+      invalidateKeys: [QUERY_KEYS.workspace.members(orgId)],
+      userOnError: (error) => {
+        toast.error(error.message ?? "권한 변경에 실패했습니다");
+      },
     },
-    onError: (error) => {
-      toast.error(error.message ?? "권한 변경에 실패했습니다.");
-    },
-  });
+  );
 
-  const deleteMemberMutation = useMutation<unknown, IApiErrorResponse, number>({
-    mutationFn: (memberId) => deleteWorkspaceMember(orgId, memberId),
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.workspace.members(orgId),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.workspace.memberCount(orgId),
-        }),
-      ]);
+  const deleteMemberMutation = useCoreMutation(
+    (memberId: number) => deleteWorkspaceMember(orgId, memberId),
+    {
+      invalidateKeys: [
+        QUERY_KEYS.workspace.members(orgId),
+        QUERY_KEYS.workspace.memberCount(orgId),
+      ],
+      userOnError: (error) => {
+        toast.error(error.message ?? "멤버 삭제에 실패했습니다");
+      },
     },
-    onError: (error) => {
-      toast.error(error.message ?? "멤버 삭제에 실패했습니다.");
-    },
-  });
+  );
 
   useEffect(() => {
     const target = observerRef.current;

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -7,10 +7,8 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import type { IApiErrorResponse } from "@/types/common/common";
-import type { TWorkspace } from "@/types/workspace/workspace";
+import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import Button from "@/components/common/button/Button";
 import Input from "@/components/common/input/Input";
@@ -41,26 +39,25 @@ export default function WorkspacePage() {
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
 
-  const queryClient = useQueryClient();
-  const workspacesQuery = useQuery<TWorkspace[], IApiErrorResponse>({
-    queryKey: QUERY_KEYS.workspace.list(),
-    queryFn: getMyWorkspaces,
-  });
+  const workspacesQuery = useCoreQuery(
+    QUERY_KEYS.workspace.list(),
+    getMyWorkspaces,
+  );
 
-  const createWorkspaceMutation = useMutation<unknown, IApiErrorResponse>({
-    mutationFn: async () => {
+  const createWorkspaceMutation = useCoreMutation(
+    async () => {
       const name = newName.trim();
       const description = newDesc.trim();
       return createWorkspace({ name, description, imageFile: logoFile });
     },
-
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.list(),
-      });
-      setCreateOpen(false);
+    {
+      invalidateKeys: [QUERY_KEYS.workspace.list()],
+      userOnSuccess: () => {
+        setCreateOpen(false);
+      },
     },
-  });
+  );
+
   const isListLoading = workspacesQuery.isLoading;
   const listErrorMsg = workspacesQuery.isError
     ? workspacesQuery.error.message

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -8,6 +8,8 @@ import React, {
 } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
+import type { TCreateOrgRequest } from "@/types/workspace/workspace";
+
 import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import Button from "@/components/common/button/Button";
@@ -45,11 +47,7 @@ export default function WorkspacePage() {
   );
 
   const createWorkspaceMutation = useCoreMutation(
-    async () => {
-      const name = newName.trim();
-      const description = newDesc.trim();
-      return createWorkspace({ name, description, imageFile: logoFile });
-    },
+    (body: TCreateOrgRequest) => createWorkspace(body),
     {
       invalidateKeys: [QUERY_KEYS.workspace.list()],
       userOnSuccess: () => {
@@ -145,9 +143,13 @@ export default function WorkspacePage() {
     };
   }, [logoPreview]);
 
-  const onSubmitCreate = async () => {
+  const onSubmitCreate = () => {
     if (!newName.trim()) return;
-    createWorkspaceMutation.mutate();
+    createWorkspaceMutation.mutate({
+      name: newName.trim(),
+      description: newDesc.trim(),
+      imageFile: logoFile,
+    });
   };
 
   const renderWorkspaceContent = () => {

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import type { IApiErrorResponse } from "@/types/common/common";
-
-import { useCoreQuery } from "@/hooks/customQuery";
+import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
@@ -30,13 +27,15 @@ export default function WorkspaceSetting() {
   const navigate = useNavigate();
   const { workspaceId } = useParams();
 
-  const { data: workspaces } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
+  const { data: workspaces } = useCoreQuery(
+    QUERY_KEYS.workspace.list(),
+    getMyWorkspaces,
+  );
   const isAdmin = useMemo(() => {
     if (!workspaceId || !workspaces) return false;
     const workspace = workspaces.find((w) => w.orgId === Number(workspaceId));
     return workspace?.myRole === "ADMIN";
   }, [workspaceId, workspaces]);
-  const queryClient = useQueryClient();
 
   const orgId = useMemo(() => {
     if (!workspaceId) return null;
@@ -45,12 +44,8 @@ export default function WorkspaceSetting() {
   }, [workspaceId]);
   const [name, setName] = useState("");
   const [desc, setDesc] = useState("");
-  const [loading, setLoading] = useState(false);
 
-  const [saving, setSaving] = useState(false);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
   const [deleteNameSnapshot, setDeleteNameSnapshot] = useState("");
   const [deleteConfirmInput, setDeleteConfirmInput] = useState("");
 
@@ -61,92 +56,79 @@ export default function WorkspaceSetting() {
   const [isImageDeleted, setIsImageDeleted] = useState(false);
   const fileRef = useRef<HTMLInputElement | null>(null);
 
-  const fetchWorkspaceDetail = async () => {
-    if (orgId === null) {
-      setErrorMsg("잘못된 워크스페이스ID 입니다");
-      return;
-    }
-    setLoading(true);
-    setErrorMsg(null);
-    setImageError(false);
-    try {
-      const detail = await getWorkspace(orgId);
-      setName(detail.name);
-      setDesc(detail.description ?? "");
-      setServerLogoUrl(detail.logoUrl ?? null);
-      setLogoFile(null);
-      setIsImageDeleted(false);
-      setLogoPreview((prev) => {
-        if (prev) URL.revokeObjectURL(prev);
-        return null;
-      });
-    } catch (e) {
-      const message = (e as IApiErrorResponse).message;
-      setErrorMsg(message);
-      toast.error(message);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const {
+    data: detail,
+    isLoading: loading,
+    isError,
+    error,
+    refetch: refetchDetail,
+  } = useCoreQuery(
+    QUERY_KEYS.workspace.detail(orgId ?? 0),
+    () => getWorkspace(orgId!),
+    { enabled: orgId !== null },
+  );
+  const errorMsg = isError ? (error.message ?? "불러오기 실패") : null;
+
   useEffect(() => {
-    void fetchWorkspaceDetail();
-  }, [orgId]);
+    if (!detail) return;
+    setName(detail.name);
+    setDesc(detail.description ?? "");
+    setServerLogoUrl(detail.logoUrl ?? null);
+    setLogoFile(null);
+    setIsImageDeleted(false);
+    setImageError(false);
+    setLogoPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+  }, [detail]);
 
-  const onSave = async () => {
-    if (orgId === null) {
-      setErrorMsg("잘못된 워크스페이스ID 입니다");
-      return;
-    }
-    const nextName = name.trim();
-    const nextDesc = desc.trim();
-    if (!nextName) return;
-    setSaving(true);
-
-    try {
-      await updateWorkspace(orgId, {
-        name: nextName,
-        description: nextDesc,
+  const updateMutation = useCoreMutation(
+    (id: number) =>
+      updateWorkspace(id, {
+        name: name.trim(),
+        description: desc.trim(),
         imageFile: logoFile,
         isImageDeleted,
-      });
-      await queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.list(),
-      });
-      toast.success("변경사항이 저장되었습니다");
-      await fetchWorkspaceDetail();
-    } catch (e) {
-      toast.error(
-        (e as IApiErrorResponse).message ?? "변경사항 저장에 실패했습니다.",
-      );
-    } finally {
-      setSaving(false);
-    }
+      }),
+    {
+      invalidateKeys: [
+        QUERY_KEYS.workspace.list(),
+        ...(orgId !== null ? [QUERY_KEYS.workspace.detail(orgId)] : []),
+      ],
+      userOnSuccess: () => toast.success("변경사항이 저장되었습니다"),
+      userOnError: (err) =>
+        toast.error(err.message ?? "변경사항 저장에 실패했습니다"),
+    },
+  );
+
+  const saving = updateMutation.isPending;
+
+  const onSave = () => {
+    if (orgId === null || !name.trim()) return;
+    updateMutation.mutate(orgId);
   };
-  const onDelete = async () => {
-    if (orgId === null) {
-      setErrorMsg("잘못된 워크스페이스ID 입니다");
-      return;
-    }
-    if (deleteConfirmInput.trim() !== deleteNameSnapshot) {
-      toast.error("워크스페이스 이름이 일치하지 않습니다.");
-      return;
-    }
-    setDeleting(true);
-    try {
-      await deleteWorkspace(orgId);
-      await queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.workspace.list(),
-      });
+
+  const deleteMutation = useCoreMutation((id: number) => deleteWorkspace(id), {
+    invalidateKeys: [QUERY_KEYS.workspace.list()],
+    userOnSuccess: () => {
       toast.success("워크스페이스가 삭제되었습니다");
       setDeleteOpen(false);
       navigate("/workspace", { replace: true });
-    } catch (e) {
-      toast.error(
-        (e as IApiErrorResponse).message ?? "워크스페이스 삭제에 실패했습니다.",
-      );
-    } finally {
-      setDeleting(false);
+    },
+    userOnError: (err) =>
+      toast.error(err.message ?? "워크스페이스 삭제에 실패했습니다"),
+  });
+
+  const deleting = deleteMutation.isPending;
+
+  const onDelete = () => {
+    if (orgId === null) return;
+    if (deleteConfirmInput.trim() !== deleteNameSnapshot) {
+      toast.error("워크스페이스 이름이 일치하지 않습니다");
+      return;
     }
+    deleteMutation.mutate(orgId);
   };
 
   const openDeleteModal = () => {
@@ -212,7 +194,9 @@ export default function WorkspaceSetting() {
           <Button
             type="button"
             variant="primary"
-            onClick={fetchWorkspaceDetail}
+            onClick={() => {
+              refetchDetail();
+            }}
           >
             다시 시도
           </Button>


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #302 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

담당영역이었던 워크스페이스 목록/생성, 기본정보/설정, 멤버 관리, 초대 에서 raw `useQuery`와 `useMutation`을 `useCoreQuery`와 `useCoreMutation`으로 통일했습니다.

mutation 성공 시 캐시 무효화는 `invalidateKeys`로 선언적 처리하고, toast/모달닫기와 같은 부수효과만 `userOnSuccess`와 `userOnError`에 남겼습니다.

타임라인은 이미 Core 패턴 적용 상태라 raw 잔여 점검만 진행했습니다

### 캐시 반영
- 워크스페이스 생성 -> 목록 갱신
- 멤버 초대/권한 변경/삭제 -> 멤버/대기/카운트 갱신
- 설정 저장 -> 목록 + 상세 갱신
- 워크스페이스 삭제 -> 목록 갱신 후에 `/workspace`로 이동

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 워크스페이스 목록과 상세 정보가 변경 후 더욱 일관되게 최신 상태로 갱신됩니다.
  - 멤버 권한 변경 및 멤버 삭제 후 멤버 목록과 인원 수가 자동으로 업데이트됩니다.
  - 워크스페이스 생성·수정·삭제 및 멤버 초대 처리의 성공·실패 안내가 토스트 메시지로 제공됩니다.
  - 멤버 초대 성공 시 입력 폼이 자동으로 초기화됩니다.
  - 워크스페이스 상세 정보 로딩 실패 시 다시 시도할 수 있습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->