### PR TITLE
[Feature/#332] 내 알림 설정 GET API 연동

### DIFF
--- a/src/api/notification/notification.ts
+++ b/src/api/notification/notification.ts
@@ -1,0 +1,14 @@
+import type { ICommonResponse } from "@/types/common/common";
+import type { IMyNotificationSettings } from "@/types/setting/notification";
+
+import { axiosInstance } from "@/lib/axiosInstance";
+
+//내 알림 설정 조회 API
+export const getMyNotificationSettings = async (
+  orgId: number,
+): Promise<IMyNotificationSettings> => {
+  const { data } = await axiosInstance.get<
+    ICommonResponse<IMyNotificationSettings>
+  >(`/api/notification/settings/${orgId}`);
+  return data.data;
+};

--- a/src/hooks/setting/useMyNotificationSettings.ts
+++ b/src/hooks/setting/useMyNotificationSettings.ts
@@ -1,0 +1,17 @@
+import { useCoreQuery } from "../customQuery";
+
+import { getMyNotificationSettings } from "@/api/notification/notification";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+export function useMyNotificationSettings() {
+  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+
+  return useCoreQuery(
+    QUERY_KEYS.notification.settings(orgId),
+    () => getMyNotificationSettings(orgId!),
+    {
+      enabled: orgId != null,
+    },
+  );
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -80,4 +80,9 @@ export const QUERY_KEYS = {
     detail: (orgId: number | null, timelineId: number | null) =>
       ["timeline", "detail", orgId, timelineId] as const,
   },
+
+  notification: {
+    settings: (orgId: number | null) =>
+      ["notification", "settings", orgId] as const,
+  },
 } as const;

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -94,6 +94,7 @@ export default function Setting() {
     isLoading: isNotificationLoading,
     isError: isNotificationError,
     error: notificationError,
+    refetch: refetchNotificationSettings,
   } = useMyNotificationSettings();
 
   const currentWorkspaceName = useMemo(() => {
@@ -141,7 +142,8 @@ export default function Setting() {
 
   const hasNotificationChanges = hasChannelChanges || hasWorkspaceNotifChanges;
 
-  const hasChanges = hasAccountChanges || hasNotificationChanges;
+  const hasChanges =
+    hasAccountChanges || (!isNotificationError && hasNotificationChanges);
 
   const [passwordErrors, setPasswordErrors] = useState({
     currentPassword: "",
@@ -209,18 +211,27 @@ export default function Setting() {
         setIsImageDeleted(false);
       }
 
-      if (hasChannelChanges) {
+      const canSaveNotification = !isNotificationError;
+
+      if (canSaveNotification && hasChannelChanges) {
         setSavedChannel(draftChannel);
         // TODO: 알림 설정 API 연동
       }
-      if (hasWorkspaceNotifChanges && selectedOrgId != null) {
+      if (
+        canSaveNotification &&
+        hasWorkspaceNotifChanges &&
+        selectedOrgId != null
+      ) {
         setSavedWorkspaceNotif(draftWorkspaceNotif);
       }
 
       const savedWorkspaceNotifiThisTime =
-        hasWorkspaceNotifChanges && selectedOrgId != null;
+        canSaveNotification &&
+        hasWorkspaceNotifChanges &&
+        selectedOrgId != null;
       const savedAnyNotification =
-        hasChannelChanges || savedWorkspaceNotifiThisTime;
+        (canSaveNotification && hasChannelChanges) ||
+        savedWorkspaceNotifiThisTime;
 
       toast.success(
         hasAccountChanges && savedAnyNotification
@@ -263,7 +274,8 @@ export default function Setting() {
   }, [setPreview]);
 
   useEffect(() => {
-    if (!notificationSettings) {
+    //워크스페이스 미선택시에만 기본값
+    if (selectedOrgId === null) {
       setSavedChannel(DEFAULT_CHANNEL);
       setDraftChannel(DEFAULT_CHANNEL);
       setSavedWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
@@ -271,28 +283,22 @@ export default function Setting() {
       return;
     }
 
+    if (!notificationSettings) return; //로딩,에러면 손대지 않음
+
     const nextChannel = {
       browserPush: notificationSettings.isBrowserPushEnabled,
       emailNotif: notificationSettings.isEmailEnabled,
     };
     const nextWorkspace = {
-      clickAlarm: notificationSettings.alertClicks,
-      weeklyReport: notificationSettings.alertReport,
+      clickAlarm: notificationSettings.orgAlertClicks,
+      weeklyReport: notificationSettings.orgAlertReport,
     };
 
     setSavedChannel(nextChannel);
     setDraftChannel(nextChannel);
     setSavedWorkspaceNotif(nextWorkspace);
     setDraftWorkspaceNotif(nextWorkspace);
-  }, [notificationSettings]);
-
-  useEffect(() => {
-    if (isNotificationError) {
-      toast.error(
-        notificationError?.message ?? "알림 설정을 불러오는데 실패했습니다",
-      );
-    }
-  }, [isNotificationError, notificationError]);
+  }, [selectedOrgId, notificationSettings]);
 
   return (
     <section className="w-full flex flex-col gap-8">
@@ -332,6 +338,23 @@ export default function Setting() {
 
         {isLoading || isNotificationSectionLoading ? (
           <div className="animate-pulse h-64 rounded-lg bg-surface-200" />
+        ) : isNotificationError ? (
+          <div className="flex min-h-40 flex-col items-center justify-center gap-4 rounded-lg bg-surface-100 p-8">
+            <p className="text-center font-body2 text-text-muted">
+              {notificationError?.message ??
+                "알림 설정을 불러오지 못했습니다. 잠시 후에 다시 시도해주세요"}
+            </p>
+            <Button
+              variant="outline"
+              size="small"
+              type="button"
+              onClick={() => {
+                refetchNotificationSettings();
+              }}
+            >
+              다시 시도
+            </Button>
+          </div>
         ) : (
           <NotificationSection
             email={draftProfile.email}
@@ -367,7 +390,7 @@ export default function Setting() {
           size="big"
           aria-label="개인 설정 변경사항 저장 버튼"
           onClick={handleSave}
-          disabled={!hasChanges || isLoading || isNotificationLoading}
+          disabled={!hasChanges || isLoading || isNotificationSectionLoading}
         >
           변경사항 저장하기
         </Button>

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useEffect, useMemo, useState } from "react";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
@@ -92,10 +92,14 @@ export default function Setting() {
   const {
     data: notificationSettings,
     isLoading: isNotificationLoading,
+    isRefetching: isNotificationRefetching,
     isError: isNotificationError,
     error: notificationError,
+    errorUpdatedAt: notificationErrorUpdatedAt,
     refetch: refetchNotificationSettings,
   } = useMyNotificationSettings();
+
+  const lastNotifiedNotificationErrorAtRef = useRef(0);
 
   const currentWorkspaceName = useMemo(() => {
     if (selectedOrgId === null) return null;
@@ -106,7 +110,8 @@ export default function Setting() {
     selectedOrgId == null || (!isWorkspacesLoading && !currentWorkspaceName);
 
   const isNotificationSectionLoading =
-    selectedOrgId !== null && isNotificationLoading;
+    selectedOrgId !== null &&
+    (isNotificationLoading || isNotificationRefetching);
 
   const handlePickFile = (e: ChangeEvent<HTMLInputElement>) => {
     setIsImageDeleted(false);
@@ -299,6 +304,19 @@ export default function Setting() {
     setSavedWorkspaceNotif(nextWorkspace);
     setDraftWorkspaceNotif(nextWorkspace);
   }, [selectedOrgId, notificationSettings]);
+
+  useEffect(() => {
+    if (!isNotificationError || notificationErrorUpdatedAt === 0) return;
+    if (
+      lastNotifiedNotificationErrorAtRef.current === notificationErrorUpdatedAt
+    )
+      return;
+
+    lastNotifiedNotificationErrorAtRef.current = notificationErrorUpdatedAt;
+    toast.error(
+      notificationError?.message ?? "알림 설정을 불러오는데 실패했습니다",
+    );
+  }, [isNotificationError, notificationError, notificationErrorUpdatedAt]);
 
   return (
     <section className="w-full flex flex-col gap-8">

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -5,6 +5,7 @@ import type { IApiErrorResponse } from "@/types/common/common";
 
 import { useImageUploader } from "@/hooks/common/useImageUploader";
 import { useCoreQuery } from "@/hooks/customQuery";
+import { useMyNotificationSettings } from "@/hooks/setting/useMyNotificationSettings";
 
 import Button from "@/components/common/button/Button";
 import NotificationSection from "@/components/setting/NotificationSection";
@@ -87,6 +88,14 @@ export default function Setting() {
     QUERY_KEYS.workspace.list(),
     getMyWorkspaces,
   );
+
+  const {
+    data: notificationSettings,
+    isLoading: isNotificationLoading,
+    isError: isNotificationError,
+    error: notificationError,
+  } = useMyNotificationSettings();
+
   const currentWorkspaceName = useMemo(() => {
     if (selectedOrgId === null) return null;
     return workspaces?.find((w) => w.orgId === selectedOrgId)?.name ?? null;
@@ -94,6 +103,9 @@ export default function Setting() {
 
   const workspaceNotifiDisabled =
     selectedOrgId == null || (!isWorkspacesLoading && !currentWorkspaceName);
+
+  const isNotificationSectionLoading =
+    selectedOrgId !== null && isNotificationLoading;
 
   const handlePickFile = (e: ChangeEvent<HTMLInputElement>) => {
     setIsImageDeleted(false);
@@ -251,9 +263,36 @@ export default function Setting() {
   }, [setPreview]);
 
   useEffect(() => {
-    setSavedWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
-    setDraftWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
-  }, [selectedOrgId]);
+    if (!notificationSettings) {
+      setSavedChannel(DEFAULT_CHANNEL);
+      setDraftChannel(DEFAULT_CHANNEL);
+      setSavedWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
+      setDraftWorkspaceNotif(DEFAULT_WORKSPACE_NOTIF);
+      return;
+    }
+
+    const nextChannel = {
+      browserPush: notificationSettings.isBrowserPushEnabled,
+      emailNotif: notificationSettings.isEmailEnabled,
+    };
+    const nextWorkspace = {
+      clickAlarm: notificationSettings.alertClicks,
+      weeklyReport: notificationSettings.alertReport,
+    };
+
+    setSavedChannel(nextChannel);
+    setDraftChannel(nextChannel);
+    setSavedWorkspaceNotif(nextWorkspace);
+    setDraftWorkspaceNotif(nextWorkspace);
+  }, [notificationSettings]);
+
+  useEffect(() => {
+    if (isNotificationError) {
+      toast.error(
+        notificationError?.message ?? "알림 설정을 불러오는데 실패했습니다",
+      );
+    }
+  }, [isNotificationError, notificationError]);
 
   return (
     <section className="w-full flex flex-col gap-8">
@@ -291,7 +330,7 @@ export default function Setting() {
           />
         )}
 
-        {isLoading ? (
+        {isLoading || isNotificationSectionLoading ? (
           <div className="animate-pulse h-64 rounded-lg bg-surface-200" />
         ) : (
           <NotificationSection
@@ -328,7 +367,7 @@ export default function Setting() {
           size="big"
           aria-label="개인 설정 변경사항 저장 버튼"
           onClick={handleSave}
-          disabled={!hasChanges || isLoading}
+          disabled={!hasChanges || isLoading || isNotificationLoading}
         >
           변경사항 저장하기
         </Button>


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #332 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `GET /api/notification/settings/{orgId}` 연동
- `useMyNotificationSettings` 훅/queryKey 추가
- Setting 알림 토글 초기값을 서버 설정으로 반영
- 로딩 스켈레톤/에러 toast 처리

## 😅 미완성 작업

- 멤버 목록 알림 조회 API 연동 및 UI 구현 (후속 이슈 예정)

## 📢 논의 사항 및 참고 사항

- 워크스페이스 미선택시에는 요청하지 않도록 하였습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 선택한 워크스페이스의 내 알림 설정을 조회하고 화면에 반영합니다.
  * 알림 설정 저장 상태와 변경 여부를 안정적으로 관리합니다.

* **버그 수정**
  * 알림 설정을 불러오는 동안 로딩 상태와 저장 버튼 비활성화를 표시합니다.
  * 조회 오류 발생 시 안내 메시지와 “다시 시도” 버튼을 제공합니다.
  * 설정 조회에 실패한 경우 잘못된 알림 설정 저장을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->