### PR TITLE
[Feature/#318] 모달 focus trap 및 키보드 네비게이션 구현

### DIFF
--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -14,6 +14,15 @@ import { twMerge } from "tailwind-merge";
 
 import CloseIcon from "@/assets/icon/common/close.svg?react";
 
+const FOCUSABLE_SELECTORS = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "a[href]",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
 export interface IModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -53,7 +62,13 @@ function Modal({
   useLayoutEffect(() => {
     if (!isOpen) return;
     previousActiveElement.current = document.activeElement as HTMLElement;
-    const id = requestAnimationFrame(() => modalRef.current?.focus());
+    const id = requestAnimationFrame(() => {
+      const first =
+        modalRef.current?.querySelectorAll<HTMLElement>(
+          FOCUSABLE_SELECTORS,
+        )?.[0];
+      (first ?? modalRef.current)?.focus();
+    });
     return () => cancelAnimationFrame(id);
   }, [isOpen]);
 
@@ -61,6 +76,31 @@ function Modal({
     setScrollLocked(false);
     previousActiveElement.current?.focus();
   }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "Tab") return;
+      const focusable = Array.from(
+        modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS) ??
+          [],
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -149,6 +189,7 @@ function Modal({
               }}
               transition={{ duration: openMs, ease: easeOut }}
               onClick={handleContentClick}
+              onKeyDown={handleKeyDown}
               tabIndex={-1}
             >
               {title ? (

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -23,6 +23,19 @@ const FOCUSABLE_SELECTORS = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(", ");
 
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS),
+  ).filter(
+    (el) =>
+      el.tabIndex >= 0 &&
+      el.getClientRects().length > 0 &&
+      getComputedStyle(el).visibility !== "hidden" &&
+      !el.closest('[aria-hidden="true"]') &&
+      !el.closest("[inert]"),
+  );
+}
+
 export interface IModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -63,10 +76,9 @@ function Modal({
     if (!isOpen) return;
     previousActiveElement.current = document.activeElement as HTMLElement;
     const id = requestAnimationFrame(() => {
-      const first =
-        modalRef.current?.querySelectorAll<HTMLElement>(
-          FOCUSABLE_SELECTORS,
-        )?.[0];
+      const first = modalRef.current
+        ? getFocusable(modalRef.current)[0]
+        : undefined;
       (first ?? modalRef.current)?.focus();
     });
     return () => cancelAnimationFrame(id);
@@ -80,11 +92,11 @@ function Modal({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key !== "Tab") return;
-      const focusable = Array.from(
-        modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS) ??
-          [],
-      );
-      if (focusable.length === 0) return;
+      const focusable = modalRef.current ? getFocusable(modalRef.current) : [];
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
       if (e.shiftKey) {


### PR DESCRIPTION
<!--
📌 제목: [Type] 작업 요약

예시:
- [Feature] 반응형 수정
- [Bugfix] 에러 잡기
- [Deploy] 배포
- [Refactor] 사용성 높이기

사용 가능한 Type:
Feature | Bugfix | Refactor | Deploy | Design | Docs | Setting | Test |
-->

## 🚨 관련 이슈

#318 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- Modal.tsx에 FOCUSABLE_SELECTORS 상수 추가 
- 모달 오픈 시 첫 번째 focusable 요소로 자동 포커스 이동 (기존: modal div 자체에 포커스)
- handleKeyDown 추가 — Tab/Shift+Tab 이벤트 인터셉트, 첫·마지막 요소 간 포커스 순환
- ESC 닫기, 모달 닫힘 시 트리거 요소로 포커스 복원은 기존 구현 유지

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

ESC 닫기(handleEscape)와 포커스 복원(previousActiveElement)은 기존 Modal.tsx에 이미 구현되어 있음
이번 PR에서는 누락된 Tab focus trap과 오픈 시 첫 번째 요소 자동 포커스만 추가했습니다.

WCAG 2.1 AA 기준:
- 2.1.1 (Keyboard) — ESC로 모달 닫기 
- 2.1.2 (No Keyboard Trap) — Tab이 모달 내부에서만 순환 

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 모달이 열릴 때 첫 번째 포커스 가능한 요소에 자동으로 포커스를 이동합니다.
  * `Tab` 키 사용 시 포커스가 모달 외부로 빠져나가지 않도록 순환 이동을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->