### PR TITLE
[Feature/#309] 플랫폼 연동 ADMIN 전용 접근 제어

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -126,6 +126,10 @@ export default function Sidebar() {
       filterNavByRole(applyWorkspacePathsToNav(mainNav, selectedOrgId), myRole),
     [selectedOrgId, myRole],
   );
+  const footerNavByRole = useMemo(
+    () => filterNavByRole(footerNav, myRole),
+    [myRole],
+  );
 
   const handleFooterItemClick = useCallback(
     (id: string, hasChildren: boolean) => {
@@ -235,7 +239,7 @@ export default function Sidebar() {
         <div
           className={twMerge("mt-2 pb-3 shrink-0", isCollapsed ? "" : "px-2")}
         >
-          {footerNav.map((item) => {
+          {footerNavByRole.map((item) => {
             const isActive =
               item.path != null ? isPathMatch(pathname, item.path) : false;
 

--- a/src/constants/sidebarNav.ts
+++ b/src/constants/sidebarNav.ts
@@ -88,6 +88,7 @@ export const footerNav: INavItem[] = [
     label: "플랫폼 연동",
     icon: ConnectIcon,
     path: "/integrations",
+    requiredRole: "ADMIN",
   },
   {
     id: "settings",

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -40,6 +40,7 @@ export default function MainLayout() {
 
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
   const setMyRole = useWorkspaceStore((s) => s.setMyRole);
+  const myRole = useWorkspaceStore((s) => s.myRole);
 
   const savedWorkspaceQuery = useCoreQuery(
     QUERY_KEYS.workspace.saved(),
@@ -59,7 +60,15 @@ export default function MainLayout() {
 
   useEffect(() => {
     if (!workspaces?.length || !savedWorkspaceQuery.isFetched) return;
-    if (selectedOrgId !== null) return;
+
+    // orgId는 있는데 myRole만 null/불일치인 경우(새로고침 등) 역할 동기화
+    if (selectedOrgId !== null) {
+      const workspace = workspaces.find((w) => w.orgId === selectedOrgId);
+      if (workspace && myRole !== workspace.myRole) {
+        setMyRole(workspace.myRole);
+      }
+      return;
+    }
 
     const savedId = savedData?.orgId;
     const isExist = workspaces.some((w) => w.orgId === savedId);
@@ -84,6 +93,7 @@ export default function MainLayout() {
     setSelectedOrgId,
     setMyRole,
     selectedOrgId,
+    myRole,
   ]);
 
   const pathname = normalizePathname(location.pathname);

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -110,7 +110,11 @@ const MainRoutes: RouteObject[] = [
   },
   {
     path: "integrations",
-    element: <PlatformIntegrationsPage />,
+    element: (
+      <RoleGuard allowedRoles={["ADMIN"]}>
+        <PlatformIntegrationsPage />
+      </RoleGuard>
+    ),
   },
   {
     path: "setting",

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from "react";
 import { Navigate, useParams } from "react-router-dom";
 
-import type { TMemberRole } from "@/types/workspace/workspace";
+import type { TMemberRole, TWorkspace } from "@/types/workspace/workspace";
 
 import { useCoreQuery } from "@/hooks/customQuery";
 
@@ -14,32 +14,51 @@ interface IRoleGuardProps {
   allowedRoles: TMemberRole[];
 }
 
+function resolveRoleFromWorkspaces(
+  workspaces: TWorkspace[],
+  selectedOrgId: number | null,
+  myRoleFromStore: TMemberRole | null,
+): TMemberRole | null {
+  if (selectedOrgId != null) {
+    const selected = workspaces.find((w) => w.orgId === selectedOrgId);
+    if (selected) return selected.myRole;
+  }
+
+  const current =
+    workspaces.find((w) => w.isCurrentWorkspace) ?? workspaces[0] ?? null;
+  if (current) return current.myRole;
+
+  return myRoleFromStore;
+}
+
 function RoleGuard({
   children,
   allowedRoles,
 }: IRoleGuardProps): ReactElement | null {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
   const myRole = useWorkspaceStore((s) => s.myRole);
+  const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
   const {
     data: workspaces,
     isPending,
     isError,
   } = useCoreQuery(QUERY_KEYS.workspace.list(), getMyWorkspaces);
 
-  //URL에 workspaceId가 있는 경우 -> URL 기준 워크스페이스의 role로 판정
+  // 워크스페이스 목록 로드 전 -> 렌더 보류
+  if (isPending) {
+    return null;
+  }
+  if (isError || !workspaces?.length) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  // URL에 workspaceId가 있는 경우 -> URL 기준 워크스페이스의 role로 판정
   if (workspaceId) {
-    //워크스페이스 목록 로드 전 -> 랜더 보류
-    if (isPending) {
-      return null;
-    }
-    if (isError || !workspaces) {
-      return <Navigate to="/dashboard" replace />;
-    }
     const targetWorkspace = workspaces.find(
       (w) => w.orgId === Number(workspaceId),
     );
 
-    //URL의 workspaceId가 내 워크스페이스 목록에 없는 경우 -> 대시보드로
+    // URL의 workspaceId가 내 워크스페이스 목록에 없는 경우 -> 대시보드로
     if (!targetWorkspace) {
       return <Navigate to="/dashboard" replace />;
     }
@@ -50,13 +69,18 @@ function RoleGuard({
     return <>{children}</>;
   }
 
-  //워크스페이스 초기화 전(null)에 랜더 보류
-  if (myRole === null) {
-    return null;
-  }
-  if (!allowedRoles.includes(myRole)) {
+  // /integrations 등 workspaceId 없는 라우트
+  // selectedOrgId 초기화를 기다리지 않고 목록에서 역할 판정
+  const resolvedRole = resolveRoleFromWorkspaces(
+    workspaces,
+    selectedOrgId,
+    myRole,
+  );
+
+  if (resolvedRole === null || !allowedRoles.includes(resolvedRole)) {
     return <Navigate to="/dashboard" replace />;
   }
+
   return <>{children}</>;
 }
 

--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -1,11 +1,11 @@
 import type { ReactElement, ReactNode } from "react";
 import { Navigate, useParams } from "react-router-dom";
 
-import type { TMemberRole, TWorkspace } from "@/types/workspace/workspace";
+import type { TMemberRole } from "@/types/workspace/workspace";
 
 import { useCoreQuery } from "@/hooks/customQuery";
 
-import { getMyWorkspaces } from "@/api/workspace/org";
+import { getMyWorkspaces, getSavedWorkspace } from "@/api/workspace/org";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
@@ -14,41 +14,27 @@ interface IRoleGuardProps {
   allowedRoles: TMemberRole[];
 }
 
-function resolveRoleFromWorkspaces(
-  workspaces: TWorkspace[],
-  selectedOrgId: number | null,
-  myRoleFromStore: TMemberRole | null,
-): TMemberRole | null {
-  if (selectedOrgId != null) {
-    const selected = workspaces.find((w) => w.orgId === selectedOrgId);
-    if (selected) return selected.myRole;
-  }
-
-  const current =
-    workspaces.find((w) => w.isCurrentWorkspace) ?? workspaces[0] ?? null;
-  if (current) return current.myRole;
-
-  return myRoleFromStore;
-}
-
 function RoleGuard({
   children,
   allowedRoles,
 }: IRoleGuardProps): ReactElement | null {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
-  const myRole = useWorkspaceStore((s) => s.myRole);
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
   const {
     data: workspaces,
-    isPending,
-    isError,
+    isPending: isWorkspacesPending,
+    isError: isWorkspacesError,
   } = useCoreQuery(QUERY_KEYS.workspace.list(), getMyWorkspaces);
+  const { isFetched: isSavedWorkspaceFetched } = useCoreQuery(
+    QUERY_KEYS.workspace.saved(),
+    getSavedWorkspace,
+  );
 
-  // 워크스페이스 목록 로드 전 -> 렌더 보류
-  if (isPending) {
+  // 워크스페이스 목록·저장 워크스페이스 조회 완료 전 -> 렌더 보류
+  if (isWorkspacesPending || !isSavedWorkspaceFetched) {
     return null;
   }
-  if (isError || !workspaces?.length) {
+  if (isWorkspacesError || !workspaces?.length) {
     return <Navigate to="/dashboard" replace />;
   }
 
@@ -70,14 +56,13 @@ function RoleGuard({
   }
 
   // /integrations 등 workspaceId 없는 라우트
-  // selectedOrgId 초기화를 기다리지 않고 목록에서 역할 판정
-  const resolvedRole = resolveRoleFromWorkspaces(
-    workspaces,
-    selectedOrgId,
-    myRole,
-  );
+  // MainLayout에서 selectedOrgId 초기화 완료 전까지 보류
+  if (selectedOrgId === null) {
+    return null;
+  }
 
-  if (resolvedRole === null || !allowedRoles.includes(resolvedRole)) {
+  const selectedWorkspace = workspaces.find((w) => w.orgId === selectedOrgId);
+  if (!selectedWorkspace || !allowedRoles.includes(selectedWorkspace.myRole)) {
     return <Navigate to="/dashboard" replace />;
   }
 


### PR DESCRIPTION
## 🚨 관련 이슈
#309 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- 플랫폼 연동 메뉴·라우트를 **ADMIN 전용**으로 제한
- `sidebarNav.ts`: `integrations`에 `requiredRole: "ADMIN"` 추가
- `Sidebar.tsx`: footerNav도 `filterNavByRole` 적용 → MEMBER에게 플랫폼 연동 메뉴 미노출
- `MainRoutes.tsx`: `/integrations` 라우트에 `RoleGuard allowedRoles={["ADMIN"]}` 적용
- `RoleGuard.tsx`: workspaceId 없는 라우트(`/integrations`)에서 워크스페이스 목록 + `selectedOrgId`로 역할 판정, MEMBER는 `/dashboard`로 리다이렉트
- `MainLayout.tsx`: 새로고침 등으로 `selectedOrgId`는 있는데 `myRole`만 null/불일치일 때 역할 동기화

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 역할에 따라 사이드바 하단 메뉴가 표시됩니다.
  - 관리자만 “플랫폼 연동” 메뉴와 페이지에 접근할 수 있습니다.

- **버그 수정**
  - 워크스페이스와 역할 정보를 불러오는 동안 잘못된 화면이 표시되지 않습니다.
  - 워크스페이스가 없거나 접근 권한이 없는 경우 대시보드로 안전하게 이동합니다.
  - 워크스페이스 선택 및 역할 변경 시 권한 상태가 올바르게 동기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->