### PR TITLE
[Bugfix/#313] 타임라인 성과 상태 UnderPerform/Pending 정리

### DIFF
--- a/src/components/timeline/TimelineStatusLegend.tsx
+++ b/src/components/timeline/TimelineStatusLegend.tsx
@@ -19,11 +19,11 @@ export default function TimelineStatusLegend({
   return (
     <div
       className={twMerge(
-        "flex w-fit max-w-full flex-wrap items-center justify-between gap-4 rounded-2xl bg-surface-200 px-5 py-3",
+        "flex min-w-0 w-full flex-wrap items-center justify-between gap-4 rounded-2xl bg-surface-200 px-5 py-3",
         className,
       )}
     >
-      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-12 gap-y-2">
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-8 gap-y-2">
         {TIMELINE_STATUS_LEGEND_ORDER.map((status) => {
           const style = TIMELINE_PERFORMANCE_STATUS_STYLE[status];
 

--- a/src/components/timeline/TimelineStatusLegend.tsx
+++ b/src/components/timeline/TimelineStatusLegend.tsx
@@ -19,31 +19,38 @@ export default function TimelineStatusLegend({
   return (
     <div
       className={twMerge(
-        "flex min-w-0 w-full flex-wrap items-center justify-between gap-4 rounded-2xl bg-surface-200 px-5 py-3",
+        "flex min-w-0 w-full items-center gap-4 rounded-2xl bg-surface-200 px-5 py-3",
         className,
       )}
     >
-      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-8 gap-y-2">
-        {TIMELINE_STATUS_LEGEND_ORDER.map((status) => {
-          const style = TIMELINE_PERFORMANCE_STATUS_STYLE[status];
+      <div className="min-w-0 flex-1 overflow-x-auto">
+        <div className="flex w-max items-center gap-x-8">
+          {TIMELINE_STATUS_LEGEND_ORDER.map((status) => {
+            const style = TIMELINE_PERFORMANCE_STATUS_STYLE[status];
 
-          return (
-            <div
-              key={status}
-              className="flex min-w-0 items-center gap-2 font-body2"
-            >
-              <span
-                className={twMerge("h-2 w-2 shrink-0 rounded-full", style.dot)}
-                aria-hidden
-              />
-              <span className="shrink-0 text-text-title">{style.label}</span>
-              <span className="text-text-placeholder" aria-hidden>
-                :
-              </span>
-              <span className="text-text-muted">{style.legendDescription}</span>
-            </div>
-          );
-        })}
+            return (
+              <div
+                key={status}
+                className="flex shrink-0 items-center gap-2 whitespace-nowrap font-body2"
+              >
+                <span
+                  className={twMerge(
+                    "h-2 w-2 shrink-0 rounded-full",
+                    style.dot,
+                  )}
+                  aria-hidden
+                />
+                <span className="shrink-0 text-text-title">{style.label}</span>
+                <span className="text-text-placeholder" aria-hidden>
+                  :
+                </span>
+                <span className="text-text-muted">
+                  {style.legendDescription}
+                </span>
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       <div className="group/help relative shrink-0">

--- a/src/constants/timeline/statusStyle.ts
+++ b/src/constants/timeline/statusStyle.ts
@@ -1,6 +1,7 @@
 import {
   TIMELINE_PERFORMANCE_STATUS,
   type TTimelinePerformanceStatus,
+  type TTimelinePerformanceStatusUi,
 } from "@/types/timeline/api";
 
 export interface ITimelinePerformanceStatusStyle {
@@ -16,14 +17,15 @@ export interface ITimelinePerformanceStatusStyle {
 export const TIMELINE_STATUS_LEGEND_ORDER = [
   "ON_TRACK",
   "ABOVE_AVERAGE",
-  "AT_RISK",
-] as const satisfies readonly TTimelinePerformanceStatus[];
+  "UNDERPERFORM",
+  "PENDING",
+] as const satisfies readonly TTimelinePerformanceStatusUi[];
 
 export const TIMELINE_STATUS_BASELINE_HELP =
-  "성과 상태는 타임라인에 설정한 비교 기간의 평균 성과를 기준으로, 현재 기간 성과가 어느 수준인지 보여줍니다.";
+  "성과 상태는 타임라인에 설정한 비교 기간의 평균 성과를 기준으로, 현재 기간 성과가 어느 수준인지 보여줍니다. 미정은 성과가 아직 산출되지 않은 상태입니다.";
 
 export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
-  TTimelinePerformanceStatus,
+  TTimelinePerformanceStatusUi,
   ITimelinePerformanceStatusStyle
 > = {
   ON_TRACK: {
@@ -44,7 +46,7 @@ export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
     dot: "bg-oauth-naver",
     ring: "ring-oauth-naver",
   },
-  AT_RISK: {
+  UNDERPERFORM: {
     label: "Underperform",
     description: "최근 평균 대비 성과가 눈에 띄게 낮아요.",
     legendDescription: "최근 평균 대비 성과가 눈에 띄게 낮음",
@@ -53,22 +55,31 @@ export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
     dot: "bg-info-red",
     ring: "ring-info-red",
   },
+  PENDING: {
+    label: "Pending",
+    description: "성과가 아직 산출되지 않았어요.",
+    legendDescription: "성과가 아직 산출되지 않음",
+    barBg: "bg-surface-300",
+    accent: "bg-text-muted",
+    dot: "bg-text-muted",
+    ring: "ring-text-muted",
+  },
 };
 
-/** API가 null/미정의/알 수 없는 값을 줄 때 ON_TRACK으로 정규화 */
+/** API가 null/미정의/알 수 없는 값을 줄 때 PENDING(미정)으로 정규화 */
 export function resolveTimelinePerformanceStatus(
   status: string | null | undefined,
-): TTimelinePerformanceStatus {
+): TTimelinePerformanceStatusUi {
   if (
     status != null &&
     (TIMELINE_PERFORMANCE_STATUS as readonly string[]).includes(status)
   ) {
     return status as TTimelinePerformanceStatus;
   }
-  return "ON_TRACK";
+  return "PENDING";
 }
 
-/** 성과 상태 → 바/패널 스타일 (미정의 시 기본 스타일) */
+/** 성과 상태 → 바/패널 스타일 (미정의 시 회색 미정 스타일) */
 export function resolveTimelinePerformanceStatusStyle(
   status: string | null | undefined,
 ): ITimelinePerformanceStatusStyle {

--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -281,8 +281,8 @@ export default function Timeline() {
     >
       <div className="flex min-h-0 flex-1 w-full min-w-0 flex-col rounded-2xl border border-surface-400/70 bg-surface-100">
         <div className="flex shrink-0 flex-col gap-4 border-b border-surface-400/80 px-5 py-5">
-          <div className="flex items-center justify-between gap-12">
-            <TimelineStatusLegend />
+          <div className="flex items-center justify-between gap-8">
+            <TimelineStatusLegend className="min-w-0 flex-1" />
             <Button
               type="button"
               size="small"

--- a/src/types/timeline/api.ts
+++ b/src/types/timeline/api.ts
@@ -12,15 +12,21 @@ export type TTimelineMetric = (typeof TIMELINE_METRICS)[number];
 /*성과 상태
  * ON_TRACK: 최근 추세와 유사한 수준 유지
  * ABOVE_AVERAGE: 최근 평균 대비 눈에 띄게 좋음
- * AT_RISK: 최근 평균 대비 눈에 띄게 낮음
+ * UNDERPERFORM: 최근 평균 대비 눈에 띄게 낮음
+ * (미산출 시 null — UI에서는 PENDING으로 표시)
  */
 export const TIMELINE_PERFORMANCE_STATUS = [
   "ON_TRACK",
   "ABOVE_AVERAGE",
-  "AT_RISK",
+  "UNDERPERFORM",
 ] as const;
 export type TTimelinePerformanceStatus =
   (typeof TIMELINE_PERFORMANCE_STATUS)[number];
+
+/** API 3종 + UI 전용 미정(PENDING). null/미지 값은 UI에서 PENDING으로 정규화 */
+export type TTimelinePerformanceStatusUi =
+  | TTimelinePerformanceStatus
+  | "PENDING";
 
 /*비교 기간 타입*/
 export const TIMELINE_COMPARISON_PERIOD_TYPES = [

--- a/src/types/timeline/summary.ts
+++ b/src/types/timeline/summary.ts
@@ -2,7 +2,7 @@ import type { TProviderType } from "@/types/dashboard/provider";
 import type {
   ITimelineDailyTrend,
   TTimelineMetric,
-  TTimelinePerformanceStatus,
+  TTimelinePerformanceStatusUi,
 } from "@/types/timeline/api";
 
 /*패널 상단 KPI 카드 한개*/
@@ -24,7 +24,7 @@ export interface ITimelineSummaryPlatformShare {
 export interface ITimelineSummaryPanelData {
   timelineName: string;
   periodLabel: string;
-  performanceStatus: TTimelinePerformanceStatus;
+  performanceStatus: TTimelinePerformanceStatusUi;
   aiSummary: string;
   metrics: ITimelineSummaryMetric[];
   platformShare: ITimelineSummaryPlatformShare[];

--- a/src/types/timeline/timeline.mock.ts
+++ b/src/types/timeline/timeline.mock.ts
@@ -49,7 +49,7 @@ export const TIMELINE_LIST_MOCK: ITimelineListItem[] = [
     name: "리타겟팅 집중 기간",
     startDate: "2026-06-10",
     endDate: "2026-06-30",
-    performanceStatus: "AT_RISK",
+    performanceStatus: "UNDERPERFORM",
   },
 ];
 
@@ -197,7 +197,7 @@ export const TIMELINE_GRID_MOCK_MONTH: ITimelineGridData = {
       colStart: 16,
       colEnd: 31,
       row: 2,
-      performanceStatus: "ON_TRACK",
+      performanceStatus: "UNDERPERFORM",
     },
   ],
 };

--- a/src/types/timeline/ui.ts
+++ b/src/types/timeline/ui.ts
@@ -1,5 +1,5 @@
 import type { TProviderType } from "@/types/dashboard/provider";
-import type { TTimelinePerformanceStatus } from "@/types/timeline/api";
+import type { TTimelinePerformanceStatusUi } from "@/types/timeline/api";
 
 export type TTimelineViewUnit = "DAY" | "WEEK" | "MONTH";
 
@@ -22,7 +22,7 @@ export interface ITimelineCampaignBar {
   colStart: number; //그리드 시작 위치
   colEnd: number;
   row: number;
-  performanceStatus: TTimelinePerformanceStatus;
+  performanceStatus: TTimelinePerformanceStatusUi;
 }
 
 /*그리드 + 바 묶음*/


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #313 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `AT_RISK` API 값 `UNDERPERFORM`으로 타입/스타일 키 정렬
- `performanceStatus`가 null/미지 값일때, `ON_TRACK` fallback 제거 -> UI는 회색으로 Pending 표시
- 범례에 Pending 설명 추가, 한줄로 보이도록 영역이랑 간격 수정

## 💻 작업 화면
<img width="1736" height="882" alt="image" src="https://github.com/user-attachments/assets/3bde89dd-dc51-46d7-afdf-4dfc7d1f3ddc" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- 기존에는 null이나 미지값일때는 ON_TRACK(파란색)으로 표시되도록 진행했는데, 사용자에게 혼동을 줄수 있고, UX적으로 맞지 않다고 판단되어서 추가로 Pending 값을 추가했습니다.
- API 성과 상태 3종: `ON_TRACK` / `ABOVE_AVERAGE` / `UNDERPERFORM`
- `Pending`은 API enum 값이 아니라 FE에서 UX 개선을 위한 상태표시 입니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 타임라인 성과 상태에 ‘미정(PENDING)’ 표시를 추가했습니다.
  - 성과가 낮은 상태를 ‘위험(AT_RISK)’에서 ‘저조(UNDERPERFORM)’로 변경했습니다.

- **개선**
  - 타임라인 상태 범례와 상단 툴바의 간격 및 너비 배치를 조정해 화면 내 표시 영역을 개선했습니다.
  - 알 수 없거나 누락된 상태를 ‘미정’으로 표시하도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->