### PR TITLE
[Feature/#312] 대시보드 예산 소진 UI 스펙 반영 (통합·플랫폼)

### DIFF
--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -61,9 +61,6 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
   const spentPct = getSpentPercentage(slice);
   const remainingPct = getRemainingPercentage(slice);
   const isOverBudget = spent > totalBudget;
-  const remainingAmount = isOverBudget
-    ? spent - totalBudget
-    : totalBudget - spent;
 
   const status = getBudgetStatus(spentPct, warningThreshold, dangerThreshold);
 
@@ -159,44 +156,22 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
         </div>
       </div>
 
-      <div
-        className={twMerge("flex flex-1 flex-col", compact ? "gap-2" : "gap-3")}
-      >
-        <div
-          className={twMerge(
-            "flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50",
-            compact ? "px-4 py-3" : "p-4",
-          )}
-        >
-          <span className="font-caption text-text-muted">남은 예산</span>
-          <span
-            className={twMerge(
-              "font-heading3 text-text-title tabular-nums",
-              isOverBudget && "text-info-red",
-            )}
-          >
-            {isOverBudget ? "-" : ""}
-            {M.spend.format(remainingAmount)}
-          </span>
+      {showInsight && (
+        <div className="flex flex-1 items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
+          <WarnCircleIcon
+            className="block size-5 shrink-0 text-text-muted"
+            aria-hidden="true"
+          />
+          <p className="m-0 min-w-0 flex-1 break-keep font-body2 text-text-body">
+            <span>{insightHead}</span>
+            {insightTail ? (
+              <span className="mt-0.5 block tablet:ml-1 tablet:mt-0 tablet:inline">
+                {insightTail}
+              </span>
+            ) : null}
+          </p>
         </div>
-
-        {showInsight && (
-          <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
-            <WarnCircleIcon
-              className="block size-5 shrink-0 text-text-muted"
-              aria-hidden="true"
-            />
-            <p className="m-0 min-w-0 flex-1 break-keep font-body2 text-text-body">
-              <span>{insightHead}</span>
-              {insightTail ? (
-                <span className="mt-0.5 block tablet:ml-1 tablet:mt-0 tablet:inline">
-                  {insightTail}
-                </span>
-              ) : null}
-            </p>
-          </div>
-        )}
-      </div>
+      )}
     </div>
   );
 });

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -1,7 +1,10 @@
 import { memo } from "react";
 import { twMerge } from "tailwind-merge";
 
-import type { IBudgetGaugeProps } from "@/types/dashboard/budget";
+import type {
+  IBudgetGaugeProps,
+  TBudgetGaugeLabel,
+} from "@/types/dashboard/budget";
 
 import {
   getRemainingPercentage,
@@ -46,6 +49,13 @@ function splitInsightHeadTail(text: string): { head: string; tail?: string } {
   return { head: m[1], tail: m[3].trim() };
 }
 
+/** 게이지 label이 예산 종류면 금액을 label 옆에 표시 */
+function isBudgetTypeLabel(label: TBudgetGaugeLabel): boolean {
+  return label === "전체 예산" || label === "일일 예산";
+}
+
+const budgetAmountClass = "font-heading4 text-text-title tabular-nums";
+
 const BudgetGaugeChart = memo(function BudgetGaugeChart({
   label,
   totalBudget,
@@ -61,6 +71,9 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
   const spentPct = getSpentPercentage(slice);
   const remainingPct = getRemainingPercentage(slice);
   const isOverBudget = spent > totalBudget;
+  const remainingAmount = isOverBudget
+    ? spent - totalBudget
+    : totalBudget - spent;
 
   const status = getBudgetStatus(spentPct, warningThreshold, dangerThreshold);
 
@@ -79,26 +92,50 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
   const { head: insightHead, tail: insightTail } =
     splitInsightHeadTail(insightDesc);
 
+  const showBudgetAmountOnLabelRow = isBudgetTypeLabel(label);
+  const headerRowGap = compact ? "mb-2" : "mb-3";
+
   return (
     <div
       className={twMerge(
-        "flex h-full w-full flex-col",
-        compact ? "pt-0" : "pt-4",
+        "flex w-full flex-col",
+        compact && "h-full",
+        compact ? "pt-0" : "pt-3",
       )}
     >
       <div className={twMerge("flex flex-col", compact ? "mb-3" : "mb-6")}>
         <div
           className={twMerge(
             "flex items-center justify-between gap-2",
-            compact ? "mb-2" : "mb-3",
+            headerRowGap,
           )}
         >
-          <h3 className="font-body2 text-text-body">{label}</h3>
+          <div className="flex min-w-0 items-baseline gap-2">
+            <h3 className="shrink-0 font-body2 text-text-body">{label}</h3>
+            {showBudgetAmountOnLabelRow && (
+              <span className={twMerge("truncate", budgetAmountClass)}>
+                {M.spend.format(totalBudget)}
+              </span>
+            )}
+          </div>
           <Badge variant={statusBadgeVariant[status]} className="shrink-0 px-2">
             {status}
           </Badge>
         </div>
-        <div className="flex items-baseline gap-2">
+        {!showBudgetAmountOnLabelRow && (
+          <div className={twMerge("flex items-baseline gap-2", headerRowGap)}>
+            <span className="font-caption text-text-muted">전체 예산</span>
+            <span className={budgetAmountClass}>
+              {M.spend.format(totalBudget)}
+            </span>
+          </div>
+        )}
+        <div
+          className={twMerge(
+            "flex items-baseline gap-2",
+            compact ? "mt-2" : "mt-3",
+          )}
+        >
           <span className="font-heading1 text-text-title tabular-nums leading-none">
             {remainingPct}%
           </span>
@@ -148,16 +185,27 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
             </span>
           </div>
           <div className="flex flex-col items-end gap-0.5">
-            <span className="font-caption text-text-muted">전체</span>
-            <span className="font-body2 text-text-body tabular-nums">
-              {M.spend.format(totalBudget)}
+            <span className="font-caption text-text-muted">남은 예산</span>
+            <span
+              className={twMerge(
+                "font-body2 text-text-body tabular-nums",
+                isOverBudget && "text-info-red",
+              )}
+            >
+              {isOverBudget ? "-" : ""}
+              {M.spend.format(remainingAmount)}
             </span>
           </div>
         </div>
       </div>
 
       {showInsight && (
-        <div className="flex flex-1 items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
+        <div
+          className={twMerge(
+            "flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4",
+            compact && "flex-1",
+          )}
+        >
           <WarnCircleIcon
             className="block size-5 shrink-0 text-text-muted"
             aria-hidden="true"

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -140,12 +140,22 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
 
         <div
           className={twMerge(
-            "flex items-center justify-between font-body2 text-text-body",
+            "flex items-end justify-between",
             compact ? "mt-2" : "mt-3",
           )}
         >
-          <span className="tabular-nums">{M.spend.format(spent)}</span>
-          <span className="tabular-nums">{M.spend.format(totalBudget)}</span>
+          <div className="flex flex-col gap-0.5">
+            <span className="font-caption text-text-muted">사용</span>
+            <span className="font-body2 text-text-body tabular-nums">
+              {M.spend.format(spent)}
+            </span>
+          </div>
+          <div className="flex flex-col items-end gap-0.5">
+            <span className="font-caption text-text-muted">전체</span>
+            <span className="font-body2 text-text-body tabular-nums">
+              {M.spend.format(totalBudget)}
+            </span>
+          </div>
         </div>
       </div>
 

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -185,14 +185,15 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
             </span>
           </div>
           <div className="flex flex-col items-end gap-0.5">
-            <span className="font-caption text-text-muted">남은 예산</span>
+            <span className="font-caption text-text-muted">
+              {isOverBudget ? "초과 금액" : "남은 예산"}
+            </span>
             <span
               className={twMerge(
                 "font-body2 text-text-body tabular-nums",
                 isOverBudget && "text-info-red",
               )}
             >
-              {isOverBudget ? "-" : ""}
               {M.spend.format(remainingAmount)}
             </span>
           </div>

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -53,6 +53,7 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
   warningThreshold,
   dangerThreshold,
   compact = false,
+  showInsight = false,
 }: IBudgetGaugeProps) {
   const mounted = useIsMounted();
 
@@ -88,8 +89,13 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
         compact ? "pt-0" : "pt-4",
       )}
     >
-      <div className={twMerge("flex flex-col", compact ? "mb-3" : "mb-4")}>
-        <div className="mb-2 flex items-center justify-between gap-2">
+      <div className={twMerge("flex flex-col", compact ? "mb-3" : "mb-6")}>
+        <div
+          className={twMerge(
+            "flex items-center justify-between gap-2",
+            compact ? "mb-2" : "mb-3",
+          )}
+        >
           <h3 className="font-body2 text-text-body">{label}</h3>
           <Badge variant={statusBadgeVariant[status]} className="shrink-0 px-2">
             {status}
@@ -103,7 +109,7 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
         </div>
       </div>
 
-      <div className={twMerge("relative w-full", compact ? "mb-3" : "mb-4")}>
+      <div className={twMerge("relative w-full", compact ? "mb-3" : "mb-6")}>
         <div
           role="progressbar"
           aria-label={`${label} 남은 비율`}
@@ -132,14 +138,26 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
           />
         </div>
 
-        <div className="mt-2 flex items-center justify-between font-body2 text-text-body">
+        <div
+          className={twMerge(
+            "flex items-center justify-between font-body2 text-text-body",
+            compact ? "mt-2" : "mt-3",
+          )}
+        >
           <span className="tabular-nums">{M.spend.format(spent)}</span>
           <span className="tabular-nums">{M.spend.format(totalBudget)}</span>
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col gap-2">
-        <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 px-4 py-3">
+      <div
+        className={twMerge("flex flex-1 flex-col", compact ? "gap-2" : "gap-3")}
+      >
+        <div
+          className={twMerge(
+            "flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50",
+            compact ? "px-4 py-3" : "p-4",
+          )}
+        >
           <span className="font-caption text-text-muted">남은 예산</span>
           <span
             className={twMerge(
@@ -152,7 +170,7 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
           </span>
         </div>
 
-        {!compact && (
+        {showInsight && (
           <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
             <WarnCircleIcon
               className="block size-5 shrink-0 text-text-muted"

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -85,11 +85,11 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
     <div
       className={twMerge(
         "flex h-full w-full flex-col",
-        compact ? "pt-2" : "pt-6",
+        compact ? "pt-0" : "pt-4",
       )}
     >
-      <div className={twMerge("flex flex-col", compact ? "mb-4" : "mb-6")}>
-        <div className="mb-3 flex items-center justify-between gap-2">
+      <div className={twMerge("flex flex-col", compact ? "mb-3" : "mb-4")}>
+        <div className="mb-2 flex items-center justify-between gap-2">
           <h3 className="font-body2 text-text-body">{label}</h3>
           <Badge variant={statusBadgeVariant[status]} className="shrink-0 px-2">
             {status}
@@ -103,7 +103,7 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
         </div>
       </div>
 
-      <div className={twMerge("relative w-full", compact ? "mb-4" : "mb-6")}>
+      <div className={twMerge("relative w-full", compact ? "mb-3" : "mb-4")}>
         <div
           role="progressbar"
           aria-label={`${label} 남은 비율`}
@@ -132,14 +132,14 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
           />
         </div>
 
-        <div className="mt-3 flex items-center justify-between font-body2 text-text-body">
+        <div className="mt-2 flex items-center justify-between font-body2 text-text-body">
           <span className="tabular-nums">{M.spend.format(spent)}</span>
           <span className="tabular-nums">{M.spend.format(totalBudget)}</span>
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col gap-3">
-        <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 p-4">
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 px-4 py-3">
           <span className="font-caption text-text-muted">남은 예산</span>
           <span
             className={twMerge(

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -1,6 +1,12 @@
 import { memo } from "react";
 import { twMerge } from "tailwind-merge";
 
+import type { IBudgetGaugeProps } from "@/types/dashboard/budget";
+
+import {
+  getRemainingPercentage,
+  getSpentPercentage,
+} from "@/utils/dashboard/budget";
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 
 import { useIsMounted } from "@/hooks/common/useIsMounted";
@@ -8,13 +14,6 @@ import { useIsMounted } from "@/hooks/common/useIsMounted";
 import { type TBadgeVariant } from "@/components/common/badge/Badge";
 
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
-
-interface IBudgetGaugeChartProps {
-  totalBudget: number;
-  spent: number;
-  warningThreshold: number;
-  dangerThreshold: number;
-}
 
 export type TBudgetStatus = "안정" | "주의" | "위험";
 
@@ -48,28 +47,32 @@ function splitInsightHeadTail(text: string): { head: string; tail?: string } {
 }
 
 const BudgetGaugeChart = memo(function BudgetGaugeChart({
+  label,
   totalBudget,
   spent,
   warningThreshold,
   dangerThreshold,
-}: IBudgetGaugeChartProps) {
+  compact = false,
+}: IBudgetGaugeProps) {
   const mounted = useIsMounted();
 
-  const percentage =
-    totalBudget > 0 ? Math.round((spent / totalBudget) * 100) : 0;
+  const slice = { totalBudget, spent };
+  const spentPct = getSpentPercentage(slice);
+  const remainingPct = getRemainingPercentage(slice);
   const isOverBudget = spent > totalBudget;
-  const remaining = isOverBudget ? spent - totalBudget : totalBudget - spent;
+  const remainingAmount = isOverBudget
+    ? spent - totalBudget
+    : totalBudget - spent;
 
-  const status = getBudgetStatus(percentage, warningThreshold, dangerThreshold);
+  const status = getBudgetStatus(spentPct, warningThreshold, dangerThreshold);
 
-  // 데이터 인사이트 메시지
   let insightDesc = "";
 
   if (isOverBudget) {
     insightDesc = "예산을 초과했습니다. 캠페인 조정이 필요해요.";
-  } else if (percentage >= dangerThreshold) {
+  } else if (spentPct >= dangerThreshold) {
     insightDesc = "예산 소진이 빨라요. 일일 한도 점검을 추천해요.";
-  } else if (percentage >= warningThreshold) {
+  } else if (spentPct >= warningThreshold) {
     insightDesc = "예산 소진 속도가 다소 높아요. 매체 효율을 확인해 보세요.";
   } else {
     insightDesc = "계획된 예산 범위 내에서 잘 사용되고 있어요.";
@@ -79,42 +82,47 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
     splitInsightHeadTail(insightDesc);
 
   return (
-    <div className="flex h-full w-full flex-col pt-6">
-      <div className="flex flex-col mb-6">
-        <h3 className="mb-3 font-body2 text-text-body">사용 예산</h3>
+    <div
+      className={twMerge(
+        "flex h-full w-full flex-col",
+        compact ? "pt-2" : "pt-6",
+      )}
+    >
+      <div className={twMerge("flex flex-col", compact ? "mb-4" : "mb-6")}>
+        <h3 className="mb-3 font-body2 text-text-body">{label}</h3>
         <div className="flex items-baseline gap-2">
           <span className="font-heading1 text-text-title tabular-nums leading-none">
-            {percentage}%
+            {remainingPct}%
           </span>
-          <span className="font-body2 text-text-body tabular-nums">소진</span>
+          <span className="font-body2 text-text-body tabular-nums">남음</span>
         </div>
       </div>
 
-      <div className="relative mb-6 w-full">
+      <div className={twMerge("relative w-full", compact ? "mb-4" : "mb-6")}>
         <div
           role="progressbar"
-          aria-label="전체 예산 소진율"
-          aria-valuenow={Math.min(Math.max(percentage, 0), 100)}
+          aria-label={`${label} 남은 비율`}
+          aria-valuenow={remainingPct}
           aria-valuemin={0}
           aria-valuemax={100}
-          className="relative h-3 w-full bg-surface-200 rounded-full overflow-hidden"
+          className="relative h-3 w-full overflow-hidden rounded-full bg-surface-200"
         >
           <div
-            className="absolute top-0 bottom-0 w-0.5 bg-surface-100/60 z-10"
-            style={{ left: `${warningThreshold}%` }}
+            className="absolute top-0 bottom-0 z-10 w-0.5 bg-surface-100/60"
+            style={{ left: `${100 - dangerThreshold}%` }}
           />
           <div
-            className="absolute top-0 bottom-0 w-0.5 bg-surface-100/60 z-10"
-            style={{ left: `${dangerThreshold}%` }}
+            className="absolute top-0 bottom-0 z-10 w-0.5 bg-surface-100/60"
+            style={{ left: `${100 - warningThreshold}%` }}
           />
 
           <div
             className={twMerge(
-              "absolute top-0 left-0 h-full w-full rounded-full transition-transform duration-1000 ease-smooth origin-left",
+              "absolute top-0 left-0 h-full w-full origin-left rounded-full transition-transform duration-1000 ease-smooth",
               statusPointClasses[status],
             )}
             style={{
-              transform: `scaleX(${mounted ? Math.min(percentage, 100) / 100 : 0})`,
+              transform: `scaleX(${mounted ? remainingPct / 100 : 0})`,
             }}
           />
         </div>
@@ -125,7 +133,7 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
         </div>
       </div>
 
-      <div className="flex-1 flex flex-col gap-3">
+      <div className="flex flex-1 flex-col gap-3">
         <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 p-4">
           <span className="font-caption text-text-muted">남은 예산</span>
           <span
@@ -135,24 +143,26 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
             )}
           >
             {isOverBudget ? "-" : ""}
-            {M.spend.format(remaining)}
+            {M.spend.format(remainingAmount)}
           </span>
         </div>
 
-        <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
-          <WarnCircleIcon
-            className="block size-5 shrink-0 text-text-muted"
-            aria-hidden="true"
-          />
-          <p className="m-0 min-w-0 flex-1 break-keep font-body2 text-text-body">
-            <span>{insightHead}</span>
-            {insightTail ? (
-              <span className="mt-0.5 block tablet:ml-1 tablet:mt-0 tablet:inline">
-                {insightTail}
-              </span>
-            ) : null}
-          </p>
-        </div>
+        {!compact && (
+          <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
+            <WarnCircleIcon
+              className="block size-5 shrink-0 text-text-muted"
+              aria-hidden="true"
+            />
+            <p className="m-0 min-w-0 flex-1 break-keep font-body2 text-text-body">
+              <span>{insightHead}</span>
+              {insightTail ? (
+                <span className="mt-0.5 block tablet:ml-1 tablet:mt-0 tablet:inline">
+                  {insightTail}
+                </span>
+              ) : null}
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -11,7 +11,7 @@ import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 
 import { useIsMounted } from "@/hooks/common/useIsMounted";
 
-import { type TBadgeVariant } from "@/components/common/badge/Badge";
+import Badge, { type TBadgeVariant } from "@/components/common/badge/Badge";
 
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 
@@ -89,7 +89,12 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
       )}
     >
       <div className={twMerge("flex flex-col", compact ? "mb-4" : "mb-6")}>
-        <h3 className="mb-3 font-body2 text-text-body">{label}</h3>
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <h3 className="font-body2 text-text-body">{label}</h3>
+          <Badge variant={statusBadgeVariant[status]} className="shrink-0 px-2">
+            {status}
+          </Badge>
+        </div>
         <div className="flex items-baseline gap-2">
           <span className="font-heading1 text-text-title tabular-nums leading-none">
             {remainingPct}%

--- a/src/components/dashboard/charts/TrafficChart.tsx
+++ b/src/components/dashboard/charts/TrafficChart.tsx
@@ -32,7 +32,7 @@ import MoreIcon from "@/assets/icon/common/more.svg?react";
 const ReactApexChart = lazy(() => import("react-apexcharts"));
 
 interface ITrafficChartProps {
-  /** ApexCharts height — 통합 대시보드 기본 520 */
+  /** ApexCharts height — 통합 대시보드 기본 590 */
   height?: number;
 }
 

--- a/src/components/dashboard/charts/TrafficChart.tsx
+++ b/src/components/dashboard/charts/TrafficChart.tsx
@@ -9,6 +9,8 @@ import {
   useState,
 } from "react";
 
+import { OVERVIEW_TRAFFIC_CHART_HEIGHT } from "@/constants/dashboard/trafficChartHeights";
+
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 import { parseMinuteToTimestamp } from "@/utils/dashboard/parseMinuteToTimestamp";
 
@@ -28,6 +30,11 @@ import { toggleDummyClicks } from "@/api/dashboard/overview";
 import MoreIcon from "@/assets/icon/common/more.svg?react";
 
 const ReactApexChart = lazy(() => import("react-apexcharts"));
+
+interface ITrafficChartProps {
+  /** ApexCharts height — 통합 대시보드 기본 520 */
+  height?: number;
+}
 
 // 차트 우측 상단 다운로드 버튼 + 더미 토글
 export function TrafficChartDownload() {
@@ -100,9 +107,12 @@ const AnomalyBubble = memo(function AnomalyBubble({
   );
 });
 
-const TrafficChart = memo(function TrafficChart() {
+const TrafficChart = memo(function TrafficChart({
+  height = OVERVIEW_TRAFFIC_CHART_HEIGHT,
+}: ITrafficChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { data, suspectDetail, isError } = useClickStream({ mode: "dummy" });
+  const chartAreaStyle = { height: `${height}px` };
 
   // timeSeriesData → datetime 기반 차트 series 변환
   const DAY_MS = 24 * 60 * 60 * 1000;
@@ -262,7 +272,10 @@ const TrafficChart = memo(function TrafficChart() {
 
   if (isError && !data) {
     return (
-      <div className="flex flex-col items-center justify-center w-full h-100 gap-2 text-text-muted">
+      <div
+        style={chartAreaStyle}
+        className="flex w-full flex-col items-center justify-center gap-2 text-text-muted"
+      >
         <p className="font-body2">실시간 데이터를 불러오지 못했습니다.</p>
         <p className="font-caption">잠시 후 다시 시도해 주세요.</p>
       </div>
@@ -270,7 +283,7 @@ const TrafficChart = memo(function TrafficChart() {
   }
 
   if (!data) {
-    return <Skeleton className="w-full h-100" />;
+    return <Skeleton className="w-full rounded-xl" style={chartAreaStyle} />;
   }
 
   return (
@@ -283,12 +296,12 @@ const TrafficChart = memo(function TrafficChart() {
         data-hide-tooltip={showBubble || undefined}
         className="relative will-change-transform [&_.apexcharts-toolbar]:hidden [&[data-hide-tooltip]_.apexcharts-tooltip]:invisible [&[data-hide-tooltip]_.apexcharts-tooltip]:pointer-events-none"
       >
-        <Suspense fallback={<div className="h-100" />}>
+        <Suspense fallback={<div style={chartAreaStyle} />}>
           <ReactApexChart
             type="area"
             options={chartOptions}
             series={series}
-            height={400}
+            height={height}
           />
         </Suspense>
         {markerPos && (

--- a/src/components/dashboard/charts/trafficChart.config.ts
+++ b/src/components/dashboard/charts/trafficChart.config.ts
@@ -172,7 +172,7 @@ export function buildChartOptions(params: {
       borderColor: "var(--color-surface-200)",
       xaxis: { lines: { show: false } },
       yaxis: { lines: { show: true } },
-      padding: { left: 16, right: 24 },
+      padding: { top: 12, left: 12, right: 16 },
     },
 
     tooltip: {

--- a/src/components/dashboard/overview/skeleton/OverviewSkeleton.tsx
+++ b/src/components/dashboard/overview/skeleton/OverviewSkeleton.tsx
@@ -30,7 +30,7 @@ export function OverviewTrafficChartSkeleton() {
 
 /** 예산 게이지 카드 — Google·Meta + NAVER compact 2개 */
 export function OverviewBudgetGaugeSkeleton() {
-  return <PlatformDualBudgetGaugeSkeleton />;
+  return <PlatformDualBudgetGaugeSkeleton mergedBudgetHeader={false} />;
 }
 
 /** 플랫폼별 ROAS 랭킹 테이블 */

--- a/src/components/dashboard/overview/skeleton/OverviewSkeleton.tsx
+++ b/src/components/dashboard/overview/skeleton/OverviewSkeleton.tsx
@@ -5,6 +5,7 @@ import {
   SkeletonCircle,
 } from "@/components/common/skeleton/Skeleton";
 import { PLATFORM_ROAS_TABLE_COL } from "@/components/dashboard/platform/PlatformRoasTable";
+import { PlatformDualBudgetGaugeSkeleton } from "@/components/dashboard/platform/skeleton/PlatformSkeleton";
 
 /** KPI StatCard 1칸 */
 export function OverviewKpiCardSkeleton() {
@@ -27,37 +28,9 @@ export function OverviewTrafficChartSkeleton() {
   );
 }
 
-/** 예산 게이지 카드 */
+/** 예산 게이지 카드 — Google·Meta + NAVER compact 2개 */
 export function OverviewBudgetGaugeSkeleton() {
-  return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3 pt-1">
-      <div className="flex shrink-0 flex-col gap-2">
-        <Skeleton className="h-4 w-20" />
-        <Skeleton className="h-8 w-24" />
-        <Skeleton className="h-2 w-full rounded-full" />
-        <div className="flex justify-between gap-3">
-          <div className="flex flex-col gap-1">
-            <Skeleton className="h-3 w-10" />
-            <Skeleton className="h-4 w-20" />
-          </div>
-          <div className="flex flex-col items-end gap-1">
-            <Skeleton className="h-3 w-14" />
-            <Skeleton className="h-4 w-20" />
-          </div>
-        </div>
-      </div>
-      <div className="flex shrink-0 flex-col gap-3">
-        <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/40 p-4">
-          <Skeleton className="h-3 w-16" />
-          <Skeleton className="h-7 w-36" />
-        </div>
-        <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
-          <Skeleton className="size-5 shrink-0 rounded-full" />
-          <Skeleton className="h-10 flex-1 rounded-md" />
-        </div>
-      </div>
-    </div>
-  );
+  return <PlatformDualBudgetGaugeSkeleton />;
 }
 
 /** 플랫폼별 ROAS 랭킹 테이블 */

--- a/src/components/dashboard/overview/skeleton/OverviewSkeleton.tsx
+++ b/src/components/dashboard/overview/skeleton/OverviewSkeleton.tsx
@@ -1,3 +1,5 @@
+import { OVERVIEW_TRAFFIC_CHART_HEIGHT } from "@/constants/dashboard/trafficChartHeights";
+
 import {
   Skeleton,
   SkeletonCircle,
@@ -17,7 +19,12 @@ export function OverviewKpiCardSkeleton() {
 
 /** 실시간 트래픽 차트 */
 export function OverviewTrafficChartSkeleton() {
-  return <Skeleton className="min-h-60 w-full flex-1 rounded-2xl" />;
+  return (
+    <Skeleton
+      className="w-full rounded-2xl"
+      style={{ height: `${OVERVIEW_TRAFFIC_CHART_HEIGHT}px` }}
+    />
+  );
 }
 
 /** 예산 게이지 카드 */

--- a/src/components/dashboard/platform/PlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/PlatformTrafficChart.tsx
@@ -1,4 +1,13 @@
-import { memo, useCallback, useId, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactApexChart from "react-apexcharts";
 import type { ApexOptions } from "apexcharts";
 
@@ -25,7 +34,12 @@ interface IPlatformTrafficChartProps {
   isError?: boolean;
   suspectDetail: IClickStreamItem["suspectDetail"] | null;
   onRetry?: () => void;
+  /** 예산 게이지 2개일 때 카드 높이에 맞춰 차트 영역 확장 */
+  fillHeight?: boolean;
 }
+
+const DEFAULT_CHART_HEIGHT = 360;
+const MIN_CHART_HEIGHT = 300;
 
 // 이상 징후 상세 버블
 const AnomalyBubble = memo(function AnomalyBubble({
@@ -78,9 +92,15 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
   isError = false,
   suspectDetail = null,
   onRetry,
+  fillHeight = false,
 }: IPlatformTrafficChartProps) {
+  const measureRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const anomalyBubbleId = useId();
+  const [chartHeight, setChartHeight] = useState<number | null>(
+    fillHeight ? null : DEFAULT_CHART_HEIGHT,
+  );
+  const [isHeightReady, setIsHeightReady] = useState(!fillHeight);
   const seriesData = useMemo(() => {
     if (!data) return [];
     return data.timeSeriesData.map((d) => ({
@@ -154,7 +174,9 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
       toolbar: { show: false },
       zoom: { enabled: false },
       fontFamily: "Pretendard",
-      animations: { enabled: true, speed: 800 },
+      animations: fillHeight
+        ? { enabled: false }
+        : { enabled: true, speed: 800 },
     },
     dataLabels: { enabled: false },
     stroke: {
@@ -255,9 +277,98 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
   const handlePointerLeave = useCallback(() => setIsAnomalyHovered(false), []);
   const showBubble = isAnomalyHovered || isAnomalyFocused;
 
+  useEffect(() => {
+    if (!fillHeight) {
+      setChartHeight(DEFAULT_CHART_HEIGHT);
+      setIsHeightReady(true);
+      return;
+    }
+
+    setChartHeight(null);
+    setIsHeightReady(false);
+  }, [fillHeight]);
+
+  const hasChartData = Boolean(data && data.timeSeriesData.length > 0);
+
+  useLayoutEffect(() => {
+    if (!fillHeight || !hasChartData) return;
+
+    const el = measureRef.current;
+    if (!el) return;
+
+    const updateHeight = () => {
+      const next = Math.max(
+        MIN_CHART_HEIGHT,
+        Math.floor(el.getBoundingClientRect().height),
+      );
+      if (next <= 0) return;
+      setChartHeight(next);
+      setIsHeightReady(true);
+    };
+
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [fillHeight, hasChartData]);
+
+  const fillContainerClassName = fillHeight
+    ? "min-h-75 flex-1 overflow-hidden"
+    : "h-75";
+
+  const anomalyLayer =
+    anomalyTimestamp !== undefined && anomalyY !== undefined && markerPos ? (
+      <>
+        <span
+          className="pointer-events-none absolute size-3 -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-info-red opacity-60 [animation-duration:2s]"
+          style={{ left: markerPos.x, top: markerPos.y }}
+        />
+        <span
+          className="pointer-events-none absolute size-3 -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-info-red opacity-40 [animation-delay:1s] [animation-duration:2s]"
+          style={{ left: markerPos.x, top: markerPos.y }}
+        />
+        <button
+          type="button"
+          className="absolute size-6 -translate-x-1/2 -translate-y-1/2 opacity-0"
+          style={{ left: markerPos.x, top: markerPos.y }}
+          aria-label="클릭 이상 징후 상세 보기"
+          aria-describedby={showBubble ? anomalyBubbleId : undefined}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onPointerEnter={handlePointerEnter}
+          onPointerLeave={handlePointerLeave}
+        />
+        {showBubble && (
+          <AnomalyBubble
+            id={anomalyBubbleId}
+            x={markerPos.x}
+            y={markerPos.y}
+            message={suspectDetail?.message}
+            campaignName={suspectDetail?.campaignName}
+            adName={suspectDetail?.adName}
+          />
+        )}
+      </>
+    ) : null;
+
+  const connectionWarning = isError ? (
+    <div className="mb-2 flex shrink-0 flex-wrap items-center gap-2">
+      <p className="font-caption text-text-muted">
+        연결이 원활하지 않아 마지막 데이터를 표시합니다.
+      </p>
+      {onRetry ? (
+        <Button variant="outline" size="small" type="button" onClick={onRetry}>
+          다시 시도
+        </Button>
+      ) : null}
+    </div>
+  ) : null;
+
   if (isError && !data) {
     return (
-      <div className="flex h-75 flex-col items-center justify-center gap-4 text-center">
+      <div
+        className={`flex flex-col items-center justify-center gap-4 text-center ${fillContainerClassName}`}
+      >
         <p className="font-body2 text-text-muted">
           실시간 데이터를 불러오지 못했습니다.
         </p>
@@ -276,83 +387,70 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
   }
 
   if (!data) {
-    return <Skeleton className="w-full h-75 rounded-xl" />;
+    return (
+      <Skeleton
+        className={`w-full rounded-xl ${fillHeight ? "min-h-75 flex-1" : "h-75"}`}
+      />
+    );
   }
 
   if (data.timeSeriesData.length === 0) {
     return (
-      <div className="flex h-75 items-center justify-center font-body2 text-text-muted">
+      <div
+        className={`flex items-center justify-center font-body2 text-text-muted ${fillContainerClassName}`}
+      >
         표시할 실시간 트래픽 데이터가 없습니다.
       </div>
     );
   }
 
   return (
-    <div className="flex h-full min-h-75 w-full flex-col">
-      {isError && (
-        <div className="mb-2 flex flex-wrap items-center gap-2">
-          <p className="font-caption text-text-muted">
-            연결이 원활하지 않아 마지막 데이터를 표시합니다.
-          </p>
-          {onRetry ? (
-            <Button
-              variant="outline"
-              size="small"
-              type="button"
-              onClick={onRetry}
+    <div
+      className={
+        fillHeight
+          ? "flex w-full min-h-0 flex-1 flex-col overflow-hidden"
+          : "flex h-full min-h-75 w-full flex-col"
+      }
+    >
+      {connectionWarning}
+      {fillHeight ? (
+        <div
+          ref={measureRef}
+          className="relative min-h-0 flex-1 overflow-hidden"
+        >
+          {!isHeightReady || chartHeight === null ? (
+            <Skeleton className="absolute inset-0 rounded-xl" />
+          ) : (
+            <div
+              ref={containerRef}
+              data-hide-tooltip={showBubble || undefined}
+              className="absolute inset-0 overflow-hidden [&[data-hide-tooltip]_.apexcharts-tooltip]:pointer-events-none [&[data-hide-tooltip]_.apexcharts-tooltip]:invisible"
             >
-              다시 시도
-            </Button>
-          ) : null}
+              <ReactApexChart
+                options={chartOptions}
+                series={series}
+                type="area"
+                height={chartHeight}
+              />
+              {anomalyLayer}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          ref={containerRef}
+          data-hide-tooltip={showBubble || undefined}
+          className="relative min-h-75 [&[data-hide-tooltip]_.apexcharts-tooltip]:pointer-events-none [&[data-hide-tooltip]_.apexcharts-tooltip]:invisible"
+        >
+          <ReactApexChart
+            options={chartOptions}
+            series={series}
+            type="area"
+            height={DEFAULT_CHART_HEIGHT}
+          />
+          {anomalyLayer}
         </div>
       )}
-      <div
-        ref={containerRef}
-        data-hide-tooltip={showBubble || undefined}
-        className="relative min-h-0 flex-1 [&[data-hide-tooltip]_.apexcharts-tooltip]:pointer-events-none [&[data-hide-tooltip]_.apexcharts-tooltip]:invisible"
-      >
-        <ReactApexChart
-          options={chartOptions}
-          series={series}
-          type="area"
-          height={360}
-        />
-        {anomalyTimestamp !== undefined &&
-          anomalyY !== undefined &&
-          markerPos && (
-            <>
-              <span
-                className="pointer-events-none absolute size-3 -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-info-red opacity-60 [animation-duration:2s]"
-                style={{ left: markerPos.x, top: markerPos.y }}
-              />
-              <span
-                className="pointer-events-none absolute size-3 -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-info-red opacity-40 [animation-delay:1s] [animation-duration:2s]"
-                style={{ left: markerPos.x, top: markerPos.y }}
-              />
-              <button
-                type="button"
-                className="absolute size-6 -translate-x-1/2 -translate-y-1/2 opacity-0"
-                style={{ left: markerPos.x, top: markerPos.y }}
-                aria-label="클릭 이상 징후 상세 보기"
-                aria-describedby={showBubble ? anomalyBubbleId : undefined}
-                onFocus={handleFocus}
-                onBlur={handleBlur}
-                onPointerEnter={handlePointerEnter}
-                onPointerLeave={handlePointerLeave}
-              />
-              {showBubble && (
-                <AnomalyBubble
-                  id={anomalyBubbleId}
-                  x={markerPos.x}
-                  y={markerPos.y}
-                  message={suspectDetail?.message}
-                  campaignName={suspectDetail?.campaignName}
-                  adName={suspectDetail?.adName}
-                />
-              )}
-            </>
-          )}
-      </div>
     </div>
   );
 });

--- a/src/components/dashboard/platform/PlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/PlatformTrafficChart.tsx
@@ -44,6 +44,7 @@ interface IPlatformTrafficChartProps {
 
 const DEFAULT_CHART_HEIGHT = PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE;
 const MIN_CHART_HEIGHT = PLATFORM_TRAFFIC_CHART_HEIGHT_DUAL_MIN;
+const CHART_ARIA_LABEL = "실시간 트래픽 변화 차트: 시간대별 클릭수 추이";
 
 // 이상 징후 상세 버블
 const AnomalyBubble = memo(function AnomalyBubble({
@@ -427,6 +428,8 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
           ) : (
             <div
               ref={containerRef}
+              role="group"
+              aria-label={CHART_ARIA_LABEL}
               data-hide-tooltip={showBubble || undefined}
               className="absolute inset-0 overflow-hidden [&[data-hide-tooltip]_.apexcharts-tooltip]:pointer-events-none [&[data-hide-tooltip]_.apexcharts-tooltip]:invisible"
             >
@@ -443,6 +446,8 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
       ) : (
         <div
           ref={containerRef}
+          role="group"
+          aria-label={CHART_ARIA_LABEL}
           data-hide-tooltip={showBubble || undefined}
           className="relative min-h-75 [&[data-hide-tooltip]_.apexcharts-tooltip]:pointer-events-none [&[data-hide-tooltip]_.apexcharts-tooltip]:invisible"
         >

--- a/src/components/dashboard/platform/PlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/PlatformTrafficChart.tsx
@@ -16,6 +16,10 @@ import type {
   TProviderType,
 } from "@/types/dashboard/overview";
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
+import {
+  PLATFORM_TRAFFIC_CHART_HEIGHT_DUAL_MIN,
+  PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE,
+} from "@/constants/dashboard/trafficChartHeights";
 
 import {
   formatCountChartAxis,
@@ -38,8 +42,8 @@ interface IPlatformTrafficChartProps {
   fillHeight?: boolean;
 }
 
-const DEFAULT_CHART_HEIGHT = 360;
-const MIN_CHART_HEIGHT = 300;
+const DEFAULT_CHART_HEIGHT = PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE;
+const MIN_CHART_HEIGHT = PLATFORM_TRAFFIC_CHART_HEIGHT_DUAL_MIN;
 
 // 이상 징후 상세 버블
 const AnomalyBubble = memo(function AnomalyBubble({

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -202,11 +202,7 @@ export default function SinglePlatformView({
             />
           }
         >
-          <div
-            className={twMerge(
-              hasDualBudgetGauges && "flex min-h-0 flex-1 flex-col",
-            )}
-          >
+          <div className="flex min-h-0 flex-1 flex-col">
             <ErrorBoundary
               FallbackComponent={ChartErrorFallback}
               resetKeys={[budgetData]}

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -190,9 +190,23 @@ export default function SinglePlatformView({
                 예산 데이터를 불러오지 못했습니다.
               </div>
             ) : budgetData ? (
-              <div className="flex flex-1 flex-col gap-5 overflow-y-auto pt-2">
-                {budgetData.gauges.map((gauge) => (
-                  <BudgetGaugeChart key={gauge.label} {...gauge} />
+              <div
+                className={twMerge(
+                  "flex flex-1 flex-col overflow-y-auto pt-2",
+                  budgetData.gauges.length === 1 && "gap-5",
+                )}
+              >
+                {budgetData.gauges.map((gauge, index) => (
+                  <div
+                    key={gauge.label}
+                    className={twMerge(
+                      index > 0 &&
+                        budgetData.gauges.length > 1 &&
+                        "mt-5 border-t border-surface-300 pt-5",
+                    )}
+                  >
+                    <BudgetGaugeChart {...gauge} />
+                  </div>
                 ))}
               </div>
             ) : (

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -4,7 +4,6 @@ import { twMerge } from "tailwind-merge";
 import type { TProviderType } from "@/types/dashboard/overview";
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
 
-import { getSpentPercentage } from "@/utils/dashboard/budget";
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 import { metricsToKpis } from "@/utils/dashboard/metricsToKpis";
 
@@ -13,7 +12,6 @@ import { useClickStream } from "@/hooks/dashboard/useClickStream";
 import { usePlatformMetricFacts } from "@/hooks/dashboard/usePlatformMetricFacts";
 import { usePlatformMetrics } from "@/hooks/dashboard/usePlatformMetrics";
 
-import Badge from "@/components/common/badge/Badge";
 import Card from "@/components/common/card/Card";
 import StatCard from "@/components/common/card/StatCard";
 import ChartLegend from "@/components/common/chart/ChartLegend";
@@ -22,10 +20,7 @@ import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import MetricErrorFallback from "@/components/common/error/MetricErrorFallback";
 import { Skeleton } from "@/components/common/skeleton/Skeleton";
 import DashboardAiSummarySection from "@/components/dashboard/ai-report/components/DashboardAiSummarySection";
-import BudgetGaugeChart, {
-  getBudgetStatus,
-  statusBadgeVariant,
-} from "@/components/dashboard/charts/BudgetGaugeChart";
+import BudgetGaugeChart from "@/components/dashboard/charts/BudgetGaugeChart";
 import PlatformDetailTable from "@/components/dashboard/platform/PlatformDetailTable";
 import PlatformTrafficChart from "@/components/dashboard/platform/PlatformTrafficChart";
 
@@ -85,14 +80,6 @@ export default function SinglePlatformView({
     mode: "dummy",
     providerType: platform,
   });
-
-  const budgetStatus = budgetData
-    ? getBudgetStatus(
-        getSpentPercentage(budgetData.statusGauge),
-        budgetData.statusGauge.warningThreshold,
-        budgetData.statusGauge.dangerThreshold,
-      )
-    : null;
 
   const platformColor = PLATFORM_CHART_COLORS[platform];
 
@@ -188,16 +175,6 @@ export default function SinglePlatformView({
                 { label: "위험", colorClass: "bg-info-red" },
               ]}
             />
-          }
-          RightElement={
-            budgetStatus && (
-              <Badge
-                variant={statusBadgeVariant[budgetStatus]}
-                className="px-2"
-              >
-                {budgetStatus}
-              </Badge>
-            )
           }
         >
           <ErrorBoundary

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -3,6 +3,7 @@ import { twMerge } from "tailwind-merge";
 
 import type { TProviderType } from "@/types/dashboard/overview";
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
+import { PLATFORM_MID_SECTION_HEIGHT_SINGLE } from "@/constants/dashboard/trafficChartHeights";
 
 import { supportsDailyBudget } from "@/utils/dashboard/budget";
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
@@ -148,7 +149,9 @@ export default function SinglePlatformView({
           title="실시간 트래픽 변화"
           className={twMerge(
             "col-span-2 flex flex-col tablet:col-span-1",
-            hasDualBudgetGauges ? "min-h-120 h-full overflow-hidden" : "h-120",
+            hasDualBudgetGauges
+              ? "min-h-120 h-full overflow-hidden"
+              : PLATFORM_MID_SECTION_HEIGHT_SINGLE,
           )}
           description={
             <ChartLegend
@@ -185,7 +188,9 @@ export default function SinglePlatformView({
           title="예산 소진 현황"
           className={twMerge(
             "col-span-1 flex flex-col tablet:col-span-1",
-            hasDualBudgetGauges ? "min-h-120 h-full" : "min-h-120",
+            hasDualBudgetGauges
+              ? "min-h-120 h-full"
+              : PLATFORM_MID_SECTION_HEIGHT_SINGLE,
           )}
           description={
             <ChartLegend
@@ -219,8 +224,9 @@ export default function SinglePlatformView({
               ) : budgetData ? (
                 <div
                   className={twMerge(
-                    "flex flex-1 flex-col overflow-y-auto pt-2",
-                    budgetData.gauges.length === 1 && "gap-5",
+                    "flex flex-col",
+                    hasDualBudgetGauges ? "pt-2" : "pt-1",
+                    hasDualBudgetGauges && "min-h-0 flex-1 overflow-y-auto",
                   )}
                 >
                   {budgetData.gauges.map((gauge, index) => (

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -4,6 +4,7 @@ import { twMerge } from "tailwind-merge";
 import type { TProviderType } from "@/types/dashboard/overview";
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
 
+import { getSpentPercentage } from "@/utils/dashboard/budget";
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 import { metricsToKpis } from "@/utils/dashboard/metricsToKpis";
 
@@ -64,7 +65,7 @@ export default function SinglePlatformView({
   const logoInfo = PLATFORM_LOGOS[platform];
 
   const {
-    data: budget,
+    data: budgetData,
     isLoading: isBudgetLoading,
     isError: isBudgetError,
   } = useBudget(platform);
@@ -85,15 +86,11 @@ export default function SinglePlatformView({
     providerType: platform,
   });
 
-  const budgetPct = budget
-    ? Math.round((budget.spent / budget.totalBudget) * 100)
-    : 0;
-
-  const budgetStatus = budget
+  const budgetStatus = budgetData
     ? getBudgetStatus(
-        budgetPct,
-        budget.warningThreshold,
-        budget.dangerThreshold,
+        getSpentPercentage(budgetData.statusGauge),
+        budgetData.statusGauge.warningThreshold,
+        budgetData.statusGauge.dangerThreshold,
       )
     : null;
 
@@ -182,7 +179,7 @@ export default function SinglePlatformView({
 
         <Card
           title="예산 소진 현황"
-          className="col-span-1 tablet:col-span-1 h-120 flex flex-col"
+          className="col-span-1 tablet:col-span-1 min-h-120 flex flex-col"
           description={
             <ChartLegend
               items={[
@@ -205,7 +202,7 @@ export default function SinglePlatformView({
         >
           <ErrorBoundary
             FallbackComponent={ChartErrorFallback}
-            resetKeys={[budget]}
+            resetKeys={[budgetData]}
           >
             {isBudgetLoading ? (
               <div className="flex flex-1 items-center justify-center p-8">
@@ -215,9 +212,11 @@ export default function SinglePlatformView({
               <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-info-red">
                 예산 데이터를 불러오지 못했습니다.
               </div>
-            ) : budget ? (
-              <div className="flex flex-1 flex-col">
-                <BudgetGaugeChart {...budget} />
+            ) : budgetData ? (
+              <div className="flex flex-1 flex-col gap-5 overflow-y-auto pt-2">
+                {budgetData.gauges.map((gauge) => (
+                  <BudgetGaugeChart key={gauge.label} {...gauge} />
+                ))}
               </div>
             ) : (
               <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-text-muted">

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -4,6 +4,7 @@ import { twMerge } from "tailwind-merge";
 import type { TProviderType } from "@/types/dashboard/overview";
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
 
+import { supportsDailyBudget } from "@/utils/dashboard/budget";
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 import { metricsToKpis } from "@/utils/dashboard/metricsToKpis";
 
@@ -23,6 +24,7 @@ import DashboardAiSummarySection from "@/components/dashboard/ai-report/componen
 import BudgetGaugeChart from "@/components/dashboard/charts/BudgetGaugeChart";
 import PlatformDetailTable from "@/components/dashboard/platform/PlatformDetailTable";
 import PlatformTrafficChart from "@/components/dashboard/platform/PlatformTrafficChart";
+import { PlatformDualBudgetGaugeSkeleton } from "@/components/dashboard/platform/skeleton/PlatformSkeleton";
 
 import GoogleLogo from "@/assets/logo/social-logo/wordmark/google-wordmark.svg?react";
 import MetaLogo from "@/assets/logo/social-logo/wordmark/meta-wordmark.svg?react";
@@ -82,6 +84,7 @@ export default function SinglePlatformView({
   });
 
   const platformColor = PLATFORM_CHART_COLORS[platform];
+  const hasDualBudgetGauges = supportsDailyBudget(platform);
 
   return (
     <div className="flex flex-col gap-8">
@@ -137,10 +140,13 @@ export default function SinglePlatformView({
       </ErrorBoundary>
 
       {/* mid */}
-      <div className="grid grid-cols-3 tablet:grid-cols-1 gap-6">
+      <div className="grid grid-cols-3 items-stretch gap-6 tablet:grid-cols-1">
         <Card
           title="실시간 트래픽 변화"
-          className="col-span-2 tablet:col-span-1 h-120 flex-col"
+          className={twMerge(
+            "col-span-2 flex flex-col tablet:col-span-1",
+            hasDualBudgetGauges ? "min-h-120 h-full overflow-hidden" : "h-120",
+          )}
           description={
             <ChartLegend
               items={[
@@ -150,23 +156,34 @@ export default function SinglePlatformView({
             />
           }
         >
-          <ErrorBoundary
-            FallbackComponent={ChartErrorFallback}
-            resetKeys={[clickStreamData, platform]}
+          <div
+            className={twMerge(
+              hasDualBudgetGauges &&
+                "flex min-h-0 flex-1 flex-col overflow-hidden",
+            )}
           >
-            <PlatformTrafficChart
-              data={clickStreamData}
-              platform={platform}
-              isError={isClickStreamError}
-              suspectDetail={suspectDetail}
-              onRetry={reconnectClickStream}
-            />
-          </ErrorBoundary>
+            <ErrorBoundary
+              FallbackComponent={ChartErrorFallback}
+              resetKeys={[clickStreamData, platform]}
+            >
+              <PlatformTrafficChart
+                data={clickStreamData}
+                platform={platform}
+                isError={isClickStreamError}
+                suspectDetail={suspectDetail}
+                onRetry={reconnectClickStream}
+                fillHeight={hasDualBudgetGauges}
+              />
+            </ErrorBoundary>
+          </div>
         </Card>
 
         <Card
           title="예산 소진 현황"
-          className="col-span-1 tablet:col-span-1 min-h-120 flex flex-col"
+          className={twMerge(
+            "col-span-1 flex flex-col tablet:col-span-1",
+            hasDualBudgetGauges ? "min-h-120 h-full" : "min-h-120",
+          )}
           description={
             <ChartLegend
               items={[
@@ -177,44 +194,54 @@ export default function SinglePlatformView({
             />
           }
         >
-          <ErrorBoundary
-            FallbackComponent={ChartErrorFallback}
-            resetKeys={[budgetData]}
-          >
-            {isBudgetLoading ? (
-              <div className="flex flex-1 items-center justify-center p-8">
-                <Skeleton className="h-32 w-full rounded-2xl" />
-              </div>
-            ) : isBudgetError ? (
-              <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-info-red">
-                예산 데이터를 불러오지 못했습니다.
-              </div>
-            ) : budgetData ? (
-              <div
-                className={twMerge(
-                  "flex flex-1 flex-col overflow-y-auto pt-2",
-                  budgetData.gauges.length === 1 && "gap-5",
-                )}
-              >
-                {budgetData.gauges.map((gauge, index) => (
-                  <div
-                    key={gauge.label}
-                    className={twMerge(
-                      index > 0 &&
-                        budgetData.gauges.length > 1 &&
-                        "mt-5 border-t border-surface-300 pt-5",
-                    )}
-                  >
-                    <BudgetGaugeChart {...gauge} />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-text-muted">
-                표시할 예산 데이터가 없습니다.
-              </div>
+          <div
+            className={twMerge(
+              hasDualBudgetGauges && "flex min-h-0 flex-1 flex-col",
             )}
-          </ErrorBoundary>
+          >
+            <ErrorBoundary
+              FallbackComponent={ChartErrorFallback}
+              resetKeys={[budgetData]}
+            >
+              {isBudgetLoading ? (
+                hasDualBudgetGauges ? (
+                  <PlatformDualBudgetGaugeSkeleton />
+                ) : (
+                  <div className="flex flex-1 items-center justify-center p-8">
+                    <Skeleton className="h-32 w-full rounded-2xl" />
+                  </div>
+                )
+              ) : isBudgetError ? (
+                <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-info-red">
+                  예산 데이터를 불러오지 못했습니다.
+                </div>
+              ) : budgetData ? (
+                <div
+                  className={twMerge(
+                    "flex flex-1 flex-col overflow-y-auto pt-2",
+                    budgetData.gauges.length === 1 && "gap-5",
+                  )}
+                >
+                  {budgetData.gauges.map((gauge, index) => (
+                    <div
+                      key={gauge.label}
+                      className={twMerge(
+                        index > 0 &&
+                          budgetData.gauges.length > 1 &&
+                          "mt-5 border-t border-surface-300 pt-5",
+                      )}
+                    >
+                      <BudgetGaugeChart {...gauge} />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-text-muted">
+                  표시할 예산 데이터가 없습니다.
+                </div>
+              )}
+            </ErrorBoundary>
+          </div>
         </Card>
       </div>
 

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -24,7 +24,10 @@ import DashboardAiSummarySection from "@/components/dashboard/ai-report/componen
 import BudgetGaugeChart from "@/components/dashboard/charts/BudgetGaugeChart";
 import PlatformDetailTable from "@/components/dashboard/platform/PlatformDetailTable";
 import PlatformTrafficChart from "@/components/dashboard/platform/PlatformTrafficChart";
-import { PlatformDualBudgetGaugeSkeleton } from "@/components/dashboard/platform/skeleton/PlatformSkeleton";
+import {
+  PlatformDualBudgetGaugeSkeleton,
+  PlatformSingleBudgetGaugeSkeleton,
+} from "@/components/dashboard/platform/skeleton/PlatformSkeleton";
 
 import GoogleLogo from "@/assets/logo/social-logo/wordmark/google-wordmark.svg?react";
 import MetaLogo from "@/assets/logo/social-logo/wordmark/meta-wordmark.svg?react";
@@ -207,9 +210,7 @@ export default function SinglePlatformView({
                 hasDualBudgetGauges ? (
                   <PlatformDualBudgetGaugeSkeleton />
                 ) : (
-                  <div className="flex flex-1 items-center justify-center p-8">
-                    <Skeleton className="h-32 w-full rounded-2xl" />
-                  </div>
+                  <PlatformSingleBudgetGaugeSkeleton />
                 )
               ) : isBudgetError ? (
                 <div className="flex flex-1 items-center justify-center px-4 py-4 text-center font-body2 text-info-red">

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -67,15 +67,27 @@ export function BadgeSkeleton({ className }: { className?: string }) {
 }
 
 /** compact BudgetGaugeChart 1칸 */
-function PlatformBudgetGaugeCompactSkeleton() {
+function PlatformBudgetGaugeCompactSkeleton({
+  mergedBudgetHeader = true,
+}: {
+  mergedBudgetHeader?: boolean;
+}) {
   return (
     <div className="flex flex-col">
       <div className="mb-3 flex flex-col">
         <div className="mb-2 flex items-center justify-between gap-2">
-          <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-6 w-12 rounded-lg" />
+          <Skeleton
+            className={twMerge("h-4", mergedBudgetHeader ? "w-36" : "w-20")}
+          />
+          <Skeleton className="h-6 w-12 shrink-0 rounded-lg" />
         </div>
-        <Skeleton className="h-8 w-24" />
+        {!mergedBudgetHeader && (
+          <div className="mb-2 flex items-baseline gap-2">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        )}
+        <Skeleton className="mt-2 h-8 w-24" />
       </div>
       <Skeleton className="mb-3 h-3 w-full rounded-full" />
       <div className="mb-3 flex items-end justify-between">
@@ -84,7 +96,7 @@ function PlatformBudgetGaugeCompactSkeleton() {
           <Skeleton className="h-4 w-24" />
         </div>
         <div className="flex flex-col items-end gap-0.5">
-          <Skeleton className="h-3 w-6" />
+          <Skeleton className="h-3 w-14" />
           <Skeleton className="h-4 w-24" />
         </div>
       </div>
@@ -99,13 +111,13 @@ function PlatformBudgetGaugeCompactSkeleton() {
 /** Naver 등 게이지 1개 — showInsight 레이아웃 */
 export function PlatformSingleBudgetGaugeSkeleton() {
   return (
-    <div className="flex flex-1 flex-col pt-2">
+    <div className="flex flex-1 flex-col pt-1">
       <div className="flex shrink-0 flex-col">
         <div className="mb-3 flex items-center justify-between gap-2">
-          <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-6 w-12 rounded-lg" />
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-6 w-12 shrink-0 rounded-lg" />
         </div>
-        <Skeleton className="mb-6 h-8 w-24" />
+        <Skeleton className="mt-3 h-8 w-24" />
         <Skeleton className="mb-3 h-3 w-full rounded-full" />
         <div className="mb-6 flex items-end justify-between">
           <div className="flex flex-col gap-0.5">
@@ -113,7 +125,7 @@ export function PlatformSingleBudgetGaugeSkeleton() {
             <Skeleton className="h-4 w-24" />
           </div>
           <div className="flex flex-col items-end gap-0.5">
-            <Skeleton className="h-3 w-6" />
+            <Skeleton className="h-3 w-14" />
             <Skeleton className="h-4 w-24" />
           </div>
         </div>
@@ -127,12 +139,20 @@ export function PlatformSingleBudgetGaugeSkeleton() {
 }
 
 /** Google/Meta — compact 게이지 2개 로딩 (최종 레이아웃 높이 유지) */
-export function PlatformDualBudgetGaugeSkeleton() {
+export function PlatformDualBudgetGaugeSkeleton({
+  mergedBudgetHeader = true,
+}: {
+  mergedBudgetHeader?: boolean;
+} = {}) {
   return (
     <div className="flex flex-1 flex-col pt-2">
-      <PlatformBudgetGaugeCompactSkeleton />
+      <PlatformBudgetGaugeCompactSkeleton
+        mergedBudgetHeader={mergedBudgetHeader}
+      />
       <div className="mt-5 border-t border-surface-300 pt-5">
-        <PlatformBudgetGaugeCompactSkeleton />
+        <PlatformBudgetGaugeCompactSkeleton
+          mergedBudgetHeader={mergedBudgetHeader}
+        />
       </div>
     </div>
   );

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -108,18 +108,26 @@ function PlatformBudgetGaugeCompactSkeleton({
   );
 }
 
-/** Naver 등 게이지 1개 — showInsight 레이아웃 */
+/** Naver 등 게이지 1개 — showInsight 레이아웃 (BudgetGaugeChart non-compact) */
 export function PlatformSingleBudgetGaugeSkeleton() {
   return (
-    <div className="flex flex-1 flex-col pt-1">
-      <div className="flex shrink-0 flex-col">
+    <div className="flex w-full flex-col pt-1">
+      <div className="mb-6 flex flex-col">
         <div className="mb-3 flex items-center justify-between gap-2">
-          <Skeleton className="h-4 w-36" />
+          <div className="flex min-w-0 items-baseline gap-2">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-24" />
+          </div>
           <Skeleton className="h-6 w-12 shrink-0 rounded-lg" />
         </div>
-        <Skeleton className="mt-3 h-8 w-24" />
+        <div className="mt-3 flex items-baseline gap-2">
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-4 w-8" />
+        </div>
+      </div>
+      <div className="mb-6">
         <Skeleton className="mb-3 h-3 w-full rounded-full" />
-        <div className="mb-6 flex items-end justify-between">
+        <div className="flex items-end justify-between">
           <div className="flex flex-col gap-0.5">
             <Skeleton className="h-3 w-6" />
             <Skeleton className="h-4 w-24" />

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -65,3 +65,39 @@ export function PerformanceEfficiencyChartSkeleton() {
 export function BadgeSkeleton({ className }: { className?: string }) {
   return <Skeleton className={twMerge("w-14 h-6 rounded-lg", className)} />;
 }
+
+/** compact BudgetGaugeChart 1칸 (인사이트 없음) */
+function PlatformBudgetGaugeCompactSkeleton() {
+  return (
+    <div className="flex flex-col">
+      <div className="mb-3 flex flex-col">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-6 w-12 rounded-lg" />
+        </div>
+        <Skeleton className="h-8 w-24" />
+      </div>
+      <Skeleton className="mb-3 h-3 w-full rounded-full" />
+      <div className="mb-3 flex items-center justify-between">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+      <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 px-4 py-3">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-7 w-36" />
+      </div>
+    </div>
+  );
+}
+
+/** Google/Meta — compact 게이지 2개 로딩 (최종 레이아웃 높이 유지) */
+export function PlatformDualBudgetGaugeSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col pt-2">
+      <PlatformBudgetGaugeCompactSkeleton />
+      <div className="mt-5 border-t border-surface-300 pt-5">
+        <PlatformBudgetGaugeCompactSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -90,6 +90,36 @@ function PlatformBudgetGaugeCompactSkeleton() {
   );
 }
 
+/** Naver 등 게이지 1개 — showInsight 레이아웃 */
+export function PlatformSingleBudgetGaugeSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col pt-2">
+      <div className="flex shrink-0 flex-col">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-6 w-12 rounded-lg" />
+        </div>
+        <Skeleton className="mb-6 h-8 w-24" />
+        <Skeleton className="mb-3 h-3 w-full rounded-full" />
+        <div className="mb-6 flex items-center justify-between">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 p-4">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-7 w-36" />
+        </div>
+        <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
+          <Skeleton className="size-5 shrink-0 rounded-full" />
+          <Skeleton className="h-10 flex-1 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** Google/Meta — compact 게이지 2개 로딩 (최종 레이아웃 높이 유지) */
 export function PlatformDualBudgetGaugeSkeleton() {
   return (

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -78,9 +78,15 @@ function PlatformBudgetGaugeCompactSkeleton() {
         <Skeleton className="h-8 w-24" />
       </div>
       <Skeleton className="mb-3 h-3 w-full rounded-full" />
-      <div className="mb-3 flex items-center justify-between">
-        <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-4 w-24" />
+      <div className="mb-3 flex items-end justify-between">
+        <div className="flex flex-col gap-0.5">
+          <Skeleton className="h-3 w-6" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="flex flex-col items-end gap-0.5">
+          <Skeleton className="h-3 w-6" />
+          <Skeleton className="h-4 w-24" />
+        </div>
       </div>
       <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 px-4 py-3">
         <Skeleton className="h-3 w-16" />
@@ -101,9 +107,15 @@ export function PlatformSingleBudgetGaugeSkeleton() {
         </div>
         <Skeleton className="mb-6 h-8 w-24" />
         <Skeleton className="mb-3 h-3 w-full rounded-full" />
-        <div className="mb-6 flex items-center justify-between">
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24" />
+        <div className="mb-6 flex items-end justify-between">
+          <div className="flex flex-col gap-0.5">
+            <Skeleton className="h-3 w-6" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <div className="flex flex-col items-end gap-0.5">
+            <Skeleton className="h-3 w-6" />
+            <Skeleton className="h-4 w-24" />
+          </div>
         </div>
       </div>
       <div className="flex flex-col gap-3">

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -66,7 +66,7 @@ export function BadgeSkeleton({ className }: { className?: string }) {
   return <Skeleton className={twMerge("w-14 h-6 rounded-lg", className)} />;
 }
 
-/** compact BudgetGaugeChart 1칸 (인사이트 없음) */
+/** compact BudgetGaugeChart 1칸 */
 function PlatformBudgetGaugeCompactSkeleton() {
   return (
     <div className="flex flex-col">
@@ -88,9 +88,9 @@ function PlatformBudgetGaugeCompactSkeleton() {
           <Skeleton className="h-4 w-24" />
         </div>
       </div>
-      <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 px-4 py-3">
-        <Skeleton className="h-3 w-16" />
-        <Skeleton className="h-7 w-36" />
+      <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
+        <Skeleton className="size-5 shrink-0 rounded-full" />
+        <Skeleton className="h-10 flex-1 rounded-md" />
       </div>
     </div>
   );
@@ -118,15 +118,9 @@ export function PlatformSingleBudgetGaugeSkeleton() {
           </div>
         </div>
       </div>
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1 rounded-2xl border border-surface-400/25 bg-surface-200/50 p-4">
-          <Skeleton className="h-3 w-16" />
-          <Skeleton className="h-7 w-36" />
-        </div>
-        <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
-          <Skeleton className="size-5 shrink-0 rounded-full" />
-          <Skeleton className="h-10 flex-1 rounded-md" />
-        </div>
+      <div className="flex items-center gap-3 rounded-2xl bg-surface-300 px-5 py-4">
+        <Skeleton className="size-5 shrink-0 rounded-full" />
+        <Skeleton className="h-10 flex-1 rounded-md" />
       </div>
     </div>
   );

--- a/src/constants/dashboard/trafficChartHeights.ts
+++ b/src/constants/dashboard/trafficChartHeights.ts
@@ -1,0 +1,8 @@
+/** 통합 대시보드 실시간 트래픽 차트 (ApexCharts height) */
+export const OVERVIEW_TRAFFIC_CHART_HEIGHT = 520;
+
+/** 플랫폼 대시보드 — 게이지 1개 (Naver 등) */
+export const PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE = 360;
+
+/** 플랫폼 대시보드 — 게이지 2개 fillHeight 측정 하한 */
+export const PLATFORM_TRAFFIC_CHART_HEIGHT_DUAL_MIN = 300;

--- a/src/constants/dashboard/trafficChartHeights.ts
+++ b/src/constants/dashboard/trafficChartHeights.ts
@@ -1,8 +1,11 @@
 /** 통합 대시보드 실시간 트래픽 차트 (ApexCharts height) */
-export const OVERVIEW_TRAFFIC_CHART_HEIGHT = 520;
+export const OVERVIEW_TRAFFIC_CHART_HEIGHT = 590;
 
-/** 플랫폼 대시보드 — 게이지 1개 (Naver 등) */
-export const PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE = 360;
+/** 플랫폼 대시보드 — 게이지 1개 (Naver 등) ApexCharts height */
+export const PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE = 290;
+
+/** 플랫폼 mid row 카드 — 게이지 1개 (예산·트래픽 공통, h-100) */
+export const PLATFORM_MID_SECTION_HEIGHT_SINGLE = "h-100" as const;
 
 /** 플랫폼 대시보드 — 게이지 2개 fillHeight 측정 하한 */
 export const PLATFORM_TRAFFIC_CHART_HEIGHT_DUAL_MIN = 300;

--- a/src/hooks/dashboard/useBudget.ts
+++ b/src/hooks/dashboard/useBudget.ts
@@ -1,13 +1,14 @@
+import type { IBudgetQueryData } from "@/types/dashboard/budget";
+import type { IBudgetResponse } from "@/types/dashboard/common";
 import type { TProviderType } from "@/types/dashboard/overview";
+
+import { toBudgetQueryData } from "@/utils/dashboard/budget";
 
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getBudget } from "@/api/dashboard/overview";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
-
-const WARNING_THRESHOLD = 50;
-const DANGER_THRESHOLD = 75;
 
 export function useBudget(provider?: TProviderType) {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
@@ -16,13 +17,12 @@ export function useBudget(provider?: TProviderType) {
     ? QUERY_KEYS.platform.budget(orgId, provider)
     : QUERY_KEYS.overview.budget(orgId);
 
-  return useCoreQuery(queryKey, () => getBudget(orgId!, provider), {
-    enabled: !!orgId && (provider ? !!provider : true),
-    select: (data) => ({
-      totalBudget: data.totalBudget,
-      spent: data.totalSpend,
-      warningThreshold: WARNING_THRESHOLD,
-      dangerThreshold: DANGER_THRESHOLD,
-    }),
-  });
+  return useCoreQuery<IBudgetResponse, IBudgetQueryData>(
+    queryKey,
+    () => getBudget(orgId!, provider),
+    {
+      enabled: !!orgId,
+      select: (data) => toBudgetQueryData(data, provider),
+    },
+  );
 }

--- a/src/pages/dashboard/overview/OverviewDashboard.tsx
+++ b/src/pages/dashboard/overview/OverviewDashboard.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from "react-router-dom";
 
+import { getSpentPercentage } from "@/utils/dashboard/budget";
+
 import { useBudget } from "@/hooks/dashboard/useBudget";
 import { useOverviewMetrics } from "@/hooks/dashboard/useOverviewMetrics";
 import { useOverviewRoasRankings } from "@/hooks/dashboard/useOverviewRoasRankings";
@@ -35,16 +37,12 @@ export default function OverviewDashboard() {
     error: rankingsError,
   } = useOverviewRoasRankings();
 
-  const budgetPct =
-    budget && budget.totalBudget > 0
-      ? Math.round((budget.spent / budget.totalBudget) * 100)
-      : 0;
   const budgetStatus =
     budget && !isBudgetLoading
       ? getBudgetStatus(
-          budgetPct,
-          budget.warningThreshold,
-          budget.dangerThreshold,
+          getSpentPercentage(budget.statusGauge),
+          budget.statusGauge.warningThreshold,
+          budget.statusGauge.dangerThreshold,
         )
       : null;
 

--- a/src/pages/dashboard/overview/OverviewDashboard.tsx
+++ b/src/pages/dashboard/overview/OverviewDashboard.tsx
@@ -1,7 +1,5 @@
 import { useNavigate } from "react-router-dom";
 
-import { getSpentPercentage } from "@/utils/dashboard/budget";
-
 import { useBudget } from "@/hooks/dashboard/useBudget";
 import { useOverviewMetrics } from "@/hooks/dashboard/useOverviewMetrics";
 import { useOverviewRoasRankings } from "@/hooks/dashboard/useOverviewRoasRankings";
@@ -9,7 +7,6 @@ import { useOverviewRoasRankings } from "@/hooks/dashboard/useOverviewRoasRankin
 import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import DashboardAiSummarySection from "@/components/dashboard/ai-report/components/DashboardAiSummarySection";
-import { getBudgetStatus } from "@/components/dashboard/charts/BudgetGaugeChart";
 
 import { OverviewBudgetSection } from "./sections/OverviewBudgetSection";
 import { OverviewKpiSection } from "./sections/OverviewKpiSection";
@@ -37,15 +34,6 @@ export default function OverviewDashboard() {
     error: rankingsError,
   } = useOverviewRoasRankings();
 
-  const budgetStatus =
-    budget && !isBudgetLoading
-      ? getBudgetStatus(
-          getSpentPercentage(budget.statusGauge),
-          budget.statusGauge.warningThreshold,
-          budget.statusGauge.dangerThreshold,
-        )
-      : null;
-
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
       <div className="grid w-full min-w-0 grid-cols-4 items-stretch gap-6 tablet:grid-cols-1 tablet:gap-6">
@@ -60,7 +48,6 @@ export default function OverviewDashboard() {
           isBudgetLoading={isBudgetLoading}
           isBudgetError={isBudgetError}
           budgetError={budgetError}
-          budgetStatus={budgetStatus}
         />
       </div>
 

--- a/src/pages/dashboard/overview/sections/OverviewBudgetSection.tsx
+++ b/src/pages/dashboard/overview/sections/OverviewBudgetSection.tsx
@@ -77,7 +77,11 @@ export function OverviewBudgetSection({
               ) : isBudgetLoading ? (
                 <OverviewBudgetGaugeSkeleton />
               ) : budget ? (
-                <BudgetGaugeChart {...budget} />
+                <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto">
+                  {budget.gauges.map((gauge) => (
+                    <BudgetGaugeChart key={gauge.label} {...gauge} />
+                  ))}
+                </div>
               ) : null}
             </ErrorBoundary>
           </div>

--- a/src/pages/dashboard/overview/sections/OverviewBudgetSection.tsx
+++ b/src/pages/dashboard/overview/sections/OverviewBudgetSection.tsx
@@ -2,17 +2,13 @@ import type { IApiErrorResponse } from "@/types/common/common";
 
 import type { useBudget } from "@/hooks/dashboard/useBudget";
 
-import Badge from "@/components/common/badge/Badge";
 import Card from "@/components/common/card/Card";
 import ChartLegend, {
   type IChartLegendItem,
 } from "@/components/common/chart/ChartLegend";
 import ChartErrorFallback from "@/components/common/error/ChartErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
-import type { getBudgetStatus } from "@/components/dashboard/charts/BudgetGaugeChart";
-import BudgetGaugeChart, {
-  statusBadgeVariant,
-} from "@/components/dashboard/charts/BudgetGaugeChart";
+import BudgetGaugeChart from "@/components/dashboard/charts/BudgetGaugeChart";
 import { OverviewBudgetGaugeSkeleton } from "@/components/dashboard/overview/skeleton/OverviewSkeleton";
 
 import OverviewCampaignSnapshotCard from "./OverviewCampaignSnapshotCard";
@@ -28,13 +24,11 @@ export function OverviewBudgetSection({
   isBudgetLoading,
   isBudgetError,
   budgetError,
-  budgetStatus,
 }: {
   budget: ReturnType<typeof useBudget>["data"];
   isBudgetLoading: boolean;
   isBudgetError: boolean;
   budgetError: IApiErrorResponse | null;
-  budgetStatus: ReturnType<typeof getBudgetStatus> | null;
 }) {
   return (
     <div className="col-span-1 flex h-full min-h-0 min-w-0 flex-col gap-3 tablet:col-span-1">
@@ -47,16 +41,6 @@ export function OverviewBudgetSection({
               className="flex-wrap gap-x-4 gap-y-1 [&_span]:text-text-muted"
               items={budgetStatusLegendItems}
             />
-          }
-          RightElement={
-            budgetStatus ? (
-              <Badge
-                variant={statusBadgeVariant[budgetStatus]}
-                className="px-2"
-              >
-                {budgetStatus}
-              </Badge>
-            ) : undefined
           }
         >
           <div className="flex min-h-0 flex-1 flex-col">

--- a/src/pages/dashboard/overview/sections/OverviewBudgetSection.tsx
+++ b/src/pages/dashboard/overview/sections/OverviewBudgetSection.tsx
@@ -61,9 +61,24 @@ export function OverviewBudgetSection({
               ) : isBudgetLoading ? (
                 <OverviewBudgetGaugeSkeleton />
               ) : budget ? (
-                <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto">
-                  {budget.gauges.map((gauge) => (
-                    <BudgetGaugeChart key={gauge.label} {...gauge} />
+                <div
+                  className={
+                    budget.gauges.length > 1
+                      ? "flex min-h-0 flex-1 flex-col overflow-y-auto"
+                      : "flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto"
+                  }
+                >
+                  {budget.gauges.map((gauge, index) => (
+                    <div
+                      key={gauge.label}
+                      className={
+                        index > 0 && budget.gauges.length > 1
+                          ? "mt-5 border-t border-surface-300 pt-5"
+                          : undefined
+                      }
+                    >
+                      <BudgetGaugeChart {...gauge} />
+                    </div>
                   ))}
                 </div>
               ) : null}

--- a/src/pages/dashboard/overview/sections/OverviewKpiSection.tsx
+++ b/src/pages/dashboard/overview/sections/OverviewKpiSection.tsx
@@ -70,7 +70,7 @@ export function OverviewKpiSection({
         }
         RightElement={<TrafficChartDownload />}
       >
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 pt-3 flex-1 flex-col">
           <ErrorBoundary FallbackComponent={ChartErrorFallback}>
             <Suspense fallback={<OverviewTrafficChartSkeleton />}>
               <TrafficChart />

--- a/src/pages/dashboard/overview/sections/OverviewKpiSection.tsx
+++ b/src/pages/dashboard/overview/sections/OverviewKpiSection.tsx
@@ -70,7 +70,7 @@ export function OverviewKpiSection({
         }
         RightElement={<TrafficChartDownload />}
       >
-        <div className="flex min-h-0 pt-3 flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col pt-1">
           <ErrorBoundary FallbackComponent={ChartErrorFallback}>
             <Suspense fallback={<OverviewTrafficChartSkeleton />}>
               <TrafficChart />

--- a/src/types/dashboard/budget.ts
+++ b/src/types/dashboard/budget.ts
@@ -1,14 +1,20 @@
-/** 게이지 1개 (전체 or 일일) */
+/** 게이지 라벨 */
+export type TBudgetGaugeLabel =
+  | "전체 예산"
+  | "일일 예산"
+  | "Google·Meta"
+  | "NAVER";
+
+/** 게이지 1개 분량 */
 export interface IBudgetSlice {
-  label: "전체 예산" | "일일 예산";
+  label: TBudgetGaugeLabel;
   totalBudget: number;
   spent: number;
 }
 
 /** 어댑터가 만드는 ViewModel */
 export interface IBudgetViewModel {
-  lifetime: IBudgetSlice;
-  daily?: IBudgetSlice;
+  slices: IBudgetSlice[];
 }
 
 /** BudgetGaugeChart에 넘기는 props */
@@ -21,6 +27,7 @@ export interface IBudgetGaugeProps extends IBudgetSlice {
 /** useBudget select 결과 */
 export interface IBudgetQueryData {
   viewModel: IBudgetViewModel;
-  lifetimeGauge: IBudgetGaugeProps;
-  dailyGauge?: IBudgetGaugeProps;
+  gauges: IBudgetGaugeProps[];
+  /** Badge·상태 계산용 (통합: Google·Meta, 플랫폼: 전체 예산) */
+  statusGauge: IBudgetGaugeProps;
 }

--- a/src/types/dashboard/budget.ts
+++ b/src/types/dashboard/budget.ts
@@ -21,7 +21,10 @@ export interface IBudgetViewModel {
 export interface IBudgetGaugeProps extends IBudgetSlice {
   warningThreshold: number;
   dangerThreshold: number;
+  /** 2게이지 등 세로 간격 축소 */
   compact?: boolean;
+  /** 하단 인사이트 멘트 표시 (compact와 별도) */
+  showInsight?: boolean;
 }
 
 /** useBudget select 결과 */

--- a/src/types/dashboard/budget.ts
+++ b/src/types/dashboard/budget.ts
@@ -28,6 +28,4 @@ export interface IBudgetGaugeProps extends IBudgetSlice {
 export interface IBudgetQueryData {
   viewModel: IBudgetViewModel;
   gauges: IBudgetGaugeProps[];
-  /** Badge·상태 계산용 (통합: Google·Meta, 플랫폼: 전체 예산) */
-  statusGauge: IBudgetGaugeProps;
 }

--- a/src/types/dashboard/budget.ts
+++ b/src/types/dashboard/budget.ts
@@ -1,0 +1,26 @@
+/** 게이지 1개 (전체 or 일일) */
+export interface IBudgetSlice {
+  label: "전체 예산" | "일일 예산";
+  totalBudget: number;
+  spent: number;
+}
+
+/** 어댑터가 만드는 ViewModel */
+export interface IBudgetViewModel {
+  lifetime: IBudgetSlice;
+  daily?: IBudgetSlice;
+}
+
+/** BudgetGaugeChart에 넘기는 props */
+export interface IBudgetGaugeProps extends IBudgetSlice {
+  warningThreshold: number;
+  dangerThreshold: number;
+  compact?: boolean;
+}
+
+/** useBudget select 결과 */
+export interface IBudgetQueryData {
+  viewModel: IBudgetViewModel;
+  lifetimeGauge: IBudgetGaugeProps;
+  dailyGauge?: IBudgetGaugeProps;
+}

--- a/src/types/dashboard/common.ts
+++ b/src/types/dashboard/common.ts
@@ -10,6 +10,12 @@ export interface IMetricsResponse {
   ROASChangeRate: number;
 }
 
+// 예산 금액 단위 (API 분리 응답)
+export interface IBudgetAmountSlice {
+  totalBudget: number;
+  totalSpend: number;
+}
+
 // 예산 소진 현황
 export interface IBudgetResponse {
   providerType: string;
@@ -17,6 +23,12 @@ export interface IBudgetResponse {
   totalBudget: number;
   totalSpend: number;
   remainingBudget: number;
+  /** 통합 대시보드 — Google·Meta / Naver 분리 */
+  googleMeta?: IBudgetAmountSlice;
+  naver?: IBudgetAmountSlice;
+  /** 플랫폼 Google/Meta — 전체 / 일일 분리 */
+  lifetime?: IBudgetAmountSlice;
+  daily?: IBudgetAmountSlice;
 }
 
 // ROAS 순위 항목

--- a/src/utils/dashboard/budget.ts
+++ b/src/utils/dashboard/budget.ts
@@ -132,6 +132,5 @@ export function toBudgetQueryData(
   return {
     viewModel,
     gauges,
-    statusGauge: gauges[0],
   };
 }

--- a/src/utils/dashboard/budget.ts
+++ b/src/utils/dashboard/budget.ts
@@ -1,16 +1,18 @@
-//어댑터 + % 계산
 import type {
   IBudgetGaugeProps,
   IBudgetSlice,
   IBudgetViewModel,
 } from "@/types/dashboard/budget";
-import type { IBudgetResponse } from "@/types/dashboard/common";
+import type {
+  IBudgetAmountSlice,
+  IBudgetResponse,
+} from "@/types/dashboard/common";
 import type { TProviderType } from "@/types/dashboard/provider";
 
 const WARNING_THRESHOLD = 50;
 const DANGER_THRESHOLD = 75;
 
-/** Google/Meta만 일일 예산 게이지 */
+/** Google/Meta 플랫폼 — 일일 예산 게이지 */
 export function supportsDailyBudget(provider?: TProviderType): boolean {
   return provider === "GOOGLE" || provider === "META";
 }
@@ -31,6 +33,29 @@ export function getRemainingPercentage(slice: {
   return Math.max(0, 100 - getSpentPercentage(slice));
 }
 
+function toAmountSlice(
+  data: IBudgetResponse,
+  slice?: IBudgetAmountSlice,
+): IBudgetAmountSlice {
+  return (
+    slice ?? {
+      totalBudget: data.totalBudget,
+      totalSpend: data.totalSpend,
+    }
+  );
+}
+
+function toBudgetSlice(
+  label: IBudgetSlice["label"],
+  amount: IBudgetAmountSlice,
+): IBudgetSlice {
+  return {
+    label,
+    totalBudget: amount.totalBudget,
+    spent: amount.totalSpend,
+  };
+}
+
 function toGaugeProps(
   slice: IBudgetSlice,
   compact?: boolean,
@@ -43,34 +68,53 @@ function toGaugeProps(
   };
 }
 
+/** 통합: Google·Meta + Naver (전체 예산 각 1개) */
+function mapOverviewBudgetViewModel(data: IBudgetResponse): IBudgetViewModel {
+  const googleMeta = toAmountSlice(data, data.googleMeta);
+  const naver = data.naver ?? { totalBudget: 0, totalSpend: 0 };
+
+  return {
+    slices: [
+      toBudgetSlice("Google·Meta", googleMeta),
+      toBudgetSlice("NAVER", naver),
+    ],
+  };
+}
+
+/** 플랫폼: Google/Meta → 전체+일일, Naver → 전체만 */
+function mapPlatformBudgetViewModel(
+  data: IBudgetResponse,
+  provider: TProviderType,
+): IBudgetViewModel {
+  const lifetime = toBudgetSlice(
+    "전체 예산",
+    toAmountSlice(data, data.lifetime),
+  );
+
+  if (!supportsDailyBudget(provider)) {
+    return { slices: [lifetime] };
+  }
+
+  const daily = toBudgetSlice("일일 예산", toAmountSlice(data, data.daily));
+
+  return { slices: [lifetime, daily] };
+}
+
 /**
- * API → UI 변환 (나중에 API 바뀌면 여기만 수정)
+ * API → UI 변환 (API 스펙 변경 시 여기만 수정)
  *
- * [현재] 단일 IBudgetResponse 가정
- * [통합] provider 없음 → lifetime 1개, daily 없음
- * [Google/Meta] lifetime + daily (daily는 API 전 임시)
+ * [통합] googleMeta + naver (legacy: googleMeta만 totalBudget/totalSpend fallback)
+ * [Google/Meta] lifetime + daily
  * [Naver] lifetime만
  */
 export function mapBudgetResponseToViewModel(
   data: IBudgetResponse,
   provider?: TProviderType,
 ): IBudgetViewModel {
-  const lifetime: IBudgetSlice = {
-    label: "전체 예산",
-    totalBudget: data.totalBudget,
-    spent: data.totalSpend,
-  };
-
-  // TODO: 백엔드 daily 필드 확정 후 교체
-  const daily: IBudgetSlice | undefined = supportsDailyBudget(provider)
-    ? {
-        label: "일일 예산",
-        totalBudget: data.totalBudget,
-        spent: data.totalSpend,
-      }
-    : undefined;
-
-  return { lifetime, daily };
+  if (provider === undefined) {
+    return mapOverviewBudgetViewModel(data);
+  }
+  return mapPlatformBudgetViewModel(data, provider);
 }
 
 /** useBudget select에서 쓸 최종 형태 */
@@ -79,13 +123,15 @@ export function toBudgetQueryData(
   provider?: TProviderType,
 ) {
   const viewModel = mapBudgetResponseToViewModel(data, provider);
-  const hasDaily = !!viewModel.daily;
+  const isCompact = viewModel.slices.length > 1;
+
+  const gauges = viewModel.slices.map((slice) =>
+    toGaugeProps(slice, isCompact),
+  );
 
   return {
     viewModel,
-    lifetimeGauge: toGaugeProps(viewModel.lifetime, hasDaily),
-    dailyGauge: viewModel.daily
-      ? toGaugeProps(viewModel.daily, true)
-      : undefined,
+    gauges,
+    statusGauge: gauges[0],
   };
 }

--- a/src/utils/dashboard/budget.ts
+++ b/src/utils/dashboard/budget.ts
@@ -12,6 +12,9 @@ import type { TProviderType } from "@/types/dashboard/provider";
 const WARNING_THRESHOLD = 50;
 const DANGER_THRESHOLD = 75;
 
+/** 예산 게이지 하단 인사이트 — 팀 논의 후 true로 전환 가능 */
+export const SHOW_BUDGET_GAUGE_INSIGHT = false;
+
 /** Google/Meta 플랫폼 — 일일 예산 게이지 */
 export function supportsDailyBudget(provider?: TProviderType): boolean {
   return provider === "GOOGLE" || provider === "META";
@@ -58,13 +61,14 @@ function toBudgetSlice(
 
 function toGaugeProps(
   slice: IBudgetSlice,
-  compact?: boolean,
+  { compact = false, showInsight = SHOW_BUDGET_GAUGE_INSIGHT } = {},
 ): IBudgetGaugeProps {
   return {
     ...slice,
     warningThreshold: WARNING_THRESHOLD,
     dangerThreshold: DANGER_THRESHOLD,
     compact,
+    showInsight,
   };
 }
 
@@ -124,9 +128,10 @@ export function toBudgetQueryData(
 ) {
   const viewModel = mapBudgetResponseToViewModel(data, provider);
   const isCompact = viewModel.slices.length > 1;
+  const showInsight = viewModel.slices.length === 1;
 
   const gauges = viewModel.slices.map((slice) =>
-    toGaugeProps(slice, isCompact),
+    toGaugeProps(slice, { compact: isCompact, showInsight }),
   );
 
   return {

--- a/src/utils/dashboard/budget.ts
+++ b/src/utils/dashboard/budget.ts
@@ -12,8 +12,8 @@ import type { TProviderType } from "@/types/dashboard/provider";
 const WARNING_THRESHOLD = 50;
 const DANGER_THRESHOLD = 75;
 
-/** 예산 게이지 하단 인사이트 — 팀 논의 후 true로 전환 가능 */
-export const SHOW_BUDGET_GAUGE_INSIGHT = false;
+/** BudgetGaugeChart showInsight 기본값 */
+export const SHOW_BUDGET_GAUGE_INSIGHT = true;
 
 /** Google/Meta 플랫폼 — 일일 예산 게이지 */
 export function supportsDailyBudget(provider?: TProviderType): boolean {
@@ -128,10 +128,9 @@ export function toBudgetQueryData(
 ) {
   const viewModel = mapBudgetResponseToViewModel(data, provider);
   const isCompact = viewModel.slices.length > 1;
-  const showInsight = viewModel.slices.length === 1;
 
   const gauges = viewModel.slices.map((slice) =>
-    toGaugeProps(slice, { compact: isCompact, showInsight }),
+    toGaugeProps(slice, { compact: isCompact, showInsight: true }),
   );
 
   return {

--- a/src/utils/dashboard/budget.ts
+++ b/src/utils/dashboard/budget.ts
@@ -1,0 +1,91 @@
+//어댑터 + % 계산
+import type {
+  IBudgetGaugeProps,
+  IBudgetSlice,
+  IBudgetViewModel,
+} from "@/types/dashboard/budget";
+import type { IBudgetResponse } from "@/types/dashboard/common";
+import type { TProviderType } from "@/types/dashboard/provider";
+
+const WARNING_THRESHOLD = 50;
+const DANGER_THRESHOLD = 75;
+
+/** Google/Meta만 일일 예산 게이지 */
+export function supportsDailyBudget(provider?: TProviderType): boolean {
+  return provider === "GOOGLE" || provider === "META";
+}
+
+export function getSpentPercentage(slice: {
+  totalBudget: number;
+  spent: number;
+}): number {
+  if (slice.totalBudget <= 0) return 0;
+  return Math.round((slice.spent / slice.totalBudget) * 100);
+}
+
+/** 화면 큰 숫자 — 남은 % */
+export function getRemainingPercentage(slice: {
+  totalBudget: number;
+  spent: number;
+}): number {
+  return Math.max(0, 100 - getSpentPercentage(slice));
+}
+
+function toGaugeProps(
+  slice: IBudgetSlice,
+  compact?: boolean,
+): IBudgetGaugeProps {
+  return {
+    ...slice,
+    warningThreshold: WARNING_THRESHOLD,
+    dangerThreshold: DANGER_THRESHOLD,
+    compact,
+  };
+}
+
+/**
+ * API → UI 변환 (나중에 API 바뀌면 여기만 수정)
+ *
+ * [현재] 단일 IBudgetResponse 가정
+ * [통합] provider 없음 → lifetime 1개, daily 없음
+ * [Google/Meta] lifetime + daily (daily는 API 전 임시)
+ * [Naver] lifetime만
+ */
+export function mapBudgetResponseToViewModel(
+  data: IBudgetResponse,
+  provider?: TProviderType,
+): IBudgetViewModel {
+  const lifetime: IBudgetSlice = {
+    label: "전체 예산",
+    totalBudget: data.totalBudget,
+    spent: data.totalSpend,
+  };
+
+  // TODO: 백엔드 daily 필드 확정 후 교체
+  const daily: IBudgetSlice | undefined = supportsDailyBudget(provider)
+    ? {
+        label: "일일 예산",
+        totalBudget: data.totalBudget,
+        spent: data.totalSpend,
+      }
+    : undefined;
+
+  return { lifetime, daily };
+}
+
+/** useBudget select에서 쓸 최종 형태 */
+export function toBudgetQueryData(
+  data: IBudgetResponse,
+  provider?: TProviderType,
+) {
+  const viewModel = mapBudgetResponseToViewModel(data, provider);
+  const hasDaily = !!viewModel.daily;
+
+  return {
+    viewModel,
+    lifetimeGauge: toGaugeProps(viewModel.lifetime, hasDaily),
+    dailyGauge: viewModel.daily
+      ? toGaugeProps(viewModel.daily, true)
+      : undefined,
+  };
+}


### PR DESCRIPTION
## 🚨 관련 이슈
close #312 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

> 예산 조회·표시 스펙 변경에 맞춰 통합/플랫폼 대시보드의 예산 소진 UI를 개편했습니다.

<img width="1704" height="972" alt="스크린샷 2026-08-01 오후 10 49 49" src="https://github.com/user-attachments/assets/1989d48e-8de7-4b7f-bdd3-499949df6629" />
<br /><br />

<img width="1705" height="978" alt="스크린샷 2026-08-01 오후 10 50 04" src="https://github.com/user-attachments/assets/fa2ba08f-079d-48fa-8eff-af684779e489" />
<br /><br />

<img width="1702" height="975" alt="스크린샷 2026-08-01 오후 10 50 19" src="https://github.com/user-attachments/assets/04358c90-334e-4344-a22b-ac30df420d36" />

---

### 데이터
- `IBudgetResponse` 분리 필드 → `budget.ts` 어댑터 → `useBudget`이 `{ gauges[] }` 반환
- 통합: Google·Meta / NAVER · 플랫폼 Google/Meta: 전체+일일 · Naver: 전체만

### BudgetGaugeChart
- 잔여 % 표시, 게이지별 `label`·Badge, `compact` / `showInsight` 분리

### 통합 대시보드
- 예산 2게이지 + 구분선, 카드 헤더 Badge 제거
- 로딩 스켈레톤 2게이지 compact
- (부가) 트래픽 차트 height 520px, `pt-3`

### 플랫폼 대시보드
- Google/Meta: 2게이지 + 트래픽 `fillHeight`
- Naver: 1게이지 + 게이지형 스켈레톤

## 😅 미완성 작업
- 캠페인 목록 예산 UI → 별도 이슈

## 📢 논의 사항 및 참고 사항
**통합 실시간 트래픽 height (520px)**
예산 게이지가 2개로 늘면서 세로 길이가 길어졌고, 그에 맞춰 왼쪽 실시간 트래픽 차트의 height을 고정(520px)으로 키웠습니다.

**예산 게이지 UI**
기존: 소진 % · 소진 비율 바 · (사용|전체) · 남은 예산 박스
변경: 남음 % · 남은 비율 바 · (사용|전체, 라벨 2줄) · 남은 예산 박스 유지
주 지표가 소진 → 남음으로 바뀌면서, 남은 금액을 바 하단에 작게 두는 방식을 생각했으나 남은 예산 박스가 이미 있어서 박스는 유지하고 하단은 사용|전체 보조 스케일로 정리했습니다. 금액 위치·박스 역할 변경 등 의견 주시면 반영하겠습니다.

**인사이트 UI (1게이지 / 2게이지)**
플랫폼 Naver처럼 1게이지일 때는 인사이트를 빼면 세로가 비어 보여서, 당장은 1게이지만 인사이트 영역을 두었습니다. 2게이지(통합·Google/Meta)는 전체가 길어져서 인사이트는 뺐고, compact + showInsight로 분리해 두었습니다.
카드 제목 `예산 소진 현황` 오른쪽에 한 줄로 넣는 것도 생각했는데, 이미 게이지마다 안정/주의/위험 Badge가 있어서 인사이트가 얼마나 필요한지 잘 모르겠습니다. 어떤 쪽이 나을지 의견 주시면 반영하겠습니다. (현재 SHOW_BUDGET_GAUGE_INSIGHT = false로 off)

**API / 백엔드**
백엔드 예산 스펙 변경이 아직 반영되지 않은 것 같아 실제 API 규격은 확인하지 못했습니다. IBudgetResponse 분리 필드·어댑터 매핑은 프론트 가정으로 붙여 둔 상태이고, 백 완료 후 스펙에 맞게 수정 예정입니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 예산 게이지에 사용액·잔여액·상태 및 초과 예산 인사이트를 표시합니다.
  * 플랫폼별 전체·일일 예산 게이지를 지원합니다.
  * 트래픽 차트가 카드 크기에 맞춰 유연하게 표시됩니다.

* **개선**
  * 대시보드와 플랫폼 화면의 예산·트래픽 레이아웃을 개선했습니다.
  * 로딩 화면이 실제 게이지 구성과 일치하도록 개선되었습니다.
  * 차트 높이, 여백 및 정렬을 조정해 시각적 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->