### PR TITLE
[Bugfix/#358] develop → main Coderabbit 피드백 반영

### DIFF
--- a/src/components/setting/NotificationSection.tsx
+++ b/src/components/setting/NotificationSection.tsx
@@ -165,7 +165,9 @@ export default function NotificationSection({
               <div className="min-w-0">
                 <p className="font-body1 text-text-title">슬랙 연동하기</p>
                 <p className="font-body2 text-text-muted">
-                  {slackConnected ? "연동됨" : "Webhook URL로 연동"}
+                  {slackConnected
+                    ? "연동됨 • 알림 on/off는 저장 시 반영"
+                    : "Webhook URL로 연동"}
                 </p>
               </div>
             </div>
@@ -230,7 +232,9 @@ export default function NotificationSection({
               <div className="min-w-0">
                 <p className="font-body1 text-text-title">디스코드 연동하기</p>
                 <p className="font-body2 text-text-muted">
-                  {discordConnected ? "연동됨" : "Webhook URL로 연동"}
+                  {discordConnected
+                    ? "연동됨 • 알림 on/off는 저장 시 반영"
+                    : "Webhook URL로 연동"}
                 </p>
               </div>
             </div>

--- a/src/components/workspace/MemberList.tsx
+++ b/src/components/workspace/MemberList.tsx
@@ -29,8 +29,8 @@ type TMemberListProps = {
   >;
   isNotificationLoading: boolean;
   isNotificationError: boolean;
-  onReceiveToggle: (email: string) => void;
-  isReceiveUpdating?: boolean;
+  onReceiveToggle: (email: string, memberId: number) => void;
+  updatingMemberId?: number | null;
 };
 
 export default function MemberList({
@@ -46,7 +46,7 @@ export default function MemberList({
   isNotificationLoading,
   isNotificationError,
   onReceiveToggle,
-  isReceiveUpdating = false,
+  updatingMemberId,
 }: TMemberListProps) {
   const [inviteMemberOpen, setInviteMemberOpen] = useState(false);
 
@@ -120,12 +120,14 @@ export default function MemberList({
                   notificationReceiveByEmail.get(member.email)?.isReceive
                 }
                 isNotificationLoading={isNotificationLoading}
-                isReceiveUpdating={isReceiveUpdating}
+                isReceiveUpdating={updatingMemberId === member.memberId}
                 onRoleChange={(newRole) =>
                   onRoleChange(member.memberId, newRole)
                 }
                 onDeleteClick={() => onDeleteClick(member)}
-                onReceiveToggle={() => onReceiveToggle(member.email)}
+                onReceiveToggle={() =>
+                  onReceiveToggle(member.email, member.memberId)
+                }
               />
             ))}
           </ul>

--- a/src/components/workspace/MemberList.tsx
+++ b/src/components/workspace/MemberList.tsx
@@ -87,7 +87,7 @@ export default function MemberList({
             현재 {totalCount}명의 구성원이 활동 중입니다
           </p>
           {isNotificationError && (
-            <p className="mt-2 font-body2 text-info-red">
+            <p role="alert" className="mt-2 font-body2 text-info-red">
               알림 설정을 불러오지 못했습니다
             </p>
           )}

--- a/src/hooks/dashboard/useClickStream.ts
+++ b/src/hooks/dashboard/useClickStream.ts
@@ -75,6 +75,12 @@ export function useClickStream(options: TUseClickStreamOptions = {}) {
           // refreshTokenOnce()로 동시 다발 401(플랫폼별 3개 SSE)에도 reissue는 1회만 실행
           if (response.status === 401) {
             const newToken = await refreshTokenOnce();
+            if (
+              controller.signal.aborted ||
+              useAuthStore.getState().accessToken !== accessToken
+            ) {
+              return;
+            }
             if (newToken) {
               useAuthStore.getState().setAccessToken(newToken);
             } else {

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -628,20 +628,29 @@ export default function Setting() {
             email={draftProfile.email}
             masterEnabled={draftOrgNotif.masterEnabled}
             onMasterEnabledChange={(value) => {
+              if (!value) {
+                setDraftOrgNotif((prev) => ({
+                  ...prev,
+                  masterEnabled: false,
+                  slackEnabled: false,
+                  discordEnabled: false,
+                }));
+                setDraftChannel({ browserPush: false, emailNotif: false });
+                setDraftWorkspaceNotif({
+                  clickAlarm: false,
+                  weeklyReport: false,
+                });
+                return;
+              }
               setDraftOrgNotif((prev) => ({
                 ...prev,
-                masterEnabled: value,
-                slackEnabled: value,
-                discordEnabled: value,
+                masterEnabled: true,
+                slackEnabled: prev.slackConnected && savedOrgNotif.slackEnabled,
+                discordEnabled:
+                  prev.discordConnected && savedOrgNotif.discordEnabled,
               }));
-              setDraftChannel({
-                browserPush: value,
-                emailNotif: value,
-              });
-              setDraftWorkspaceNotif({
-                clickAlarm: value,
-                weeklyReport: value,
-              });
+              setDraftChannel(savedChannel);
+              setDraftWorkspaceNotif(savedWorkspaceNotif);
             }}
             browserPush={draftChannel.browserPush}
             emailNotif={draftChannel.emailNotif}

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -418,6 +418,7 @@ export default function Setting() {
         shouldSaveMaster ||
         shouldSaveOrg
       ) {
+        const savedSteps: string[] = [];
         try {
           if (shouldSaveChannel) {
             await updateChannels.mutateAsync({
@@ -425,6 +426,7 @@ export default function Setting() {
               isEmailEnabled: draftChannel.emailNotif,
             });
             setSavedChannel(draftChannel);
+            savedSteps.push("알림 채널");
           }
           if (shouldSaveAlerts) {
             await updateAlerts.mutateAsync({
@@ -432,6 +434,7 @@ export default function Setting() {
               alertReport: draftWorkspaceNotif.weeklyReport,
             });
             setSavedWorkspaceNotif(draftWorkspaceNotif);
+            savedSteps.push("워크스페이스 알림");
           }
           if (shouldSaveMaster) {
             await updateMaster.mutateAsync({
@@ -441,6 +444,7 @@ export default function Setting() {
               ...prev,
               masterEnabled: draftOrgNotif.masterEnabled,
             }));
+            savedSteps.push("마스터 알림");
           }
           if (shouldSaveOrg) {
             await updateOrg.mutateAsync(
@@ -458,6 +462,7 @@ export default function Setting() {
               slackEnabled: draftOrgNotif.slackEnabled,
               discordEnabled: draftOrgNotif.discordEnabled,
             }));
+            savedSteps.push("슬랙/디스코드 설정");
           }
           savedAnyNotification = true;
         } catch (e) {
@@ -465,7 +470,11 @@ export default function Setting() {
           if (savedAccount) {
             toast.success("회원정보가 수정되었습니다");
           }
-          toast.error(error.message ?? "알림 설정 저장에 실패했습니다");
+          toast.error(
+            savedSteps.length > 0
+              ? `${savedSteps.join(", ")}은(는) 저장됐지만, 이후 단계에서 실패했습니다`
+              : (error.message ?? "알림 설정 저장에 실패했습니다"),
+          );
           return;
         }
       }

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -164,8 +164,8 @@ export default function Setting() {
     isDiscordEnabled: draftOrgNotif.discordEnabled,
     discordWebhookUrl: "",
     disconnectDiscord: false,
-    alertClicks: notificationSettings?.orgAlertClicks ?? false,
-    alertReport: notificationSettings?.orgAlertReport ?? false,
+    alertClicks: draftWorkspaceNotif.clickAlarm ?? false,
+    alertReport: draftWorkspaceNotif.weeklyReport ?? false,
     ...overrides,
   });
 

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -38,6 +38,8 @@ export default function MemberManagement() {
   const [selectedDeleteMember, setSelectedDeleteMember] =
     useState<TWorkspaceMember | null>(null);
 
+  const [updatingMemberId, setUpdatingMemberId] = useState<number | null>(null);
+
   const observerRef = useRef<HTMLDivElement | null>(null);
 
   const notificationMembersQuery = useNotificationMembers(orgId);
@@ -266,10 +268,11 @@ export default function MemberManagement() {
   };
   const updateNotificationMembersMutation = useUpdateNotificationMembers(orgId);
 
-  const handleReceiveToggle = async (email: string) => {
+  const handleReceiveToggle = async (email: string, memberId: number) => {
     const current = notificationReceiveByEmail.get(email);
     if (!current) return;
 
+    setUpdatingMemberId(memberId);
     try {
       await updateNotificationMembersMutation.mutateAsync({
         members: [
@@ -287,6 +290,8 @@ export default function MemberManagement() {
     } catch (e) {
       const error = e as IApiErrorResponse;
       toast.error(error.message ?? "알림 수신 변경에 실패했습니다");
+    } finally {
+      setUpdatingMemberId(null);
     }
   };
 
@@ -351,7 +356,7 @@ export default function MemberManagement() {
           }
           isNotificationError={notificationMembersQuery.isError}
           onReceiveToggle={handleReceiveToggle}
-          isReceiveUpdating={updateNotificationMembersMutation.isPending}
+          updatingMemberId={updatingMemberId}
         />
 
         <PermissionTable />


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #358 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 슬랙/디스코드 행에 알림 토글은 저장 시 반영된다는 안내 문구 추가
- 멤버 알림 수신 토글 pending을 `updatingMemberId`로 행 단위 처리
- `buildOrgBody`의 `alertClicks`/`alertReport`를 draft 값으로 전달해 stale 덮어쓰기 방지
- 알림 설정 부분 저장 실패 시 성공한 단계명을 toast에 표시
- 마스터 알림 재활성화 시 기존 저장값 복원
- SSE 401 재발급 중 abort/토큰 변경 시 early return

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- develop → main 머지 시 CodeRabbit 피드백을 후반영한 PR입니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
