### PR TITLE
[Feature/#310] 플랫폼·광고·연동 페이지 ErrorBoundary 적용

### DIFF
--- a/src/components/common/error/AreaErrorFallback.stories.tsx
+++ b/src/components/common/error/AreaErrorFallback.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+
+import AreaErrorFallback from "./AreaErrorFallback";
+
+const meta: Meta<typeof AreaErrorFallback> = {
+  title: "Common/Error/AreaErrorFallback",
+  component: AreaErrorFallback,
+  args: {
+    error: new Error("영역을 불러오지 못했습니다."),
+    resetErrorBoundary: fn(),
+  },
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+type TStory = StoryObj<typeof AreaErrorFallback>;
+
+export const Default: TStory = {};
+
+export const InCard: TStory = {
+  render: (args) => (
+    <div className="w-120 rounded-3xl bg-surface-100 p-7 shadow-Soft">
+      <p className="mb-4 font-heading4 text-text-title">캠페인 목록</p>
+      <AreaErrorFallback {...args} />
+    </div>
+  ),
+};

--- a/src/components/common/error/AreaErrorFallback.tsx
+++ b/src/components/common/error/AreaErrorFallback.tsx
@@ -1,0 +1,36 @@
+import { memo } from "react";
+
+import Button from "@/components/common/button/Button";
+
+import type { FallbackProps } from "./ErrorBoundary";
+
+import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
+
+const AreaErrorFallback = memo(function AreaErrorFallback({
+  resetErrorBoundary,
+}: FallbackProps) {
+  return (
+    <div
+      role="alert"
+      className="flex min-h-40 w-full flex-1 flex-col items-center justify-center gap-4 rounded-2xl bg-surface-200/40 px-6 py-8 text-center"
+    >
+      <WarnCircleIcon
+        className="h-7 w-7 shrink-0 text-info-red"
+        aria-hidden="true"
+      />
+      <div className="flex flex-col gap-1">
+        <p className="font-body1 text-text-title">
+          이 영역을 불러오지 못했어요
+        </p>
+        <p className="font-body2 text-text-muted">
+          일시적인 오류입니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      </div>
+      <Button variant="outline" size="small" onClick={resetErrorBoundary}>
+        다시 시도
+      </Button>
+    </div>
+  );
+});
+
+export default AreaErrorFallback;

--- a/src/components/dashboard/platform/AllPlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/AllPlatformTrafficChart.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import ReactApexChart from "react-apexcharts";
 import type { ApexOptions } from "apexcharts";
 
@@ -17,6 +17,7 @@ import { parseMinuteToTimestamp } from "@/utils/dashboard/parseMinuteToTimestamp
 
 import { useClickStream } from "@/hooks/dashboard/useClickStream";
 
+import Button from "@/components/common/button/Button";
 import { Skeleton } from "@/components/common/skeleton/Skeleton";
 
 const STREAM_MODE = "dummy" as const;
@@ -36,6 +37,12 @@ const AllPlatformTrafficChart = memo(function AllPlatformTrafficChart() {
   });
 
   const streams = [googleStream, naverStream, metaStream];
+
+  const reconnectFailedStreams = useCallback(() => {
+    if (googleStream.isError) googleStream.reconnect();
+    if (naverStream.isError) naverStream.reconnect();
+    if (metaStream.isError) metaStream.reconnect();
+  }, [googleStream, naverStream, metaStream]);
 
   // 첫 응답도 에러도 없는 스트림이 있으면 로딩
   const isLoading = streams.some((s) => s.data == null && !s.isError);
@@ -159,8 +166,18 @@ const AllPlatformTrafficChart = memo(function AllPlatformTrafficChart() {
 
   if (isAllFailed) {
     return (
-      <div className="flex h-75 items-center justify-center font-body2 text-text-muted">
-        실시간 데이터를 불러오지 못했습니다.
+      <div className="flex h-75 flex-col items-center justify-center gap-4 text-center">
+        <p className="font-body2 text-text-muted">
+          실시간 데이터를 불러오지 못했습니다.
+        </p>
+        <Button
+          variant="outline"
+          size="small"
+          type="button"
+          onClick={reconnectFailedStreams}
+        >
+          다시 시도
+        </Button>
       </div>
     );
   }
@@ -180,9 +197,19 @@ const AllPlatformTrafficChart = memo(function AllPlatformTrafficChart() {
   return (
     <div className="flex h-full min-h-75 w-full flex-col">
       {hasPartialError && (
-        <p className="mb-2 font-caption text-text-muted">
-          일부 플랫폼 실시간 데이터를 불러오지 못했습니다.
-        </p>
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          <p className="font-caption text-text-muted">
+            일부 플랫폼 실시간 데이터를 불러오지 못했습니다.
+          </p>
+          <Button
+            variant="outline"
+            size="small"
+            type="button"
+            onClick={reconnectFailedStreams}
+          >
+            다시 시도
+          </Button>
+        </div>
       )}
       <div className="min-h-0 flex-1">
         <ReactApexChart

--- a/src/components/dashboard/platform/AllPlatformView.tsx
+++ b/src/components/dashboard/platform/AllPlatformView.tsx
@@ -13,6 +13,8 @@ import { usePlatformRoasRankings } from "@/hooks/dashboard/usePlatformRoasRankin
 import Badge from "@/components/common/badge/Badge";
 import Card from "@/components/common/card/Card";
 import ChartLegend from "@/components/common/chart/ChartLegend";
+import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import AdStatusChart from "@/components/dashboard/charts/AdStatusChart";
 import PerformanceEfficiencyChart from "@/components/dashboard/charts/PerformanceEfficiencyChart";
 import AllPlatformTrafficChart from "@/components/dashboard/platform/AllPlatformTrafficChart";
@@ -63,19 +65,24 @@ export default function AllPlatformView() {
           }
           className="flex-1 min-h-67 flex flex-col"
         >
-          {isRankingsLoading ? (
-            <TopPerformanceListSkeleton />
-          ) : isRankingsError || !roasRankings ? (
-            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
-              데이터를 불러오지 못했습니다.
-            </div>
-          ) : roasRankings.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
-              표시할 순위 데이터가 없습니다.
-            </div>
-          ) : (
-            <TopPerformanceList rankings={roasRankings} />
-          )}
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[roasRankings]}
+          >
+            {isRankingsLoading ? (
+              <TopPerformanceListSkeleton />
+            ) : isRankingsError || !roasRankings ? (
+              <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+                데이터를 불러오지 못했습니다.
+              </div>
+            ) : roasRankings.length === 0 ? (
+              <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+                표시할 순위 데이터가 없습니다.
+              </div>
+            ) : (
+              <TopPerformanceList rankings={roasRankings} />
+            )}
+          </ErrorBoundary>
         </Card>
 
         {/* 광고 소재 현황 */}
@@ -98,19 +105,24 @@ export default function AllPlatformView() {
           }
           className="flex-1 min-h-67 flex flex-col"
         >
-          {isAdStatusLoading ? (
-            <AdStatusChartSkeleton />
-          ) : isAdStatusError || !adStatus ? (
-            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
-              데이터를 불러오지 못했습니다.
-            </div>
-          ) : adStatus.providerCount.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
-              표시할 광고 소재가 없습니다.
-            </div>
-          ) : (
-            <AdStatusChart data={adStatus.providerCount} />
-          )}
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[adStatus]}
+          >
+            {isAdStatusLoading ? (
+              <AdStatusChartSkeleton />
+            ) : isAdStatusError || !adStatus ? (
+              <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+                데이터를 불러오지 못했습니다.
+              </div>
+            ) : adStatus.providerCount.length === 0 ? (
+              <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+                표시할 광고 소재가 없습니다.
+              </div>
+            ) : (
+              <AdStatusChart data={adStatus.providerCount} />
+            )}
+          </ErrorBoundary>
         </Card>
 
         {/* 플랫폼별 성과 효율 비교 */}
@@ -127,19 +139,24 @@ export default function AllPlatformView() {
             />
           }
         >
-          {isPerformanceLoading ? (
-            <PerformanceEfficiencyChartSkeleton />
-          ) : isPerformanceError || !platformPerformance ? (
-            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
-              데이터를 불러오지 못했습니다.
-            </div>
-          ) : platformPerformance.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
-              표시할 성과 데이터가 없습니다.
-            </div>
-          ) : (
-            <PerformanceEfficiencyChart data={platformPerformance} />
-          )}
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[platformPerformance]}
+          >
+            {isPerformanceLoading ? (
+              <PerformanceEfficiencyChartSkeleton />
+            ) : isPerformanceError || !platformPerformance ? (
+              <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+                데이터를 불러오지 못했습니다.
+              </div>
+            ) : platformPerformance.length === 0 ? (
+              <div className="flex flex-1 items-center justify-center font-body2 text-text-sub">
+                표시할 성과 데이터가 없습니다.
+              </div>
+            ) : (
+              <PerformanceEfficiencyChart data={platformPerformance} />
+            )}
+          </ErrorBoundary>
         </Card>
       </div>
 
@@ -150,30 +167,37 @@ export default function AllPlatformView() {
         description={<ChartLegend items={platformChartLegendItems} />}
       >
         <div className="flex-1 min-h-0">
-          <AllPlatformTrafficChart />
+          <ErrorBoundary FallbackComponent={ChartErrorFallback}>
+            <AllPlatformTrafficChart />
+          </ErrorBoundary>
         </div>
       </Card>
 
       {/* 개별 플랫폼 상세 */}
-      <div className="grid grid-cols-3 tablet:grid-cols-1 gap-6">
-        {isPerformanceLoading ? (
-          Array.from({ length: 3 }).map((_, i) => (
-            <PlatformDetailCardSkeleton key={i} />
-          ))
-        ) : isPerformanceError || !platformPerformance ? (
-          <div className="col-span-3 tablet:col-span-1 flex items-center justify-center font-body2 text-text-sub py-16">
-            데이터를 불러오지 못했습니다.
-          </div>
-        ) : platformPerformance.length === 0 ? (
-          <div className="col-span-3 tablet:col-span-1 flex items-center justify-center font-body2 text-text-sub py-16">
-            표시할 플랫폼 데이터가 없습니다.
-          </div>
-        ) : (
-          platformPerformance.map((platform) => (
-            <PlatformDetailCard key={platform.provider} data={platform} />
-          ))
-        )}
-      </div>
+      <ErrorBoundary
+        FallbackComponent={ChartErrorFallback}
+        resetKeys={[platformPerformance]}
+      >
+        <div className="grid grid-cols-3 tablet:grid-cols-1 gap-6">
+          {isPerformanceLoading ? (
+            Array.from({ length: 3 }).map((_, i) => (
+              <PlatformDetailCardSkeleton key={i} />
+            ))
+          ) : isPerformanceError || !platformPerformance ? (
+            <div className="col-span-3 tablet:col-span-1 flex items-center justify-center font-body2 text-text-sub py-16">
+              데이터를 불러오지 못했습니다.
+            </div>
+          ) : platformPerformance.length === 0 ? (
+            <div className="col-span-3 tablet:col-span-1 flex items-center justify-center font-body2 text-text-sub py-16">
+              표시할 플랫폼 데이터가 없습니다.
+            </div>
+          ) : (
+            platformPerformance.map((platform) => (
+              <PlatformDetailCard key={platform.provider} data={platform} />
+            ))
+          )}
+        </div>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/components/dashboard/platform/PlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/PlatformTrafficChart.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/utils/dashboard/metricRegistry";
 import { parseMinuteToTimestamp } from "@/utils/dashboard/parseMinuteToTimestamp";
 
+import Button from "@/components/common/button/Button";
 import { Skeleton } from "@/components/common/skeleton/Skeleton";
 import { useAnomalyMarkerPos } from "@/components/dashboard/charts/useAnomalyMarkerPos";
 
@@ -23,6 +24,7 @@ interface IPlatformTrafficChartProps {
   platform: TProviderType;
   isError?: boolean;
   suspectDetail: IClickStreamItem["suspectDetail"] | null;
+  onRetry?: () => void;
 }
 
 // 이상 징후 상세 버블
@@ -75,6 +77,7 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
   platform,
   isError = false,
   suspectDetail = null,
+  onRetry,
 }: IPlatformTrafficChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const anomalyBubbleId = useId();
@@ -254,8 +257,20 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
 
   if (isError && !data) {
     return (
-      <div className="flex h-75 items-center justify-center font-body2 text-text-muted">
-        실시간 데이터를 불러오지 못했습니다.
+      <div className="flex h-75 flex-col items-center justify-center gap-4 text-center">
+        <p className="font-body2 text-text-muted">
+          실시간 데이터를 불러오지 못했습니다.
+        </p>
+        {onRetry ? (
+          <Button
+            variant="outline"
+            size="small"
+            type="button"
+            onClick={onRetry}
+          >
+            다시 시도
+          </Button>
+        ) : null}
       </div>
     );
   }
@@ -275,9 +290,21 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
   return (
     <div className="flex h-full min-h-75 w-full flex-col">
       {isError && (
-        <p className="mb-2 font-caption text-text-muted">
-          연결이 원활하지 않아 마지막 데이터를 표시합니다.
-        </p>
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          <p className="font-caption text-text-muted">
+            연결이 원활하지 않아 마지막 데이터를 표시합니다.
+          </p>
+          {onRetry ? (
+            <Button
+              variant="outline"
+              size="small"
+              type="button"
+              onClick={onRetry}
+            >
+              다시 시도
+            </Button>
+          ) : null}
+        </div>
       )}
       <div
         ref={containerRef}

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -79,6 +79,7 @@ export default function SinglePlatformView({
     data: clickStreamData,
     suspectDetail,
     isError: isClickStreamError,
+    reconnect: reconnectClickStream,
   } = useClickStream({
     mode: "dummy",
     providerType: platform,
@@ -174,6 +175,7 @@ export default function SinglePlatformView({
               platform={platform}
               isError={isClickStreamError}
               suspectDetail={suspectDetail}
+              onRetry={reconnectClickStream}
             />
           </ErrorBoundary>
         </Card>

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -16,6 +16,9 @@ import Badge from "@/components/common/badge/Badge";
 import Card from "@/components/common/card/Card";
 import StatCard from "@/components/common/card/StatCard";
 import ChartLegend from "@/components/common/chart/ChartLegend";
+import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
+import MetricErrorFallback from "@/components/common/error/MetricErrorFallback";
 import { Skeleton } from "@/components/common/skeleton/Skeleton";
 import DashboardAiSummarySection from "@/components/dashboard/ai-report/components/DashboardAiSummarySection";
 import BudgetGaugeChart, {
@@ -111,37 +114,42 @@ export default function SinglePlatformView({
       </div>
 
       {/* top */}
-      <div className="grid grid-cols-4 tablet:grid-cols-2 gap-4">
-        {isMetricsLoading ? (
-          Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="rounded-3xl border border-surface-100/40 bg-surface-100/80 p-7 shadow-Soft backdrop-blur-sm flex flex-col gap-4"
-            >
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-8 w-24" />
-              <Skeleton className="h-6 w-14 rounded-full" />
+      <ErrorBoundary
+        FallbackComponent={MetricErrorFallback}
+        resetKeys={[platformData]}
+      >
+        <div className="grid grid-cols-4 tablet:grid-cols-2 gap-4">
+          {isMetricsLoading ? (
+            Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-3xl border border-surface-100/40 bg-surface-100/80 p-7 shadow-Soft backdrop-blur-sm flex flex-col gap-4"
+              >
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-8 w-24" />
+                <Skeleton className="h-6 w-14 rounded-full" />
+              </div>
+            ))
+          ) : isMetricsError ? (
+            <div className="col-span-4 flex items-center justify-center py-8 text-center font-body2 text-text-muted">
+              지표 데이터를 불러오지 못했습니다.
             </div>
-          ))
-        ) : isMetricsError ? (
-          <div className="col-span-4 flex items-center justify-center py-8 text-center font-body2 text-text-muted">
-            지표 데이터를 불러오지 못했습니다.
-          </div>
-        ) : !platformData ? (
-          <div className="col-span-4 flex items-center justify-center py-8 text-center font-body2 text-text-muted">
-            표시할 지표 데이터가 없습니다.
-          </div>
-        ) : (
-          kpis.map((kpi) => (
-            <StatCard
-              key={kpi.title}
-              title={kpi.title}
-              value={kpi.value}
-              trend={kpi.trend}
-            />
-          ))
-        )}
-      </div>
+          ) : !platformData ? (
+            <div className="col-span-4 flex items-center justify-center py-8 text-center font-body2 text-text-muted">
+              표시할 지표 데이터가 없습니다.
+            </div>
+          ) : (
+            kpis.map((kpi) => (
+              <StatCard
+                key={kpi.title}
+                title={kpi.title}
+                value={kpi.value}
+                trend={kpi.trend}
+              />
+            ))
+          )}
+        </div>
+      </ErrorBoundary>
 
       {/* mid */}
       <div className="grid grid-cols-3 tablet:grid-cols-1 gap-6">
@@ -157,12 +165,17 @@ export default function SinglePlatformView({
             />
           }
         >
-          <PlatformTrafficChart
-            data={clickStreamData}
-            platform={platform}
-            isError={isClickStreamError}
-            suspectDetail={suspectDetail}
-          />
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[clickStreamData, platform]}
+          >
+            <PlatformTrafficChart
+              data={clickStreamData}
+              platform={platform}
+              isError={isClickStreamError}
+              suspectDetail={suspectDetail}
+            />
+          </ErrorBoundary>
         </Card>
 
         <Card
@@ -188,23 +201,28 @@ export default function SinglePlatformView({
             )
           }
         >
-          {isBudgetLoading ? (
-            <div className="flex flex-1 items-center justify-center p-8">
-              <Skeleton className="h-32 w-full rounded-2xl" />
-            </div>
-          ) : isBudgetError ? (
-            <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-info-red">
-              예산 데이터를 불러오지 못했습니다.
-            </div>
-          ) : budget ? (
-            <div className="flex flex-1 flex-col">
-              <BudgetGaugeChart {...budget} />
-            </div>
-          ) : (
-            <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-text-muted">
-              표시할 예산 데이터가 없습니다.
-            </div>
-          )}
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[budget]}
+          >
+            {isBudgetLoading ? (
+              <div className="flex flex-1 items-center justify-center p-8">
+                <Skeleton className="h-32 w-full rounded-2xl" />
+              </div>
+            ) : isBudgetError ? (
+              <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-info-red">
+                예산 데이터를 불러오지 못했습니다.
+              </div>
+            ) : budget ? (
+              <div className="flex flex-1 flex-col">
+                <BudgetGaugeChart {...budget} />
+              </div>
+            ) : (
+              <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-text-muted">
+                표시할 예산 데이터가 없습니다.
+              </div>
+            )}
+          </ErrorBoundary>
         </Card>
       </div>
 
@@ -241,30 +259,37 @@ export default function SinglePlatformView({
           </div>
         }
       >
-        {isMetricFactsLoading ? (
-          <div className="flex items-center justify-center py-16">
-            <Skeleton className="h-40 w-full rounded-2xl" />
-          </div>
-        ) : isMetricFactsError ? (
-          <div className="flex items-center justify-center py-16 text-center font-body2 text-info-red">
-            광고 현황 데이터를 불러오지 못했습니다.
-          </div>
-        ) : !metricFacts?.dailyRows.length ? (
-          <div className="flex items-center justify-center py-16 text-center font-body2 text-text-muted">
-            표시할 광고 현황 데이터가 없습니다.
-          </div>
-        ) : (
-          <PlatformDetailTable
-            data={metricFacts.dailyRows}
-            total={metricFacts.totalRow}
-          />
-        )}
+        <ErrorBoundary
+          FallbackComponent={ChartErrorFallback}
+          resetKeys={[metricFacts, viewRange]}
+        >
+          {isMetricFactsLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <Skeleton className="h-40 w-full rounded-2xl" />
+            </div>
+          ) : isMetricFactsError ? (
+            <div className="flex items-center justify-center py-16 text-center font-body2 text-info-red">
+              광고 현황 데이터를 불러오지 못했습니다.
+            </div>
+          ) : !metricFacts?.dailyRows.length ? (
+            <div className="flex items-center justify-center py-16 text-center font-body2 text-text-muted">
+              표시할 광고 현황 데이터가 없습니다.
+            </div>
+          ) : (
+            <PlatformDetailTable
+              data={metricFacts.dailyRows}
+              total={metricFacts.totalRow}
+            />
+          )}
+        </ErrorBoundary>
       </Card>
 
-      <DashboardAiSummarySection
-        provider={platform}
-        idPrefix={`platform-ai-${platform.toLowerCase()}`}
-      />
+      <ErrorBoundary FallbackComponent={ChartErrorFallback}>
+        <DashboardAiSummarySection
+          provider={platform}
+          idPrefix={`platform-ai-${platform.toLowerCase()}`}
+        />
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/hooks/dashboard/useClickStream.ts
+++ b/src/hooks/dashboard/useClickStream.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchEventSource } from "@microsoft/fetch-event-source";
 
 import type {
@@ -46,7 +46,12 @@ export function useClickStream(options: TUseClickStreamOptions = {}) {
   const [suspectDetail, setSuspectDetail] =
     useState<IClickStreamItem["suspectDetail"]>(null);
   const [isError, setIsError] = useState(false);
+  const [connectAttempt, setConnectAttempt] = useState(0);
   const retryCountRef = useRef(0);
+
+  const reconnect = useCallback(() => {
+    setConnectAttempt((attempt) => attempt + 1);
+  }, []);
 
   useEffect(() => {
     if (!orgId || !accessToken) return;
@@ -130,7 +135,7 @@ export function useClickStream(options: TUseClickStreamOptions = {}) {
     );
 
     return () => controller.abort();
-  }, [orgId, accessToken, mode, providerType]);
+  }, [orgId, accessToken, mode, providerType, connectAttempt]);
 
-  return { data, suspectDetail, isError };
+  return { data, suspectDetail, isError, reconnect };
 }

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -8,6 +8,8 @@ import { useOverviewCampaignList } from "@/hooks/dashboard/useOverviewCampaignLi
 import CampaignTable from "@/components/ads/CampaignTable";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
+import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
 
@@ -217,14 +219,19 @@ export default function AdsListPage() {
         </div>
 
         <div className="min-w-0 flex-1">
-          <CampaignTable
-            embedded
-            campaigns={campaigns}
-            onRowClick={(id) => handleCampaignClick(id)}
-            selectedProjectIds={selectedIds}
-            onToggleProject={toggleProject}
-            onToggleSelectAllVisible={toggleSelectAllVisible}
-          />
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[campaigns]}
+          >
+            <CampaignTable
+              embedded
+              campaigns={campaigns}
+              onRowClick={(id) => handleCampaignClick(id)}
+              selectedProjectIds={selectedIds}
+              onToggleProject={toggleProject}
+              onToggleSelectAllVisible={toggleSelectAllVisible}
+            />
+          </ErrorBoundary>
         </div>
       </Card>
 

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -8,7 +8,7 @@ import { useOverviewCampaignList } from "@/hooks/dashboard/useOverviewCampaignLi
 import CampaignTable from "@/components/ads/CampaignTable";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
-import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
@@ -220,7 +220,7 @@ export default function AdsListPage() {
 
         <div className="min-w-0 flex-1">
           <ErrorBoundary
-            FallbackComponent={ChartErrorFallback}
+            FallbackComponent={AreaErrorFallback}
             resetKeys={[campaigns]}
           >
             <CampaignTable

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -11,7 +11,7 @@ import AdListTable from "@/components/ads/AdListTable";
 import Badge from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
-import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
@@ -328,7 +328,7 @@ export default function CampaignDetail() {
 
           <div className="min-h-0 min-w-0 flex-1">
             <ErrorBoundary
-              FallbackComponent={ChartErrorFallback}
+              FallbackComponent={AreaErrorFallback}
               resetKeys={[adsList]}
             >
               <AdListTable

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -11,6 +11,8 @@ import AdListTable from "@/components/ads/AdListTable";
 import Badge from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
+import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
 
@@ -325,14 +327,19 @@ export default function CampaignDetail() {
           </div>
 
           <div className="min-h-0 min-w-0 flex-1">
-            <AdListTable
-              embedded
-              ads={adsList}
-              refetchAds={refetchAds}
-              selectedAdIds={selectedAdIds}
-              onToggleAd={toggleAd}
-              onToggleSelectAllVisible={toggleSelectAllVisible}
-            />
+            <ErrorBoundary
+              FallbackComponent={ChartErrorFallback}
+              resetKeys={[adsList]}
+            >
+              <AdListTable
+                embedded
+                ads={adsList}
+                refetchAds={refetchAds}
+                selectedAdIds={selectedAdIds}
+                onToggleAd={toggleAd}
+                onToggleSelectAllVisible={toggleSelectAllVisible}
+              />
+            </ErrorBoundary>
           </div>
         </Card>
       )}

--- a/src/pages/ads/new/CampaignGroup.tsx
+++ b/src/pages/ads/new/CampaignGroup.tsx
@@ -3,6 +3,8 @@ import { useCampaignGroup } from "@/hooks/ads/useCampaignGroup";
 import CampaignPlatformDropdown from "@/components/ads/CampaignPlatformDropdown";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
+import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Input from "@/components/common/input/Input";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
@@ -93,49 +95,54 @@ export default function CampaignGroup() {
             매체에서 캠페인을 선택해야 합니다.
           </p>
         </div>
-        <div className="flex flex-col gap-10">
-          {/* Google */}
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-2 px-1">
-              <GoogleIcon className="w-6 h-6" />
-              <span className="font-body1 text-text-title">Google</span>
+        <ErrorBoundary
+          FallbackComponent={ChartErrorFallback}
+          resetKeys={[googleCampaigns, naverCampaigns, metaCampaigns]}
+        >
+          <div className="flex flex-col gap-10">
+            {/* Google */}
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2 px-1">
+                <GoogleIcon className="w-6 h-6" />
+                <span className="font-body1 text-text-title">Google</span>
+              </div>
+              <CampaignPlatformDropdown
+                placeholder="캠페인 선택"
+                options={googleCampaigns}
+                selected={googleSelected}
+                onSelect={setGoogleSelected}
+              />
             </div>
-            <CampaignPlatformDropdown
-              placeholder="캠페인 선택"
-              options={googleCampaigns}
-              selected={googleSelected}
-              onSelect={setGoogleSelected}
-            />
-          </div>
 
-          {/* NAVER */}
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-2 px-1">
-              <NaverIcon className="w-6 h-6" />
-              <span className="font-body1 text-text-title">NAVER</span>
+            {/* NAVER */}
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2 px-1">
+                <NaverIcon className="w-6 h-6" />
+                <span className="font-body1 text-text-title">NAVER</span>
+              </div>
+              <CampaignPlatformDropdown
+                placeholder="캠페인 선택"
+                options={naverCampaigns}
+                selected={naverSelected}
+                onSelect={setNaverSelected}
+              />
             </div>
-            <CampaignPlatformDropdown
-              placeholder="캠페인 선택"
-              options={naverCampaigns}
-              selected={naverSelected}
-              onSelect={setNaverSelected}
-            />
-          </div>
 
-          {/* Meta */}
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-2 px-1">
-              <MetaIcon className="h-6 w-6 shrink-0 text-text-title" />
-              <span className="font-body1 text-text-title">Meta</span>
+            {/* Meta */}
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2 px-1">
+                <MetaIcon className="h-6 w-6 shrink-0 text-text-title" />
+                <span className="font-body1 text-text-title">Meta</span>
+              </div>
+              <CampaignPlatformDropdown
+                placeholder="캠페인 선택"
+                options={metaCampaigns}
+                selected={metaSelected}
+                onSelect={setMetaSelected}
+              />
             </div>
-            <CampaignPlatformDropdown
-              placeholder="캠페인 선택"
-              options={metaCampaigns}
-              selected={metaSelected}
-              onSelect={setMetaSelected}
-            />
           </div>
-        </div>
+        </ErrorBoundary>
       </Card>
 
       <div className="flex justify-end mb-5">

--- a/src/pages/ads/new/CampaignGroup.tsx
+++ b/src/pages/ads/new/CampaignGroup.tsx
@@ -3,7 +3,7 @@ import { useCampaignGroup } from "@/hooks/ads/useCampaignGroup";
 import CampaignPlatformDropdown from "@/components/ads/CampaignPlatformDropdown";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
-import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Input from "@/components/common/input/Input";
 import Modal from "@/components/common/modal/Modal";
@@ -96,7 +96,7 @@ export default function CampaignGroup() {
           </p>
         </div>
         <ErrorBoundary
-          FallbackComponent={ChartErrorFallback}
+          FallbackComponent={AreaErrorFallback}
           resetKeys={[googleCampaigns, naverCampaigns, metaCampaigns]}
         >
           <div className="flex flex-col gap-10">

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -14,7 +14,7 @@ import { useCoreMutation } from "@/hooks/customQuery";
 import { useIntegrationOAuthReturn } from "@/hooks/integration/useIntegrationOAuthReturn";
 import { usePlatformConnections } from "@/hooks/integration/usePlatformConnections";
 
-import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import NaverConnectModal from "@/components/integration/NaverConnectModal";
 import PlatformDisconnectModal from "@/components/integration/PlatformDisconnectModal";
@@ -194,7 +194,7 @@ export default function PlatformIntegrationsPage() {
       ) : (
         <>
           <ErrorBoundary
-            FallbackComponent={ChartErrorFallback}
+            FallbackComponent={AreaErrorFallback}
             resetKeys={[platformConnections]}
           >
             <ul className="grid w-full min-w-0 list-none grid-cols-3 items-stretch gap-6 p-0 m-0 tablet:grid-cols-1">

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -14,6 +14,8 @@ import { useCoreMutation } from "@/hooks/customQuery";
 import { useIntegrationOAuthReturn } from "@/hooks/integration/useIntegrationOAuthReturn";
 import { usePlatformConnections } from "@/hooks/integration/usePlatformConnections";
 
+import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
+import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import NaverConnectModal from "@/components/integration/NaverConnectModal";
 import PlatformDisconnectModal from "@/components/integration/PlatformDisconnectModal";
 import PlatformIntegrationCard from "@/components/integration/PlatformIntegrationCard";
@@ -191,26 +193,31 @@ export default function PlatformIntegrationsPage() {
         </div>
       ) : (
         <>
-          <ul className="grid w-full min-w-0 list-none grid-cols-3 items-stretch gap-6 p-0 m-0 tablet:grid-cols-1">
-            {platformConnections.map((item) => (
-              <li
-                key={item.provider}
-                className="flex h-full min-h-0 w-full min-w-0"
-              >
-                <PlatformIntegrationCard
-                  {...item}
-                  onConnect={() => handleConnect(item.provider)}
-                  onReconnect={() => handleConnect(item.provider)}
-                  onDisconnect={() => handleDisconnect(item)}
-                  isConnectLoading={
-                    reconnectMutation.isPending &&
-                    reconnectMutation.variables?.accountId ===
-                      item.platformAccountId
-                  }
-                />
-              </li>
-            ))}
-          </ul>
+          <ErrorBoundary
+            FallbackComponent={ChartErrorFallback}
+            resetKeys={[platformConnections]}
+          >
+            <ul className="grid w-full min-w-0 list-none grid-cols-3 items-stretch gap-6 p-0 m-0 tablet:grid-cols-1">
+              {platformConnections.map((item) => (
+                <li
+                  key={item.provider}
+                  className="flex h-full min-h-0 w-full min-w-0"
+                >
+                  <PlatformIntegrationCard
+                    {...item}
+                    onConnect={() => handleConnect(item.provider)}
+                    onReconnect={() => handleConnect(item.provider)}
+                    onDisconnect={() => handleDisconnect(item)}
+                    isConnectLoading={
+                      reconnectMutation.isPending &&
+                      reconnectMutation.variables?.accountId ===
+                        item.platformAccountId
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </ErrorBoundary>
 
           <div className="flex w-full min-w-0 flex-col items-center gap-8 pt-15">
             <p className="w-full text-center font-body1 text-text-muted/70">


### PR DESCRIPTION
## 🚨 관련 이슈
close #310 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- Overview에 적용된 ErrorBoundary 패턴을 담당 페이지에 동일하게 적용
- 플랫폼 대시보드(전체/단일), 광고 목록·상세·캠페인 그룹, 플랫폼 연동 페이지의 주요 콘텐츠 영역을 섹션별 ErrorBoundary로 감쌈
- API 에러·로딩·empty UI는 기존 분기 유지, 렌더 crash 시에만 fallback + `다시 시도` 표시

> 리뷰 반영

- `AreaErrorFallback` 추가 — 표·드롭다운·카드 등 차트가 아닌 영역용 (`이 영역을 불러오지 못했어요`)
- 광고 목록·상세·캠페인 그룹·플랫폼 연동 페이지에서 `ChartErrorFallback` → `AreaErrorFallback`으로 교체

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 대시보드 차트와 주요 지표 영역에서 오류 발생 시 전체 화면 대신 안내용 대체 화면을 표시합니다.
  * 광고 목록, 캠페인 상세, 캠페인 그룹 및 플랫폼 연동 카드의 렌더링 오류를 안정적으로 처리합니다.
  * 데이터가 새로 로드되면 오류 상태가 자동으로 초기화되어 콘텐츠를 다시 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->