### PR TITLE
[Bugfix/#351] 타임라인 performanceStatus ABOVE_AVERAGE → ABOVE_AVG로 값명 변경

### DIFF
--- a/src/constants/timeline/statusStyle.ts
+++ b/src/constants/timeline/statusStyle.ts
@@ -16,7 +16,7 @@ export interface ITimelinePerformanceStatusStyle {
 
 export const TIMELINE_STATUS_LEGEND_ORDER = [
   "ON_TRACK",
-  "ABOVE_AVERAGE",
+  "ABOVE_AVG",
   "UNDERPERFORM",
   "PENDING",
 ] as const satisfies readonly TTimelinePerformanceStatusUi[];
@@ -37,7 +37,7 @@ export const TIMELINE_PERFORMANCE_STATUS_STYLE: Record<
     dot: "bg-primary-400",
     ring: "ring-primary-400",
   },
-  ABOVE_AVERAGE: {
+  ABOVE_AVG: {
     label: "Above Avg",
     description: "최근 평균 대비 눈에 띄게 좋은 성과를 보이고 있어요.",
     legendDescription: "최근 평균보다 눈에 띄게 좋은 성과",

--- a/src/types/timeline/api.ts
+++ b/src/types/timeline/api.ts
@@ -11,13 +11,13 @@ export type TTimelineMetric = (typeof TIMELINE_METRICS)[number];
 
 /*성과 상태
  * ON_TRACK: 최근 추세와 유사한 수준 유지
- * ABOVE_AVERAGE: 최근 평균 대비 눈에 띄게 좋음
+ * ABOVE_AVG: 최근 평균 대비 눈에 띄게 좋음
  * UNDERPERFORM: 최근 평균 대비 눈에 띄게 낮음
  * (미산출 시 null — UI에서는 PENDING으로 표시)
  */
 export const TIMELINE_PERFORMANCE_STATUS = [
   "ON_TRACK",
-  "ABOVE_AVERAGE",
+  "ABOVE_AVG",
   "UNDERPERFORM",
 ] as const;
 export type TTimelinePerformanceStatus =

--- a/src/types/timeline/timeline.mock.ts
+++ b/src/types/timeline/timeline.mock.ts
@@ -129,7 +129,7 @@ export const TIMELINE_GRID_MOCK_WEEK: ITimelineGridData = {
       colStart: 2,
       colEnd: 7,
       row: 1,
-      performanceStatus: "ABOVE_AVERAGE",
+      performanceStatus: "ABOVE_AVG",
     },
     {
       id: 2,
@@ -159,7 +159,7 @@ export const TIMELINE_GRID_MOCK_DAY: ITimelineGridData = {
       colStart: 1,
       colEnd: 2,
       row: 1,
-      performanceStatus: "ABOVE_AVERAGE",
+      performanceStatus: "ABOVE_AVG",
     },
     {
       id: 2,
@@ -187,7 +187,7 @@ export const TIMELINE_GRID_MOCK_MONTH: ITimelineGridData = {
       colStart: 1,
       colEnd: 16,
       row: 1,
-      performanceStatus: "ABOVE_AVERAGE",
+      performanceStatus: "ABOVE_AVG",
     },
     {
       id: 2,
@@ -220,7 +220,7 @@ export const TIMELINE_GRID_EMPTY_MOCK: ITimelineGridData = {
 export const TIMELINE_SUMMARY_PANEL_MOCK: ITimelineSummaryPanelData = {
   timelineName: TIMELINE_DETAIL_MOCK.name,
   periodLabel: "2026.06.01 ~ 2026.06.30",
-  performanceStatus: "ABOVE_AVERAGE",
+  performanceStatus: "ABOVE_AVG",
   aiSummary: TIMELINE_DETAIL_MOCK.summary,
   metrics: [
     { metric: "CLICK", label: "클릭", value: 3730, changeRate: 0.08 },


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #351 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

타임라인 `performaceStatus` 값 `ABOVE_AVERAGE` → `ABOVE_AVG`로 백엔드와 통일

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 타임라인 성과 상태 명칭을 `ABOVE_AVERAGE`에서 `ABOVE_AVG`로 통일했습니다.
  * 주간·일간·월간 타임라인과 성과 요약 영역에 변경된 상태값을 반영했습니다.
  * 해당 상태에 대한 범례와 UI 스타일 표시가 정상적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->