### PR TITLE
[Setting/#319] CSP 보안 헤더 CloudFront Function 코드 추가 및 CI 배포 자동화

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,6 +50,24 @@ jobs:
         run: |
           aws s3 cp --recursive dist s3://${{ secrets.AWS_BUCKET_NAME }}
 
+      # CloudFront Function 업데이트 (CSP 보안 헤더)
+      - name: Update CloudFront CSP Function
+        run: |
+          ETAG=$(aws cloudfront describe-function \
+            --name add-csp-report-only \
+            --query 'ETag' --output text)
+          aws cloudfront update-function \
+            --name add-csp-report-only \
+            --if-match "$ETAG" \
+            --function-config Comment="CSP security headers",Runtime="cloudfront-js-2.0" \
+            --function-code fileb://scripts/cloudfront-functions/csp-headers.js
+          NEW_ETAG=$(aws cloudfront describe-function \
+            --name add-csp-report-only \
+            --query 'ETag' --output text)
+          aws cloudfront publish-function \
+            --name add-csp-report-only \
+            --if-match "$NEW_ETAG"
+
       # CloudFront 캐시 무효화
       - name: Invalidate CloudFront Cache
         run: |

--- a/scripts/cloudfront-functions/csp-headers.js
+++ b/scripts/cloudfront-functions/csp-headers.js
@@ -1,0 +1,20 @@
+function handler(event) {
+  var response = event.response;
+  var headers = response.headers;
+
+  headers['content-security-policy'] = {
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-eval'",
+      "connect-src 'self' https://api.whereyouad.com",
+      "img-src 'self' data: blob: https://*.amazonaws.com",
+      "style-src 'self' 'unsafe-inline'",
+      "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "object-src 'none'",
+    ].join('; '),
+  };
+
+  return response;
+}

--- a/scripts/cloudfront-functions/csp-headers.js
+++ b/scripts/cloudfront-functions/csp-headers.js
@@ -1,8 +1,9 @@
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 function handler(event) {
   var response = event.response;
   var headers = response.headers;
 
-  headers['content-security-policy'] = {
+  headers["content-security-policy"] = {
     value: [
       "default-src 'self'",
       "script-src 'self' 'unsafe-eval'",
@@ -13,7 +14,7 @@ function handler(event) {
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "object-src 'none'",
-    ].join('; '),
+    ].join("; "),
   };
 
   return response;


### PR DESCRIPTION
## 🚨 관련 이슈

#319 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [X] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 배경

accessToken을 메모리(Zustand)에 저장해 XSS 토큰 탈취를 방어하고 있었지만,
악성 스크립트 실행 자체를 막는 1차 방어선(CSP 헤더)이 없었습니다.

XSS 방어는 두 레이어가 함께 동작해야 완성됩니다:
- **1차 방어 (CSP):** 악성 스크립트 실행 자체를 브라우저에서 차단
- **2차 방어 (메모리 저장):** 탈취되더라도 피해 최소화

### 구현 방식

CloudFront Response Headers Policy 대신 **CloudFront Functions**로 구현했습니다.

> CloudFront Functions는 엣지에서 응답 헤더를 수정하는 경량 JS 함수입니다.
> 월 200만 건까지 무료이며, 코드베이스 변경 없이 CDN 레벨에서 일괄 적용됩니다.

### 적용 과정

**1단계 — Report-Only로 안전하게 검증**

먼저 `Content-Security-Policy-Report-Only` 헤더를 적용했습니다.
이 모드에서는 CSP 위반이 발생해도 앱이 차단되지 않고 콘솔에만 로그가 찍힙니다.

content-security-policy-report-only: default-src 'self'; script-src 'self' 'unsafe-eval'; ...

로그인 · 대시보드 · AI 분석 · 소셜 로그인 · 워크스페이스 이미지 등
기능을 테스트한 결과 **CSP 위반 없음** 확인.

**2단계 — Enforcing 전환**

위반이 없으므로 `Content-Security-Policy`(실제 차단 모드)로 전환했습니다.

### 최종 CSP 정책

| 디렉티브 | 값 | 이유 |
|----------|-----|------|
| `default-src` | `'self'` | 기본값: 동일 오리진만 허용 |
| `script-src` | `'self' 'unsafe-eval'` | ApexCharts가 내부적으로 `eval()` 사용 |
| `connect-src` | `'self' https://api.whereyouad.com` | API가 별도 서브도메인으로 분리됨 |
| `img-src` | `'self' data: blob: https://*.amazonaws.com` | 차트 PNG 다운로드(data:), S3 프로필 이미지 |
| `style-src` | `'self' 'unsafe-inline'` | framer-motion · Tailwind v4 인라인 스타일 주입 |
| `font-src` | `'self' https://fonts.gstatic.com https://fonts.googleapis.com` | Google Fonts 대비 |
| `frame-ancestors` | `'none'` | 클릭재킹 방지 |
| `base-uri` | `'self'` | `<base>` 태그 주입 공격 차단 |
| `object-src` | `'none'` | Flash 등 플러그인 완전 차단 |

### 변경 파일

- `scripts/cloudfront-functions/csp-headers.js`
  - CloudFront Function 코드 버전 관리
  - 이 파일이 CSP 정책의 단일 출처(SSOT)

- `.github/workflows/main.yaml`
  - main 브랜치 배포 시 CloudFront Function 자동 업데이트 · 게시 스텝 추가
  - 이후 CSP 수정은 `csp-headers.js`만 변경하면 배포 시 자동 반영


## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
AWS 콘솔에 함수가 생성되어 있습니다.


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
