### PR TITLE
[Feature/#306] Setting 페이지 내 클릭수/주간리포트 알림 UI

### DIFF
--- a/src/components/setting/NotificationSection.tsx
+++ b/src/components/setting/NotificationSection.tsx
@@ -3,21 +3,26 @@ import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
 import Toggle from "@/components/common/toggle/Toggle";
 
+import DownloadIcon from "@/assets/icon/common/download.svg?react";
 import MailIcon from "@/assets/icon/common/mail.svg?react";
+import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 import BellIcon from "@/assets/icon/sidebar/notification.svg?react";
 import SlackIcon from "@/assets/logo/social-logo/plain/slack.svg?react";
 
-export interface INotificationSettings {
-  browserPush: boolean;
-  emailNotif: boolean;
-}
-
 type TNotificationSectionProps = {
   email: string;
+  //channel
   browserPush: boolean;
   emailNotif: boolean;
   onBrowserPushChange: (value: boolean) => void;
   onEmailNotifChange: (value: boolean) => void;
+  //workspace
+  workspaceName: string | null; // null이면 미선택/없음
+  clickAlarm: boolean;
+  weeklyReport: boolean;
+  onClickAlarmChange: (value: boolean) => void;
+  onWeeklyReportChange: (value: boolean) => void;
+  workspaceNotifiDisabled: boolean; //selectedOrgId === null 등
 };
 
 export default function NotificationSection({
@@ -26,58 +31,145 @@ export default function NotificationSection({
   emailNotif,
   onBrowserPushChange,
   onEmailNotifChange,
+  workspaceName,
+  clickAlarm,
+  weeklyReport,
+  onClickAlarmChange,
+  onWeeklyReportChange,
+  workspaceNotifiDisabled,
 }: TNotificationSectionProps) {
+  const rowIconClass =
+    "h-5 w-5 shrink-0 text-text-muted [&_path]:[stroke-width:2]";
+
   return (
     <Card className="p-8 tablet:p-10">
       <header className="mb-7 flex items-center gap-4">
         <BellIcon />
-        <h2 className="font-heading4 text-text-title">알림 채널 설정</h2>
+        <h2 className="font-heading4 text-text-title">알림 설정</h2>
       </header>
 
-      <div className="flex flex-col divide-y divide-surface-300">
-        <div className="flex items-center justify-between py-5 first:pt-0">
-          <div className="flex items-center gap-4">
-            <BellIcon className="h-5 w-5 shrink-0 text-text-muted" />
-            <p className="font-body1 text-text-title">브라우저 푸시 알림</p>
-          </div>
-          <div className="flex items-center gap-4">
-            {browserPush && <Badge variant="infoBlue">켜짐</Badge>}
-            <Toggle
-              checked={browserPush}
-              onToggle={() => onBrowserPushChange(!browserPush)}
-              ariaLabel="브라우저 푸시 알림 켜기/끄기"
-            />
-          </div>
-        </div>
+      <section aria-labelledby="notification-channel-heading">
+        <h3
+          id="notification-channel-heading"
+          className="mb-4 font-label text-text-muted"
+        >
+          알림 채널
+        </h3>
 
-        <div className="flex items-center justify-between py-5">
-          <div className="flex items-center gap-4">
-            <MailIcon className="h-5 w-5 shrink-0 text-text-muted" />
-            <div>
-              <p className="font-body1 text-text-title">이메일 알림 설정</p>
-              <p className="font-body2 text-text-muted">{email}</p>
+        <div className="flex flex-col divide-y divide-surface-300">
+          <div className="flex items-center justify-between py-5 first:pt-0">
+            <div className="flex items-center gap-4">
+              <BellIcon className={rowIconClass} />
+              <p className="font-body1 text-text-title">브라우저 푸시 알림</p>
+            </div>
+            <div className="flex items-center gap-4">
+              {browserPush && <Badge variant="infoBlue">켜짐</Badge>}
+              <Toggle
+                checked={browserPush}
+                onToggle={() => onBrowserPushChange(!browserPush)}
+                ariaLabel="브라우저 푸시 알림 켜기/끄기"
+              />
             </div>
           </div>
-          <Toggle
-            checked={emailNotif}
-            onToggle={() => onEmailNotifChange(!emailNotif)}
-            ariaLabel="이메일 알림 켜기/끄기"
-          />
-        </div>
 
-        <div className="flex items-center justify-between py-5 last:pb-0">
-          <div className="flex items-center gap-4">
-            <SlackIcon className="h-5 w-5 shrink-0" />
-            <div>
-              <p className="font-body1 text-text-title">슬랙 연동하기</p>
-              <p className="font-body2 text-text-muted">#채널명</p>
+          <div className="flex items-center justify-between py-5">
+            <div className="flex items-center gap-4">
+              <MailIcon className={rowIconClass} />
+              <div>
+                <p className="font-body1 text-text-title">이메일 알림 설정</p>
+                <p className="font-body2 text-text-muted">{email}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              {emailNotif && <Badge variant="infoBlue">켜짐</Badge>}
+              <Toggle
+                checked={emailNotif}
+                onToggle={() => onEmailNotifChange(!emailNotif)}
+                ariaLabel="이메일 알림 켜기/끄기"
+              />
             </div>
           </div>
-          <Button variant="outline" size="small" type="button">
-            연동
-          </Button>
+
+          <div className="flex items-center justify-between py-5">
+            <div className="flex items-center gap-4">
+              <SlackIcon className={rowIconClass} />
+              <div>
+                <p className="font-body1 text-text-title">슬랙 연동하기</p>
+                <p className="font-body2 text-text-muted">#채널명</p>
+              </div>
+            </div>
+            <Button variant="outline" size="small" type="button">
+              연동
+            </Button>
+          </div>
         </div>
-      </div>
+      </section>
+
+      <div className="my-8 border-t border-surface-300" aria-hidden />
+
+      <section aria-labelledby="notification-workspace-heading">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h3
+            id="notification-workspace-heading"
+            className="font-label text-text-muted"
+          >
+            워크스페이스 알림
+          </h3>
+          <p className="min-w-0 truncate font-caption text-text-muted">
+            {workspaceNotifiDisabled
+              ? "워크스페이스를 선택해주세요"
+              : workspaceName}
+          </p>
+        </div>
+
+        <div className="flex flex-col divide-y divide-surface-300">
+          <div className="flex items-center justify-between gap-4 py-5 first:pt-0">
+            <div className="flex min-w-0 items-center gap-4">
+              <WarnCircleIcon className={rowIconClass} />
+              <div className="min-w-0">
+                <p className="font-body1 text-text-title">클릭수 알림</p>
+                <p className="font-body2 text-text-muted">
+                  이상 징후가 있을 때 알림
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-4">
+              {clickAlarm && !workspaceNotifiDisabled && (
+                <Badge variant="infoBlue">켜짐</Badge>
+              )}
+              <Toggle
+                ariaLabel="클릭수 알람 켜기/끄기"
+                checked={clickAlarm}
+                disabled={workspaceNotifiDisabled}
+                onToggle={() => onClickAlarmChange(!clickAlarm)}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-4 py-5 last:pb-0">
+            <div className="flex min-w-0 items-center gap-4">
+              <DownloadIcon className={rowIconClass} />
+              <div className="min-w-0">
+                <p className="font-body1 text-text-title">주간 리포트</p>
+                <p className="font-body2 text-text-muted">
+                  매주 월요일 오전 8시 리포트 이메일 발송
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-4">
+              {weeklyReport && !workspaceNotifiDisabled && (
+                <Badge variant="infoBlue">켜짐</Badge>
+              )}
+              <Toggle
+                ariaLabel="주간리포트 받기/안받기"
+                checked={weeklyReport}
+                disabled={workspaceNotifiDisabled}
+                onToggle={() => onWeeklyReportChange(!weeklyReport)}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
     </Card>
   );
 }

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -2,23 +2,34 @@ import { type ChangeEvent, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
+import type {
+  IChannelNotificationSettings,
+  IWorkspaceNotificationSettings,
+} from "@/types/setting/notification";
 
 import { useImageUploader } from "@/hooks/common/useImageUploader";
+import { useCoreQuery } from "@/hooks/customQuery";
 
 import Button from "@/components/common/button/Button";
-import NotificationSection, {
-  type INotificationSettings,
-} from "@/components/setting/NotificationSection";
+import NotificationSection from "@/components/setting/NotificationSection";
 import PasswordSection from "@/components/setting/PasswordSection";
 import PasswordSectionSkeleton from "@/components/setting/PasswordSectionSkeleton";
 import ProfileSection from "@/components/setting/ProfileSection";
 import ProfileSectionSkeleton from "@/components/setting/ProfileSectionSkeleton";
 
 import { getMyInfo, updateMyInfo } from "@/api/auth/auth";
+import { getMyWorkspaces } from "@/api/workspace/org";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
 
-const DEFAULT_NOTIFICATION_SETTINGS: INotificationSettings = {
+const DEFAULT_CHANNEL: IChannelNotificationSettings = {
   browserPush: false,
   emailNotif: false,
+};
+
+const DEFAULT_WORKSPACE_NOTIF: IWorkspaceNotificationSettings = {
+  clickAlarm: false,
+  weeklyReport: false,
 };
 
 interface IDraftProfile {
@@ -45,10 +56,14 @@ export default function Setting() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
-  const [savedNotification, setSavedNotification] =
-    useState<INotificationSettings>(DEFAULT_NOTIFICATION_SETTINGS);
-  const [draftNotification, setDraftNotification] =
-    useState<INotificationSettings>(DEFAULT_NOTIFICATION_SETTINGS);
+  const [savedChannel, setSavedChannel] =
+    useState<IChannelNotificationSettings>(DEFAULT_CHANNEL);
+  const [draftChannel, setDraftChannel] =
+    useState<IChannelNotificationSettings>(DEFAULT_CHANNEL);
+  const [savedWorkspaceNotif, setSavedWorkspaceNotif] =
+    useState<IWorkspaceNotificationSettings>(DEFAULT_WORKSPACE_NOTIF);
+  const [draftWorkspaceNotif, setDraftWorkspaceNotif] =
+    useState<IWorkspaceNotificationSettings>(DEFAULT_WORKSPACE_NOTIF);
   const [isImageDeleted, setIsImageDeleted] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const {
@@ -60,6 +75,19 @@ export default function Setting() {
     onPickFile,
     resetImage,
   } = useImageUploader();
+
+  const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
+  const { data: workspaces } = useCoreQuery(
+    QUERY_KEYS.workspace.list(),
+    getMyWorkspaces,
+  );
+  const currentWorkspaceName = useMemo(() => {
+    if (selectedOrgId === null) return null;
+    return workspaces?.find((w) => w.orgId === selectedOrgId)?.name ?? null;
+  }, [selectedOrgId, workspaces]);
+
+  const workspaceNotifiDisabled =
+    selectedOrgId == null || !currentWorkspaceName;
 
   const handlePickFile = (e: ChangeEvent<HTMLInputElement>) => {
     setIsImageDeleted(false);
@@ -77,14 +105,23 @@ export default function Setting() {
     );
   }, [savedProfile, draftProfile, preview, file]);
 
-  const hasNotificationChanges = useMemo(() => {
+  const hasChannelChanges = useMemo(() => {
     return (
-      savedNotification.browserPush !== draftNotification.browserPush ||
-      savedNotification.emailNotif !== draftNotification.emailNotif
+      savedChannel.browserPush !== draftChannel.browserPush ||
+      savedChannel.emailNotif !== draftChannel.emailNotif
     );
-  }, [savedNotification, draftNotification]);
+  }, [savedChannel, draftChannel]);
+
+  const hasWorkspaceNotifChanges = useMemo(() => {
+    return (
+      savedWorkspaceNotif.clickAlarm !== draftWorkspaceNotif.clickAlarm ||
+      savedWorkspaceNotif.weeklyReport !== draftWorkspaceNotif.weeklyReport
+    );
+  }, [savedWorkspaceNotif, draftWorkspaceNotif]);
 
   const hasAccountChanges = hasProfileChanges || hasPasswordChanges;
+
+  const hasNotificationChanges = hasChannelChanges || hasWorkspaceNotifChanges;
 
   const hasChanges = hasAccountChanges || hasNotificationChanges;
 
@@ -154,15 +191,18 @@ export default function Setting() {
         setIsImageDeleted(false);
       }
 
-      if (hasNotificationChanges) {
-        setSavedNotification(draftNotification);
+      if (hasChannelChanges) {
+        setSavedChannel(draftChannel);
         // TODO: 알림 설정 API 연동
+      }
+      if (hasWorkspaceNotifChanges && selectedOrgId != null) {
+        setSavedWorkspaceNotif(draftWorkspaceNotif);
       }
 
       toast.success(
-        hasAccountChanges && hasNotificationChanges
+        hasAccountChanges && hasChannelChanges
           ? "설정이 저장되었습니다"
-          : hasNotificationChanges
+          : hasChannelChanges
             ? "알림 설정이 저장되었습니다"
             : "회원정보가 수정되었습니다",
       );
@@ -198,6 +238,11 @@ export default function Setting() {
     };
     fetchMyInfo();
   }, [setPreview]);
+
+  useEffect(() => {
+    setSavedWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
+    setDraftWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
+  }, [selectedOrgId]);
 
   return (
     <section className="w-full flex flex-col gap-8">
@@ -240,14 +285,27 @@ export default function Setting() {
         ) : (
           <NotificationSection
             email={draftProfile.email}
-            browserPush={draftNotification.browserPush}
-            emailNotif={draftNotification.emailNotif}
+            browserPush={draftChannel.browserPush}
+            emailNotif={draftChannel.emailNotif}
             onBrowserPushChange={(value) =>
-              setDraftNotification((prev) => ({ ...prev, browserPush: value }))
+              setDraftChannel((prev) => ({ ...prev, browserPush: value }))
             }
             onEmailNotifChange={(value) =>
-              setDraftNotification((prev) => ({ ...prev, emailNotif: value }))
+              setDraftChannel((prev) => ({ ...prev, emailNotif: value }))
             }
+            workspaceName={currentWorkspaceName}
+            clickAlarm={draftWorkspaceNotif.clickAlarm}
+            weeklyReport={draftWorkspaceNotif.weeklyReport}
+            onClickAlarmChange={(value) =>
+              setDraftWorkspaceNotif((prev) => ({ ...prev, clickAlarm: value }))
+            }
+            onWeeklyReportChange={(value) =>
+              setDraftWorkspaceNotif((prev) => ({
+                ...prev,
+                weeklyReport: value,
+              }))
+            }
+            workspaceNotifiDisabled={workspaceNotifiDisabled}
           />
         )}
       </div>

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -77,7 +77,7 @@ export default function Setting() {
   } = useImageUploader();
 
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
-  const { data: workspaces } = useCoreQuery(
+  const { data: workspaces, isLoading: isWorkspacesLoading } = useCoreQuery(
     QUERY_KEYS.workspace.list(),
     getMyWorkspaces,
   );
@@ -87,7 +87,7 @@ export default function Setting() {
   }, [selectedOrgId, workspaces]);
 
   const workspaceNotifiDisabled =
-    selectedOrgId == null || !currentWorkspaceName;
+    selectedOrgId == null || (!isWorkspacesLoading && !currentWorkspaceName);
 
   const handlePickFile = (e: ChangeEvent<HTMLInputElement>) => {
     setIsImageDeleted(false);

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -199,10 +199,15 @@ export default function Setting() {
         setSavedWorkspaceNotif(draftWorkspaceNotif);
       }
 
+      const savedWorkspaceNotifiThisTime =
+        hasWorkspaceNotifChanges && selectedOrgId != null;
+      const savedAnyNotification =
+        hasChannelChanges || savedWorkspaceNotifiThisTime;
+
       toast.success(
-        hasAccountChanges && hasChannelChanges
+        hasAccountChanges && savedAnyNotification
           ? "설정이 저장되었습니다"
-          : hasChannelChanges
+          : savedAnyNotification
             ? "알림 설정이 저장되었습니다"
             : "회원정보가 수정되었습니다",
       );

--- a/src/types/setting/notification.ts
+++ b/src/types/setting/notification.ts
@@ -1,0 +1,9 @@
+export interface IChannelNotificationSettings {
+  browserPush: boolean;
+  emailNotif: boolean;
+}
+
+export interface IWorkspaceNotificationSettings {
+  clickAlarm: boolean;
+  weeklyReport: boolean;
+}


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #306 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- Setting 알림을 채널/워크스페이스 영역으로 분리
- `selectedOrgId` 기준으로 워크스페이스명 표시하고, 미선택하였으면, empty/disabled
- 클릭수 알림/주간 리포트 on/off 토글 UI 구현
- draft/saved, 변경 감지, 저장 버튼 연동 (API는 UI이슈마무리후 별도로 진행예정)

## 🖥️ 작업 화면
<img width="1733" height="900" alt="image" src="https://github.com/user-attachments/assets/9c6902f2-fabe-4b6b-bafa-450830bc0b23" />


## 😅 미완성 작업

- 알림 설정 API 연동
- 페이지 헤더 우측에 사이드바 BellIcon이용하여 알람 기록 확인 UI (다음 이슈 예정)

## 📢 논의 사항 및 참고 사항

- 채널 = 유저 단위
- 클릭수/주간 리포트 = 현재 워크스페이스 단위
- 현재는 저장시 로컬 saved 반영만되고, 실제 API는 후속 이슈로 다룰예정입니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 알림 설정을 채널 알림과 워크스페이스 알림으로 구분해 관리할 수 있습니다.
  * 워크스페이스별 클릭 알림과 주간 리포트 알림을 설정할 수 있습니다.
  * 선택한 워크스페이스에 따라 알림 상태와 설정 가능 여부가 자동으로 반영됩니다.
* **개선 사항**
  * 알림 설정 화면의 제목과 아이콘 표시를 정리했습니다.
  * 변경한 알림 설정 유형에 맞춰 저장 완료 안내가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->