### PR TITLE
[Bugfix/#352] SSE 연결 중 accessToken 만료 시 401 자동 갱신 및 Sentry 에러 전파 방지

### DIFF
--- a/src/hooks/dashboard/useClickStream.ts
+++ b/src/hooks/dashboard/useClickStream.ts
@@ -6,11 +6,27 @@ import type {
   TProviderType,
 } from "@/types/dashboard/overview";
 
+import { reissueToken } from "@/api/auth/auth";
 import useAuthStore from "@/store/useAuthStore";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const MAX_RETRIES = 3;
 const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+
+// 여러 SSE 연결이 동시에 401을 받아도 reissueToken은 1번만 실행되도록 보장
+// (AllPlatformTrafficChart에서 3개 연결이 동시에 토큰 만료되는 케이스 대응)
+let sseRefreshPromise: Promise<string | null> | null = null;
+
+async function refreshTokenOnce(): Promise<string | null> {
+  if (sseRefreshPromise) return sseRefreshPromise;
+  sseRefreshPromise = reissueToken()
+    .then((r) => r.data?.accessToken ?? null)
+    .catch(() => null)
+    .finally(() => {
+      sseRefreshPromise = null;
+    });
+  return sseRefreshPromise;
+}
 
 export type TUseClickStreamOptions = {
   mode?: "real" | "dummy";
@@ -55,6 +71,19 @@ export function useClickStream(options: TUseClickStreamOptions = {}) {
         },
         signal: controller.signal,
         onopen: async (response) => {
+          // 401: 토큰 갱신 후 abort → accessToken 변경 → useEffect 재실행 → 새 토큰으로 재연결
+          // refreshTokenOnce()로 동시 다발 401(플랫폼별 3개 SSE)에도 reissue는 1회만 실행
+          if (response.status === 401) {
+            const newToken = await refreshTokenOnce();
+            if (newToken) {
+              useAuthStore.getState().setAccessToken(newToken);
+            } else {
+              useAuthStore.getState().logout();
+            }
+            controller.abort();
+            return;
+          }
+
           const contentType = response.headers.get("content-type") ?? "";
           const isSse = contentType.includes("text/event-stream");
           if (!response.ok || !isSse) {
@@ -80,10 +109,14 @@ export function useClickStream(options: TUseClickStreamOptions = {}) {
           }
         },
         onerror(err) {
+          // AbortError는 controller.abort() 호출로 인한 정상 종료 — 무시
+          if (err instanceof DOMException && err.name === "AbortError") return;
+
           retryCountRef.current += 1;
           if (retryCountRef.current >= MAX_RETRIES) {
             setIsError(true);
-            throw err; // 재시도 중단
+            controller.abort(); // throw 대신 abort → unhandled rejection 방지
+            return;
           }
           // MAX_RETRIES 미만이면 기본 재시도 동작 유지
         },


### PR DESCRIPTION
## 🚨 관련 이슈

#352 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

**원인**

`fetchEventSource`는 fetch 기반이라 `axiosInstance` 인터셉터가 개입하지 못한다.
SSE 연결 중 accessToken이 만료되면 서버가 401을 반환해도 토큰 갱신 없이 에러가 throw되고,
unhandled promise rejection으로 Sentry에 캡처됐다.

또한 `AllPlatformTrafficChart`는 `useClickStream`을 3개 동시 사용하기 때문에,
3개 연결이 동시에 401을 받으면 `reissueToken()`이 3번 중복 호출되어 refreshToken 소진 → 강제 로그아웃 위험이 있었다.

**변경 내용**

- `onopen` 401 감지 시 `refreshTokenOnce()` 호출 후 `controller.abort()`
  → `setAccessToken(newToken)` → `accessToken` 변경 → `useEffect` 재실행 → 새 토큰으로 SSE 재연결
- 모듈 레벨 `sseRefreshPromise` 싱글턴(`refreshTokenOnce`)으로 3개 SSE 동시 401 시 `reissueToken()` 1회만 실행 보장
- `onerror` MAX_RETRIES 초과 시 `throw err` → `controller.abort() + return`으로 교체해 unhandled rejection 제거
- `onerror` AbortError 무시 처리 추가 (abort 정상 종료와 실제 에러 구분)


## 😅 미완성 작업
N/A


## 📢 논의 사항 및 참고 사항
N/A


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 실시간 데이터 연결 중 인증이 만료되어도 자동으로 인증 토큰을 갱신해 연결을 복구합니다.
  - 여러 연결에서 인증 만료가 동시에 발생해도 불필요한 토큰 갱신이 반복되지 않습니다.
  - 연결 종료 과정에서 불필요한 오류나 재시도가 발생하지 않도록 개선했습니다.
  - 토큰 갱신에 실패하면 안전하게 로그아웃 처리됩니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->