### PR TITLE
[Feature/#367] 로그인/회원가입 returnUrl 복귀 처리

### DIFF
--- a/src/components/auth/flows/signup/ProfileSetupStep.tsx
+++ b/src/components/auth/flows/signup/ProfileSetupStep.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import type { z } from "zod";
 
 import { stripPhoneHyphens } from "@/utils/auth/formatPhoneNumber";
+import { buildPathWithReturnUrl } from "@/utils/auth/returnUrl";
 import { signupProfileSchema } from "@/utils/auth/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
@@ -25,15 +26,18 @@ interface IProfileSetupStepProps {
 
 export default function ProfileSetupStep({ password }: IProfileSetupStepProps) {
   const navigate = useNavigate();
+
+  const [searchParams] = useSearchParams();
+  const returnUrl = searchParams.get("returnUrl");
   const { email, resetAuth } = useAuthStore();
   const { openModal } = useModalStore();
   const { useSignUp } = useAuth();
 
   useEffect(() => {
     if (!email || !password) {
-      navigate("/signup", { replace: true });
+      navigate(buildPathWithReturnUrl("/signup", returnUrl), { replace: true });
     }
-  }, [email, password, navigate]);
+  }, [email, password, navigate, returnUrl]);
 
   const {
     register,
@@ -60,7 +64,9 @@ export default function ProfileSetupStep({ password }: IProfileSetupStepProps) {
             description: `${data.name}님, 환영합니다!`,
           });
           resetAuth();
-          navigate("/login");
+          navigate(buildPathWithReturnUrl("/login", returnUrl), {
+            replace: true,
+          });
         },
         onError: (error) => {
           toast.error(error.message ?? "회원가입에 실패했습니다.");

--- a/src/hooks/auth/useSocialLogin.ts
+++ b/src/hooks/auth/useSocialLogin.ts
@@ -1,9 +1,21 @@
+import { useSearchParams } from "react-router-dom";
+
 import { type TSocialLoginPlatform } from "@/types/auth/auth";
 
+import { AUTH_RETURN_URL_KEY, getSafeReturnUrl } from "@/utils/auth/returnUrl";
+
 export const useSocialLogin = () => {
+  const [searchParams] = useSearchParams();
   const handleSocialLogin = (platform: TSocialLoginPlatform) => {
     const API_TARGET_URL =
       import.meta.env.VITE_API_TARGET_URL || import.meta.env.VITE_API_BASE_URL;
+
+    const safeReturnUrl = getSafeReturnUrl(searchParams.get("returnUrl"), "");
+    if (safeReturnUrl) {
+      sessionStorage.setItem(AUTH_RETURN_URL_KEY, safeReturnUrl);
+    } else {
+      sessionStorage.removeItem(AUTH_RETURN_URL_KEY);
+    }
 
     window.location.href = `${API_TARGET_URL}/oauth2/authorization/${platform}`;
   };

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,9 +1,13 @@
 import { type SubmitHandler, useForm } from "react-hook-form";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import type { z } from "zod";
 
+import {
+  buildPathWithReturnUrl,
+  getSafeReturnUrl,
+} from "@/utils/auth/returnUrl";
 import { loginSchema } from "@/utils/auth/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
@@ -29,13 +33,17 @@ export default function Login() {
   });
 
   const navigate = useNavigate();
+
+  const [searchParams] = useSearchParams();
+  const returnUrl = searchParams.get("returnUrl");
+
   const { useLogin } = useAuth();
   const { handleSocialLogin } = useSocialLogin();
 
   const onSubmit: SubmitHandler<TLoginFormValues> = (data) => {
     useLogin.mutate(data, {
       onSuccess: () => {
-        navigate("/dashboard", { replace: true });
+        navigate(getSafeReturnUrl(returnUrl), { replace: true });
       },
       onError: (error) => {
         toast.error(error.message ?? "로그인에 실패했습니다.");
@@ -68,7 +76,7 @@ export default function Login() {
         />
 
         <Link
-          to="/find-email"
+          to={buildPathWithReturnUrl("/find-email", returnUrl)}
           className="block w-full text-center mt-3 font-caption text-text-body underline underline-offset-4 hover:text-text-auth-sub"
         >
           이메일/비밀번호를 잊어버렸어요
@@ -111,7 +119,7 @@ export default function Login() {
         </div>
 
         <Link
-          to="/signup"
+          to={buildPathWithReturnUrl("/signup", returnUrl)}
           state={{ step: 1 }}
           className="mt-6 font-body2 text-text-placeholder underline underline-offset-4 hover:text-text-auth-sub"
         >

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -2,6 +2,12 @@ import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
+import {
+  AUTH_RETURN_URL_KEY,
+  buildPathWithReturnUrl,
+  getSafeReturnUrl,
+} from "@/utils/auth/returnUrl";
+
 import useAuthStore from "@/store/useAuthStore";
 
 export default function RedirectPage() {
@@ -24,6 +30,9 @@ export default function RedirectPage() {
         name + "=; Max-Age=0; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
     };
 
+    const storedReturnUrl = sessionStorage.getItem(AUTH_RETURN_URL_KEY);
+    sessionStorage.removeItem(AUTH_RETURN_URL_KEY);
+
     const accessToken = getCookie("access_token");
 
     if (accessToken) {
@@ -31,10 +40,12 @@ export default function RedirectPage() {
       setAccessToken(accessToken);
 
       toast.success("소셜 로그인되었습니다.");
-      navigate("/dashboard", { replace: true });
+      navigate(getSafeReturnUrl(storedReturnUrl), { replace: true });
     } else {
       toast.error("소셜 로그인에 실패했습니다. 다시 시도해주세요.");
-      navigate("/login", { replace: true });
+      navigate(buildPathWithReturnUrl("/login", storedReturnUrl), {
+        replace: true,
+      });
     }
   }, [navigate, setAccessToken]);
 

--- a/src/pages/auth/Signup.tsx
+++ b/src/pages/auth/Signup.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useSearchParams } from "react-router-dom";
+
+import { buildPathWithReturnUrl } from "@/utils/auth/returnUrl";
 
 import { useSocialLogin } from "@/hooks/auth/useSocialLogin";
 import { useStepNavigation } from "@/hooks/common/useStepNavigation";
@@ -18,6 +20,9 @@ import useAuthStore from "@/store/useAuthStore";
 
 export default function Signup() {
   const location = useLocation();
+
+  const [searchParams] = useSearchParams();
+  const returnUrl = searchParams.get("returnUrl");
   const { resetAuth } = useAuthStore();
   const { step, setStep, handleNext } = useStepNavigation(
     location.state?.step || 0,
@@ -102,7 +107,7 @@ export default function Signup() {
       <div className="font-body2 text-text-body mt-15 flex gap-2">
         <span>이미 사용자 계정이 있다면?</span>
         <Link
-          to="/login"
+          to={buildPathWithReturnUrl("/login", returnUrl)}
           className="text-text-body underline hover:text-text-auth-sub"
         >
           로그인하기

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { createBrowserRouter, Navigate } from "react-router-dom";
+import { createBrowserRouter, Navigate, useLocation } from "react-router-dom";
+
+import { buildPathWithReturnUrl } from "@/utils/auth/returnUrl";
 
 import AuthRoutes from "./AuthRoutes";
 import MainRoutes from "./MainRoutes";
@@ -16,13 +18,17 @@ const LandingPage = React.lazy(() => import("@/pages/landing/LandingPage"));
 function AuthGuard({ children }: { children: React.ReactNode }) {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const isTokenInitialized = useAuthStore((state) => state.isTokenInitialized);
+  const location = useLocation();
 
   if (!isTokenInitialized) {
     return null;
   }
 
   if (!isLoggedIn) {
-    return <Navigate to="/login" replace />;
+    const returnUrl = `${location.pathname}${location.search}`;
+    return (
+      <Navigate to={buildPathWithReturnUrl("/login", returnUrl)} replace />
+    );
   }
 
   return <>{children}</>;

--- a/src/utils/auth/returnUrl.ts
+++ b/src/utils/auth/returnUrl.ts
@@ -18,12 +18,12 @@ export function getSafeReturnUrl(
   return value;
 }
 
-/*path에 안전한 returnUrl 쿼리를 붙인다. 없으면 path 그대로(소셜로그인은 나가면 url잃어버리니까 미리 저장해놓기)*/
+/*path에 안전한 returnUrl 쿼리를 붙인다. 없으면 path 그대로(즉, path에 쿼리붙이기)*/
 export function buildPathWithReturnUrl(
   path: string,
   returnUrl: string | null | undefined,
 ): string {
-  const safe = getSafeReturnUrl(returnUrl);
+  const safe = getSafeReturnUrl(returnUrl, "");
   if (!safe) return path;
 
   const params = new URLSearchParams({ returnUrl: safe });

--- a/src/utils/auth/returnUrl.ts
+++ b/src/utils/auth/returnUrl.ts
@@ -1,0 +1,31 @@
+export const AUTH_RETURN_URL_KEY = "authReturnUrl";
+
+const DEFAULT_FALLBACK = "/dashboard";
+
+// 내부 경로로만 허용되도록. 오픈 리다이렉트 방지
+export function getSafeReturnUrl(
+  raw: string | null | undefined,
+  fallback: string = DEFAULT_FALLBACK,
+): string {
+  if (!raw) return fallback;
+
+  const value = raw.trim();
+  if (!value.startsWith("/")) return fallback;
+  if (value.startsWith("//")) return fallback;
+  if (value.includes("://")) return fallback;
+  if (value.includes("\\")) return fallback;
+
+  return value;
+}
+
+/*path에 안전한 returnUrl 쿼리를 붙인다. 없으면 path 그대로(소셜로그인은 나가면 url잃어버리니까 미리 저장해놓기)*/
+export function buildPathWithReturnUrl(
+  path: string,
+  returnUrl: string | null | undefined,
+): string {
+  const safe = getSafeReturnUrl(returnUrl);
+  if (!safe) return path;
+
+  const params = new URLSearchParams({ returnUrl: safe });
+  return `${path}?${params.toString()}`;
+}

--- a/src/utils/auth/returnUrl.ts
+++ b/src/utils/auth/returnUrl.ts
@@ -10,6 +10,12 @@ export function getSafeReturnUrl(
   if (!raw) return fallback;
 
   const value = raw.trim();
+  // if (/[\u0000-\u001F\u007F]/.test(value)) return fallback;
+  // ESLint가 정규식 리터럴을 막기 때문에 같은 조건의 charCodeAt 사용
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return fallback;
+  }
   if (!value.startsWith("/")) return fallback;
   if (value.startsWith("//")) return fallback;
   if (value.includes("://")) return fallback;


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #367 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

로그인/회원가입/소셜 로그인/AuthGuard에서 `returnUrl` 쿼리로 인증 후 복귀 경로를 제어합니다.

- 내부 경로만 허용하는 `getSafeReturnUrl`
- `buildPathWithReturnUrl` : path뒤에 안전한 returnUrl 쿼리를 붙임. 만약 없다면 `""`빈문자열
- 로그인 성공시에 `returnUrl`이 있으면 해당 경로로 이동하고, 없으면 `/dashboard`로 이동하도록 구현
- 현재 WhereYouAd 서비스흐름이 회원가입후에 다시 로그인을 진행하는 구조이기 때문에, 회원가입 완료후에 `/login`으로 보낼때 `retunUrl` 유지되도록 구현
- 로그인-회원가입 링크에서 `returnUrl` 유지
- AuthGuard가 미로그인 사용자를 `/login?returnUrl=현재경로`로 리다이렉트
- 소셜로그인은 OAuth 이탈전에 `sessionStorage`에 안전한 `returnUrl` 저장되도록 했습니다. `/oauth2/redirect`에서 복원

## 😅 미완성 작업

- [ ] 백엔드와 논의후 `/invite:token` 초대 수락 페이지를 새로 UI 구현예정이고, 수락 API연동도 후속이슈에서 같이 진행할 예정


## 📢 논의 사항 및 참고 사항

- `returnUrl`은 token 자체가 아니라, 복귀 경로 입니다. ex)`/invite/{token}`
- 오픈 리다이렉트를 막기 위해서 `//`, `://`, `\` 는 fallback처리합니다. (`/dashboard`로보냄)
- 소셜은 서버에 `returnUrl`을 넘기지 않고, 세션스토리지에서 `authReturnUrl`을 유지합니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인, 소셜 로그인, 회원가입 과정에서 원래 이동하려던 페이지로 안전하게 돌아갈 수 있습니다.
  * 인증되지 않은 페이지 접근 시 현재 경로가 로그인 후 이동 목적지로 유지됩니다.
  * 로그인·회원가입·이메일 찾기 화면 간 이동에서도 반환 경로가 보존됩니다.
  * 외부 주소나 유효하지 않은 반환 경로는 차단하고 안전한 기본 경로로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->