### PR TITLE
[Bugfix/#341] 배포 환경 로그인 불가 수정 및 auth 방어 코드 보완

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,12 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Create .env file
+        run: |
+          echo "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}" >> .env
+          echo "VITE_NAVER_AES_SECRET=${{ secrets.VITE_NAVER_AES_SECRET }}" >> .env
+          echo "VITE_NAVER_AES_IV=${{ secrets.VITE_NAVER_AES_IV }}" >> .env
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/src/hooks/auth/useTokenRefresh.ts
+++ b/src/hooks/auth/useTokenRefresh.ts
@@ -19,7 +19,7 @@ export const useTokenRefresh = () => {
     const initAuth = async () => {
       try {
         const { data } = await reissueToken();
-        if (data.accessToken) {
+        if (data?.accessToken) {
           setAccessToken(data.accessToken);
         }
       } catch {

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -106,7 +106,8 @@ axiosInstance.interceptors.response.use(
       try {
         const { data } = await authInstance.post("/api/auth/reissue");
 
-        const newAccessToken = data.data.accessToken;
+        const newAccessToken = data.data?.accessToken;
+        if (!newAccessToken) throw new Error("토큰 재발급 실패");
 
         useAuthStore.getState().setAccessToken(newAccessToken);
         onRefreshed(newAccessToken);

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -31,6 +31,7 @@ const useAuthStore = create<IAuthState>((set) => ({
     localStorage.removeItem("hasSession");
     set({
       isLoggedIn: false,
+      isTokenInitialized: false,
       accessToken: null,
       email: "",
       socialId: null,


### PR DESCRIPTION
## 🚨 관련 이슈

#341 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- .env.production 삭제 - 환경변수는 GitHub Secrets에서만 관리
- useTokenRefresh.ts - reissue 응답 data?.accessToken optional chaining 추가
- useAuthStore.ts - logout() 시 isTokenInitialized: false 초기화
- axiosInstance.ts - 401 인터셉터 reissue 후 accessToken null 체크 추가
- ci.yaml — Create .env file step 추가 (Lighthouse CI NO_FCP 수정)

> **.env.production이 존재했던 이유**
CloudFront behavior로 /api/*를 백엔드에 라우팅하는 구조를 의도하여 생성한 파일임. 해당 방식이라면 VITE_API_BASE_URL=/로 same-origin 요청만 해도 동작하기 때문.
그러나 실제 아키텍처는 api.whereyouad.com 별도 도메인으로 백엔드를 분리하는 구조여서 값이 맞지 않았음. .env.production을 삭제하고 GitHub Secret으로 전체 URL을 주입하는 방식으로 통일함.


## 😅 미완성 작업
N/A


## 📢 논의 사항 및 참고 사항
N/A



> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
