### PR TITLE
[Feature/#368] 워크스페이스 초대 수락 페이지 연동

### DIFF
--- a/src/api/workspace/org.ts
+++ b/src/api/workspace/org.ts
@@ -1,5 +1,6 @@
 import type { ICommonResponse } from "@/types/common/common";
 import {
+  type TAcceptInvitationResponse,
   type TCreateOrgRequest,
   type TCreateOrgResponse,
   type TDeleteWorkspaceMemberResponse,
@@ -153,4 +154,13 @@ export const getSavedWorkspace = async () => {
 
 export const saveSelectedWorkspace = async (orgId: number): Promise<void> => {
   await axiosInstance.post(`/api/org/${orgId}/workspace`);
+};
+
+export const acceptInvitaton = async (
+  token: string,
+): Promise<TAcceptInvitationResponse> => {
+  const { data } = await axiosInstance.post<
+    ICommonResponse<TAcceptInvitationResponse>
+  >(`/api/org/invitations/${token}`);
+  return data.data;
 };

--- a/src/components/common/error/ErrorLayout.tsx
+++ b/src/components/common/error/ErrorLayout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 
 import WarningIcon from "@/assets/icon/ai/warning.svg?react";
@@ -8,6 +8,16 @@ interface IErrorLayoutProps {
   title: string;
   description: string;
   actions: ReactNode;
+}
+
+function renderMultilineText(text: string) {
+  // 실제 개행과 문자 그대로의 "\n" 둘 다 줄바꿈으로 처리
+  return text.split(/\r?\n|\\n/).map((line, index) => (
+    <Fragment key={index}>
+      {index > 0 && <br />}
+      {line}
+    </Fragment>
+  ));
 }
 
 function ErrorLayout({ title, description, actions }: IErrorLayoutProps) {
@@ -32,19 +42,19 @@ function ErrorLayout({ title, description, actions }: IErrorLayoutProps) {
         </motion.div>
 
         <motion.h1
-          className="mb-4 text-balance font-heading1 text-text-title"
+          className="mb-4 break-keep font-heading1 text-text-title"
           variants={itemVariants}
           custom={!!reduceMotion}
         >
-          {title}
+          {renderMultilineText(title)}
         </motion.h1>
 
         <motion.p
-          className="whitespace-pre-line break-keep font-body1 leading-relaxed text-text-auth-sub"
+          className="break-keep font-body1 leading-relaxed text-text-auth-sub"
           variants={itemVariants}
           custom={!!reduceMotion}
         >
-          {description}
+          {renderMultilineText(description)}
         </motion.p>
 
         <motion.div

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -1,5 +1,174 @@
-export default function IniviteAcceptPage() {
-  <>
-    <div>aa</div>
-  </>;
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import type { IApiErrorResponse } from "@/types/common/common";
+
+import { buildPathWithReturnUrl } from "@/utils/auth/returnUrl";
+
+import Button from "@/components/common/button/Button";
+import ErrorLayout from "@/components/common/error/ErrorLayout";
+
+import { acceptInvitaton, saveSelectedWorkspace } from "@/api/workspace/org";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+import useAuthStore from "@/store/useAuthStore";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+type TInviteStatus = "loading" | "success" | "error";
+
+function getInviteErrorCopy(error: IApiErrorResponse | null): {
+  title: string;
+  description: string;
+} {
+  const message = error?.message ?? "";
+  const code = error?.code ?? "";
+
+  if (
+    code.includes("EXPIRED") ||
+    message.includes("만료") ||
+    message.toLowerCase().includes("expired")
+  ) {
+    return {
+      title: "초대 링크가 만료 되었습니다",
+      description:
+        "초대 링크 유효시간(24시간)이 지났습니다. \n워크스페이스 관리자에게 다시 초대를 요청해 주세요",
+    };
+  }
+  if (
+    code.includes("ALREADY") ||
+    message.includes("이미") ||
+    message.toLowerCase().includes("already")
+  ) {
+    return {
+      title: "이미 완료된 초대입니다",
+      description: "이미 이 워크스페이스에 참여중이거나 초대 완료한 상태입니다",
+    };
+  }
+  if (
+    code.includes("EMAIL") ||
+    message.includes("이메일") ||
+    message.toLowerCase().includes("email")
+  ) {
+    return {
+      title: "초대 이메일이 일치하지 않습니다",
+      description:
+        "초대받은 이메일 계정으로 로그인한 뒤\n다시 링크를 열어주세요",
+    };
+  }
+
+  return {
+    title: "초대를 수락할 수 없습니다",
+    description:
+      message ||
+      "초대 처리 중 오류가 발생했습니다. \n잠시 후 다시 시도해 주세요",
+  };
+}
+
+export default function getInviteAcceptPage() {
+  const { token } = useParams<{ token: string }>();
+  const nav = useNavigate();
+  const queryClient = useQueryClient();
+
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
+  const isTokenInitialized = useAuthStore((s) => s.isTokenInitialized);
+  const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
+
+  const [status, setStatus] = useState<TInviteStatus>("loading");
+  const [error, setError] = useState<IApiErrorResponse | null>(null);
+  const processedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isTokenInitialized) return;
+
+    if (!token) {
+      setStatus("error");
+      setError({
+        status: "error",
+        code: "INVALID_TOKEN",
+        message: "유효하지 않은 초대 링크입니다",
+        method: "POST",
+        requestURI: "/api/org/invitations",
+      });
+      return;
+    }
+    if (!isLoggedIn) {
+      nav(buildPathWithReturnUrl("/login", `/invite/${token}`), {
+        replace: true,
+      });
+    }
+    if (processedRef.current) return;
+    processedRef.current = true;
+
+    const accept = async () => {
+      try {
+        const data = await acceptInvitaton(token);
+        await saveSelectedWorkspace(data.orgId);
+        setSelectedOrgId(data.orgId);
+
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.workspace.list(),
+        });
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.workspace.saved(),
+        });
+
+        toast.success(data.message || "초대를 수락했습니다");
+        setStatus("success");
+        nav("/dashboard", { replace: true });
+      } catch (err) {
+        const apiError = err as IApiErrorResponse;
+        setError(apiError);
+        setStatus("error");
+      }
+    };
+    void accept();
+  }, [
+    isTokenInitialized,
+    isLoggedIn,
+    token,
+    nav,
+    queryClient,
+    setSelectedOrgId,
+  ]);
+
+  if (status === "error") {
+    const copy = getInviteErrorCopy(error);
+    return (
+      <ErrorLayout
+        title={copy.title}
+        description={copy.description}
+        actions={
+          <>
+            <Button
+              size="big"
+              variant="primary"
+              fullWidth
+              onClick={() => nav("/login", { replace: true })}
+            >
+              로그인으로 이동
+            </Button>
+            <Button
+              size="big"
+              variant="secondary"
+              fullWidth
+              onClick={() => nav("/", { replace: true })}
+            >
+              홈으로 이동
+            </Button>
+          </>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="relative flex h-screen w-full items-center justify-center bg-surface-100">
+      <p className="animate-pulse font-body2 text-text-muted">
+        {status === "success"
+          ? "워크스페이스로 이동 중..."
+          : "초대를 확인하는 중..."}
+      </p>
+    </div>
+  );
 }

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -95,11 +95,16 @@ export default function InviteAcceptPage() {
   const { mutate: acceptInvite } = useCoreMutation(acceptInvitaton, {
     invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
     userOnSuccess: async (data: TAcceptInvitationResponse) => {
-      await saveSelectedWorkspace(data.orgId);
-      setSelectedOrgId(data.orgId);
-      toast.success(data.message || "초대를 수락했습니다");
-      setUiStatus("success");
-      nav("/dashboard", { replace: true });
+      try {
+        await saveSelectedWorkspace(data.orgId);
+        setSelectedOrgId(data.orgId);
+        toast.success(data.message || "초대를 수락했습니다");
+        setUiStatus("success");
+        nav("/dashboard", { replace: true });
+      } catch (err) {
+        setAcceptError(err as IApiErrorResponse);
+        setUiStatus("error");
+      }
     },
     userOnError: (err) => {
       setAcceptError(err);

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -79,7 +79,7 @@ export default function getInviteAcceptPage() {
   const [status, setStatus] = useState<TInviteStatus>("loading");
   const [error, setError] = useState<IApiErrorResponse | null>(null);
   const [countdown, setCountdown] = useState(LOGIN_REDIRECT_SECONDS);
-  const processedRef = useRef(false);
+  const processedRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isTokenInitialized) return;
@@ -99,8 +99,8 @@ export default function getInviteAcceptPage() {
       setStatus("needLogin");
       return;
     }
-    if (processedRef.current) return;
-    processedRef.current = true;
+    if (processedRef.current === token) return;
+    processedRef.current = token;
 
     const accept = async () => {
       try {

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -93,7 +93,7 @@ export default function InviteAcceptPage() {
   const processedRef = useRef<string | null>(null);
 
   const { mutate: acceptInvite } = useCoreMutation(acceptInvitaton, {
-    invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
+    invalidateKeys: [QUERY_KEYS.workspace.list()],
     userOnSuccess: async (data: TAcceptInvitationResponse) => {
       try {
         await saveSelectedWorkspace(data.orgId);

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -17,7 +17,12 @@ import { QUERY_KEYS } from "@/lib/queryKeys";
 import useAuthStore from "@/store/useAuthStore";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
-type TInviteUiStatus = "loading" | "needLogin" | "invalidToken";
+type TInviteUiStatus =
+  | "loading"
+  | "needLogin"
+  | "invalidToken"
+  | "error"
+  | "success";
 
 const LOGIN_REDIRECT_SECONDS = 3;
 
@@ -30,13 +35,16 @@ function getInviteErrorCopy(error: IApiErrorResponse | null): {
 
   if (
     code.includes("EXPIRED") ||
+    code.includes("ORG_INVITATION_400") ||
     message.includes("만료") ||
-    message.toLowerCase().includes("expired")
+    message.includes("유효하지 않") ||
+    message.toLowerCase().includes("expired") ||
+    message.toLowerCase().includes("invalid")
   ) {
     return {
-      title: "초대 링크가 만료 되었습니다",
+      title: "초대 링크가 만료되었거나\n유효하지 않습니다",
       description:
-        "초대 링크 유효시간(24시간)이 지났습니다.\n워크스페이스 관리자에게 다시 초대를 요청해 주세요",
+        "초대 링크가 만료되었거나 더 이상 사용할 수 없습니다.\n워크스페이스 관리자에게 다시 초대를 요청해 주세요",
     };
   }
   if (
@@ -78,23 +86,29 @@ export default function InviteAcceptPage() {
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
 
   const [uiStatus, setUiStatus] = useState<TInviteUiStatus>("loading");
+  const [acceptError, setAcceptError] = useState<IApiErrorResponse | null>(
+    null,
+  );
   const [countdown, setCountdown] = useState(LOGIN_REDIRECT_SECONDS);
   const processedRef = useRef<string | null>(null);
 
-  const {
-    mutate: acceptInvite,
-    isError,
-    isSuccess,
-    error,
-  } = useCoreMutation(acceptInvitaton, {
+  const { mutate: acceptInvite } = useCoreMutation(acceptInvitaton, {
     invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
     userOnSuccess: async (data: TAcceptInvitationResponse) => {
       await saveSelectedWorkspace(data.orgId);
       setSelectedOrgId(data.orgId);
       toast.success(data.message || "초대를 수락했습니다");
+      setUiStatus("success");
       nav("/dashboard", { replace: true });
     },
+    userOnError: (err) => {
+      setAcceptError(err);
+      setUiStatus("error");
+    },
   });
+
+  const acceptInviteRef = useRef(acceptInvite);
+  acceptInviteRef.current = acceptInvite;
 
   useEffect(() => {
     if (!isTokenInitialized) return;
@@ -111,9 +125,10 @@ export default function InviteAcceptPage() {
 
     if (processedRef.current === token) return;
     processedRef.current = token;
+    setAcceptError(null);
     setUiStatus("loading");
-    acceptInvite(token);
-  }, [isTokenInitialized, isLoggedIn, token, acceptInvite]);
+    acceptInviteRef.current(token);
+  }, [isTokenInitialized, isLoggedIn, token]);
 
   useEffect(() => {
     if (uiStatus !== "needLogin" || !token) return;
@@ -144,9 +159,9 @@ export default function InviteAcceptPage() {
     requestURI: "/api/org/invitations",
   };
 
-  if (uiStatus === "invalidToken" || isError) {
+  if (uiStatus === "invalidToken" || uiStatus === "error") {
     const copy = getInviteErrorCopy(
-      uiStatus === "invalidToken" ? invalidTokenError : (error ?? null),
+      uiStatus === "invalidToken" ? invalidTokenError : acceptError,
     );
     return (
       <ErrorLayout
@@ -196,7 +211,9 @@ export default function InviteAcceptPage() {
   return (
     <div className="relative flex h-screen w-full items-center justify-center bg-surface-100">
       <p className="animate-pulse font-body1 text-text-muted">
-        {isSuccess ? "워크스페이스로 이동 중..." : "초대를 확인하는 중..."}
+        {uiStatus === "success"
+          ? "워크스페이스로 이동 중..."
+          : "초대를 확인하는 중..."}
       </p>
     </div>
   );

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -1,0 +1,5 @@
+export default function IniviteAcceptPage() {
+  <>
+    <div>aa</div>
+  </>;
+}

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -17,6 +17,8 @@ import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 type TInviteStatus = "loading" | "success" | "error" | "needLogin";
 
+const LOGIN_REDIRECT_SECONDS = 3;
+
 function getInviteErrorCopy(error: IApiErrorResponse | null): {
   title: string;
   description: string;
@@ -76,6 +78,7 @@ export default function getInviteAcceptPage() {
 
   const [status, setStatus] = useState<TInviteStatus>("loading");
   const [error, setError] = useState<IApiErrorResponse | null>(null);
+  const [countdown, setCountdown] = useState(LOGIN_REDIRECT_SECONDS);
   const processedRef = useRef(false);
 
   useEffect(() => {
@@ -134,12 +137,22 @@ export default function getInviteAcceptPage() {
   useEffect(() => {
     if (status !== "needLogin" || !token) return;
 
+    setCountdown(LOGIN_REDIRECT_SECONDS);
+
+    const interval = window.setInterval(() => {
+      setCountdown((prev) => Math.max(prev - 1, 0));
+    }, 1000);
+
     const timer = window.setTimeout(() => {
       nav(buildPathWithReturnUrl("/login", `/invite/${token}`), {
         replace: true,
       });
-    }, 3500); //약 3.5초로 대기시간설정
-    return () => window.clearTimeout(timer);
+    }, LOGIN_REDIRECT_SECONDS * 1000);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timer);
+    };
   }, [status, token, nav]);
 
   if (status === "error") {
@@ -174,30 +187,24 @@ export default function getInviteAcceptPage() {
 
   if (status === "needLogin") {
     return (
-      <ErrorLayout
-        title="로그인이 필요합니다"
-        description="계정 로그인이 되어 있지 않습니다.\n잠시 후 로그인 페이지로 이동합니다"
-        actions={
-          <Button
-            size="big"
-            variant="primary"
-            fullWidth
-            onClick={() =>
-              nav(buildPathWithReturnUrl("/login", `/invite/${token}`), {
-                replace: true,
-              })
-            }
-          >
-            바로 로그인하기
-          </Button>
-        }
-      />
+      <div className="relative flex h-screen w-full flex-col items-center justify-center gap-5 bg-surface-100">
+        <span
+          className="h-12 w-12 animate-spin rounded-full border-4 border-primary-400 border-t-transparent"
+          aria-hidden
+        />
+        <p className="text-center font-heading3 text-text-title">
+          로그인이 필요합니다
+        </p>
+        <p className="text-center font-body1 text-text-muted">
+          {countdown}초 후 로그인 페이지로 이동합니다
+        </p>
+      </div>
     );
   }
 
   return (
     <div className="relative flex h-screen w-full items-center justify-center bg-surface-100">
-      <p className="animate-pulse font-body2 text-text-muted">
+      <p className="animate-pulse font-body1 text-text-muted">
         {status === "success"
           ? "워크스페이스로 이동 중..."
           : "초대를 확인하는 중..."}

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
+import type { TAcceptInvitationResponse } from "@/types/workspace/workspace";
 
 import { buildPathWithReturnUrl } from "@/utils/auth/returnUrl";
+
+import { useCoreMutation } from "@/hooks/customQuery";
 
 import Button from "@/components/common/button/Button";
 import ErrorLayout from "@/components/common/error/ErrorLayout";
@@ -15,7 +17,7 @@ import { QUERY_KEYS } from "@/lib/queryKeys";
 import useAuthStore from "@/store/useAuthStore";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
-type TInviteStatus = "loading" | "success" | "error" | "needLogin";
+type TInviteUiStatus = "loading" | "needLogin" | "invalidToken";
 
 const LOGIN_REDIRECT_SECONDS = 3;
 
@@ -67,75 +69,54 @@ function getInviteErrorCopy(error: IApiErrorResponse | null): {
   };
 }
 
-export default function getInviteAcceptPage() {
+export default function InviteAcceptPage() {
   const { token } = useParams<{ token: string }>();
   const nav = useNavigate();
-  const queryClient = useQueryClient();
 
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
   const isTokenInitialized = useAuthStore((s) => s.isTokenInitialized);
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
 
-  const [status, setStatus] = useState<TInviteStatus>("loading");
-  const [error, setError] = useState<IApiErrorResponse | null>(null);
+  const [uiStatus, setUiStatus] = useState<TInviteUiStatus>("loading");
   const [countdown, setCountdown] = useState(LOGIN_REDIRECT_SECONDS);
   const processedRef = useRef<string | null>(null);
+
+  const {
+    mutate: acceptInvite,
+    isError,
+    isSuccess,
+    error,
+  } = useCoreMutation(acceptInvitaton, {
+    invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
+    userOnSuccess: async (data: TAcceptInvitationResponse) => {
+      await saveSelectedWorkspace(data.orgId);
+      setSelectedOrgId(data.orgId);
+      toast.success(data.message || "초대를 수락했습니다");
+      nav("/dashboard", { replace: true });
+    },
+  });
 
   useEffect(() => {
     if (!isTokenInitialized) return;
 
     if (!token) {
-      setStatus("error");
-      setError({
-        status: "error",
-        code: "INVALID_TOKEN",
-        message: "유효하지 않은 초대 링크입니다",
-        method: "POST",
-        requestURI: "/api/org/invitations",
-      });
+      setUiStatus("invalidToken");
       return;
     }
+
     if (!isLoggedIn) {
-      setStatus("needLogin");
+      setUiStatus("needLogin");
       return;
     }
+
     if (processedRef.current === token) return;
     processedRef.current = token;
-
-    const accept = async () => {
-      try {
-        const data = await acceptInvitaton(token);
-        await saveSelectedWorkspace(data.orgId);
-        setSelectedOrgId(data.orgId);
-
-        await queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.workspace.list(),
-        });
-        await queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.workspace.saved(),
-        });
-
-        toast.success(data.message || "초대를 수락했습니다");
-        setStatus("success");
-        nav("/dashboard", { replace: true });
-      } catch (err) {
-        const apiError = err as IApiErrorResponse;
-        setError(apiError);
-        setStatus("error");
-      }
-    };
-    void accept();
-  }, [
-    isTokenInitialized,
-    isLoggedIn,
-    token,
-    nav,
-    queryClient,
-    setSelectedOrgId,
-  ]);
+    setUiStatus("loading");
+    acceptInvite(token);
+  }, [isTokenInitialized, isLoggedIn, token, acceptInvite]);
 
   useEffect(() => {
-    if (status !== "needLogin" || !token) return;
+    if (uiStatus !== "needLogin" || !token) return;
 
     setCountdown(LOGIN_REDIRECT_SECONDS);
 
@@ -153,10 +134,20 @@ export default function getInviteAcceptPage() {
       window.clearInterval(interval);
       window.clearTimeout(timer);
     };
-  }, [status, token, nav]);
+  }, [uiStatus, token, nav]);
 
-  if (status === "error") {
-    const copy = getInviteErrorCopy(error);
+  const invalidTokenError: IApiErrorResponse = {
+    status: "error",
+    code: "INVALID_TOKEN",
+    message: "유효하지 않은 초대 링크입니다",
+    method: "POST",
+    requestURI: "/api/org/invitations",
+  };
+
+  if (uiStatus === "invalidToken" || isError) {
+    const copy = getInviteErrorCopy(
+      uiStatus === "invalidToken" ? invalidTokenError : (error ?? null),
+    );
     return (
       <ErrorLayout
         title={copy.title}
@@ -185,7 +176,7 @@ export default function getInviteAcceptPage() {
     );
   }
 
-  if (status === "needLogin") {
+  if (uiStatus === "needLogin") {
     return (
       <div className="relative flex h-screen w-full flex-col items-center justify-center gap-5 bg-surface-100">
         <span
@@ -205,9 +196,7 @@ export default function getInviteAcceptPage() {
   return (
     <div className="relative flex h-screen w-full items-center justify-center bg-surface-100">
       <p className="animate-pulse font-body1 text-text-muted">
-        {status === "success"
-          ? "워크스페이스로 이동 중..."
-          : "초대를 확인하는 중..."}
+        {isSuccess ? "워크스페이스로 이동 중..." : "초대를 확인하는 중..."}
       </p>
     </div>
   );

--- a/src/pages/workspace/InviteAcceptPage.tsx
+++ b/src/pages/workspace/InviteAcceptPage.tsx
@@ -15,7 +15,7 @@ import { QUERY_KEYS } from "@/lib/queryKeys";
 import useAuthStore from "@/store/useAuthStore";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
-type TInviteStatus = "loading" | "success" | "error";
+type TInviteStatus = "loading" | "success" | "error" | "needLogin";
 
 function getInviteErrorCopy(error: IApiErrorResponse | null): {
   title: string;
@@ -32,7 +32,7 @@ function getInviteErrorCopy(error: IApiErrorResponse | null): {
     return {
       title: "초대 링크가 만료 되었습니다",
       description:
-        "초대 링크 유효시간(24시간)이 지났습니다. \n워크스페이스 관리자에게 다시 초대를 요청해 주세요",
+        "초대 링크 유효시간(24시간)이 지났습니다.\n워크스페이스 관리자에게 다시 초대를 요청해 주세요",
     };
   }
   if (
@@ -51,7 +51,7 @@ function getInviteErrorCopy(error: IApiErrorResponse | null): {
     message.toLowerCase().includes("email")
   ) {
     return {
-      title: "초대 이메일이 일치하지 않습니다",
+      title: "초대 이메일이\n일치하지 않습니다",
       description:
         "초대받은 이메일 계정으로 로그인한 뒤\n다시 링크를 열어주세요",
     };
@@ -61,7 +61,7 @@ function getInviteErrorCopy(error: IApiErrorResponse | null): {
     title: "초대를 수락할 수 없습니다",
     description:
       message ||
-      "초대 처리 중 오류가 발생했습니다. \n잠시 후 다시 시도해 주세요",
+      "초대 처리 중 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요",
   };
 }
 
@@ -93,9 +93,8 @@ export default function getInviteAcceptPage() {
       return;
     }
     if (!isLoggedIn) {
-      nav(buildPathWithReturnUrl("/login", `/invite/${token}`), {
-        replace: true,
-      });
+      setStatus("needLogin");
+      return;
     }
     if (processedRef.current) return;
     processedRef.current = true;
@@ -132,6 +131,17 @@ export default function getInviteAcceptPage() {
     setSelectedOrgId,
   ]);
 
+  useEffect(() => {
+    if (status !== "needLogin" || !token) return;
+
+    const timer = window.setTimeout(() => {
+      nav(buildPathWithReturnUrl("/login", `/invite/${token}`), {
+        replace: true,
+      });
+    }, 3500); //약 3.5초로 대기시간설정
+    return () => window.clearTimeout(timer);
+  }, [status, token, nav]);
+
   if (status === "error") {
     const copy = getInviteErrorCopy(error);
     return (
@@ -157,6 +167,29 @@ export default function getInviteAcceptPage() {
               홈으로 이동
             </Button>
           </>
+        }
+      />
+    );
+  }
+
+  if (status === "needLogin") {
+    return (
+      <ErrorLayout
+        title="로그인이 필요합니다"
+        description="계정 로그인이 되어 있지 않습니다.\n잠시 후 로그인 페이지로 이동합니다"
+        actions={
+          <Button
+            size="big"
+            variant="primary"
+            fullWidth
+            onClick={() =>
+              nav(buildPathWithReturnUrl("/login", `/invite/${token}`), {
+                replace: true,
+              })
+            }
+          >
+            바로 로그인하기
+          </Button>
         }
       />
     );

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -29,6 +29,11 @@ const RedirectPage = loadable(
 
 const Signup = lazy(() => import("@/pages/auth/Signup"));
 
+const InviteAcceptPage = loadable(
+  lazy(() => import("@/pages/workspace/InviteAcceptPage")),
+  <AuthFormSkeleton />,
+);
+
 function SignupPage() {
   const location = useLocation();
   const step = location.state?.step;
@@ -68,6 +73,10 @@ const AuthRoutes: RouteObject[] = [
   {
     path: "oauth2/meta/result",
     element: <MetaOAuthResultPage />,
+  },
+  {
+    path: "invite/:token",
+    element: <InviteAcceptPage />,
   },
 ];
 

--- a/src/types/workspace/workspace.ts
+++ b/src/types/workspace/workspace.ts
@@ -124,3 +124,9 @@ export type TPendingMemberData = {
 export type TPendingMemberResponse = {
   pendingMembers: TPendingMemberData[];
 };
+
+export type TAcceptInvitationResponse = {
+  orgId: number;
+  message: string;
+  email: string;
+};


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #368 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

메일 링크 `/invite/{token}` 진입 시 초대 수락하는 페이지 연동했습니다.

- 초대 수락 페이지 UI
  - 로딩: 초대 확인 / 워크스페이스로 이동
  - 로그인됨: 수락 API호출 → `orgId` 기준으로 현재워크스페이스 저장 →`/dashboard`로 이동
  - 미로그인: 스패너 + 초 수 카운트다운후(3초) `login?returnUrl=/invite/{token}`으로 이동
  - 에러: 만료 / 이미 수락 / 이메일 불일치 등 `ErrorLayout` 안내

## 💻 작업 화면
<img width="1861" height="880" alt="image" src="https://github.com/user-attachments/assets/2b42cf83-6ea2-410d-ad47-628c2ff790ee" />
<img width="1836" height="880" alt="image" src="https://github.com/user-attachments/assets/5c94b452-46da-48bb-931c-a0aab744a629" />
<img width="1857" height="878" alt="image" src="https://github.com/user-attachments/assets/853a6c6e-b590-4945-bc53-7c659bb1af80" />
<img width="1887" height="882" alt="image" src="https://github.com/user-attachments/assets/865b3796-e0c8-418e-8ab4-f95a9b15d59d" />

## 😅 미완성 작업

- 회원가입 완료 후 로그인 페이지 미이동 이슈는 다음 후속이슈로 처리 예정입니다 (초대링크테스트도중 확인한 버그. 현재 브랜치와는 내용이 맞지 않아 따로 브랜치파서 진행예정)


## 📢 논의 사항 및 참고 사항

- 현재 로컬 메일 링크 origin이 `localhost:3000`으로 오고 있어서, 프론트에서 test진행할때는 직접 포트 5173으로 바꿔서 진행하면 잘 작동됩니다! 백엔드에게는 배포환경인 whereyouad.com으로 변경요청드린상태입니다 (8/2 02:30 기준- 아직 답변전) → **(8/3 10:50 기준 배포환경으로 세팅완료)**

- 초대 링크/멤버 테스트 과정중에 멤버삭제에서 서버500에러가 발생하고 있어서 백엔드에 확인요청해둔상황입니다 (8/2 02:30 기준- 아직 답변전) -> **(8/3 10:50 기준 버그 수정 완료)**

- 최대한 많은 에러상황을 테스트중입니다만, 아직 멤버 삭제가 진행되지않아 계정개수한계로 많은 테스트는 하지못했습니다! 멤버분들께서 test중 다른 에러가 발견되면 알려주시면 감사하겠습니다! 바로 수정진행하겠습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새 기능**
  * 초대 링크를 통해 워크스페이스 초대를 수락할 수 있습니다.
  * 초대 토큰을 확인하고 수락한 뒤 해당 워크스페이스로 이동합니다.
  * 로그인하지 않은 경우 로그인 후 초대 페이지로 돌아갈 수 있습니다.
  * 초대 토큰 누락 및 수락 실패 상황에 맞는 안내와 이동 버튼을 제공합니다.

* **버그 수정**
  * 오류 메시지의 실제 줄바꿈과 `\n` 형식이 올바르게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->