### PR TITLE
[Feature/#373] 최초 로그인 온보딩 투어 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.2.0",
     "react-error-boundary": "^6.1.2",
     "react-hook-form": "^7.71.1",
+    "react-joyride": "^3.2.0",
     "react-markdown": "^10.1.0",
     "react-remove-scroll": "^2.7.2",
     "react-router-dom": "^7.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.1
         version: 7.71.1(react@19.2.4)
+      react-joyride:
+        specifier: ^3.2.0
+        version: 3.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
@@ -73,7 +76,7 @@ importers:
         version: 4.3.6
       zustand:
         specifier: ^5.0.10
-        version: 5.0.11(@types/react@19.2.14)(react@19.2.4)
+        version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.3.1
@@ -532,6 +535,24 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
 
@@ -546,6 +567,17 @@ packages:
 
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
+
+  '@gilbarbara/deep-equal@0.4.1':
+    resolution: {integrity: sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==}
+
+  '@gilbarbara/hooks@0.11.0':
+    resolution: {integrity: sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==}
+    peerDependencies:
+      react: 16.8 - 19
+
+  '@gilbarbara/types@0.2.2':
+    resolution: {integrity: sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -2799,6 +2831,9 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-lite@2.0.0:
+    resolution: {integrity: sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -3668,11 +3703,23 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-innertext@1.1.5:
+    resolution: {integrity: sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==}
+    peerDependencies:
+      '@types/react': '>=0.0.0 <=99'
+      react: '>=0.0.0 <=99'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-joyride@3.2.0:
+    resolution: {integrity: sha512-UrA/XWdWElMLNnjZt2eWmPFmpHl1IZ2CeI9XhS+PuEVvfqHMD9U4tavCq1csDAGVoj0YEGfaCDmhZwgNc9yE2g==}
+    peerDependencies:
+      react: 16.8 - 19
+      react-dom: 16.8 - 19
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -3840,6 +3887,12 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  scroll@3.0.1:
+    resolution: {integrity: sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==}
+
+  scrollparent@2.1.0:
+    resolution: {integrity: sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -4224,6 +4277,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -4327,6 +4384,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -4963,6 +5025,25 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fastify/deepmerge@3.2.1': {}
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.12': {}
+
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -4988,6 +5069,17 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.2':
     dependencies:
       tslib: 2.8.1
+
+  '@gilbarbara/deep-equal@0.4.1': {}
+
+  '@gilbarbara/hooks@0.11.0(react@19.2.4)':
+    dependencies:
+      '@gilbarbara/deep-equal': 0.4.1
+      react: 19.2.4
+
+  '@gilbarbara/types@0.2.2':
+    dependencies:
+      type-fest: 4.41.0
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.4))':
     dependencies:
@@ -7503,6 +7595,8 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-lite@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -8503,9 +8597,31 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  react-innertext@1.1.5(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-joyride@3.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@fastify/deepmerge': 3.2.1
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@gilbarbara/deep-equal': 0.4.1
+      '@gilbarbara/hooks': 0.11.0(react@19.2.4)
+      '@gilbarbara/types': 0.2.2
+      is-lite: 2.0.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-innertext: 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      scroll: 3.0.1
+      scrollparent: 2.1.0
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -8726,6 +8842,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
+
+  scroll@3.0.1: {}
+
+  scrollparent@2.1.0: {}
 
   semver@5.7.2: {}
 
@@ -9172,6 +9292,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -9306,6 +9428,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util@0.12.5:
     dependencies:
@@ -9553,9 +9679,10 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4):
+  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   zwitch@2.0.4: {}

--- a/src/components/common/OnboardingTooltip.tsx
+++ b/src/components/common/OnboardingTooltip.tsx
@@ -1,0 +1,57 @@
+import type { TooltipRenderProps } from "react-joyride";
+
+import Button from "@/components/common/button/Button";
+
+export default function OnboardingTooltip({
+  continuous,
+  index,
+  size,
+  step,
+  isLastStep,
+  backProps,
+  primaryProps,
+  skipProps,
+  tooltipProps,
+}: TooltipRenderProps) {
+  return (
+    <div
+      {...tooltipProps}
+      className="bg-surface-100 rounded-3xl shadow-Soft p-6 w-80 flex flex-col gap-5"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <p className="font-body2 text-text-body leading-relaxed flex-1">
+          {step.content}
+        </p>
+        <span className="font-caption text-text-muted shrink-0 pt-0.5">
+          {index + 1} / {size}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between pt-1 border-t border-surface-300">
+        {!isLastStep ? (
+          <button
+            {...skipProps}
+            className="font-body2 text-text-muted hover:text-text-body transition-colors duration-150"
+          >
+            건너뛰기
+          </button>
+        ) : (
+          <span />
+        )}
+
+        <div className="flex items-center gap-2">
+          {index > 0 && (
+            <Button {...backProps} size="small" variant="outline">
+              이전
+            </Button>
+          )}
+          {continuous && (
+            <Button {...primaryProps} size="small" variant="primary">
+              {isLastStep ? "완료" : "다음"}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/OnboardingTooltip.tsx
+++ b/src/components/common/OnboardingTooltip.tsx
@@ -16,44 +16,49 @@ export default function OnboardingTooltip({
   return (
     <div
       {...tooltipProps}
-      className="animate-tooltip-enter bg-surface-100 rounded-3xl shadow-tooltip p-6 w-84 flex flex-col gap-4"
+      className="bg-surface-100 rounded-3xl shadow-tooltip w-84 overflow-hidden"
     >
-      <div className="flex items-start justify-between gap-4">
-        {step.title && (
-          <h3 className="font-heading4 text-text-title">{step.title}</h3>
-        )}
-        <span className="font-caption text-text-muted shrink-0 pt-1">
-          {index + 1} / {size}
-        </span>
-      </div>
-
-      <p className="font-body2 text-text-body leading-relaxed break-keep">
-        {step.content}
-      </p>
-
-      <div className="flex items-center justify-between pt-3 border-t border-surface-300">
-        {!isLastStep ? (
-          <button
-            {...skipProps}
-            className="font-body2 text-text-muted hover:text-text-body transition-colors duration-150"
-          >
-            건너뛰기
-          </button>
-        ) : (
-          <span />
-        )}
-
-        <div className="flex items-center gap-2">
-          {index > 0 && (
-            <Button {...backProps} size="small" variant="outline">
-              이전
-            </Button>
+      <div
+        key={index}
+        className="animate-tooltip-enter flex flex-col gap-4 p-6"
+      >
+        <div className="flex items-start justify-between gap-4">
+          {step.title && (
+            <h3 className="font-heading4 text-text-title">{step.title}</h3>
           )}
-          {continuous && (
-            <Button {...primaryProps} size="small" variant="primary">
-              {isLastStep ? "완료" : "다음"}
-            </Button>
+          <span className="font-caption text-text-muted shrink-0 pt-1">
+            {index + 1} / {size}
+          </span>
+        </div>
+
+        <p className="font-body2 text-text-body leading-relaxed break-keep">
+          {step.content}
+        </p>
+
+        <div className="flex items-center justify-between pt-3 border-t border-surface-300">
+          {!isLastStep ? (
+            <button
+              {...skipProps}
+              className="font-body2 text-text-muted hover:text-text-body transition-colors duration-150"
+            >
+              건너뛰기
+            </button>
+          ) : (
+            <span />
           )}
+
+          <div className="flex items-center gap-2">
+            {index > 0 && (
+              <Button {...backProps} size="small" variant="outline">
+                이전
+              </Button>
+            )}
+            {continuous && (
+              <Button {...primaryProps} size="small" variant="primary">
+                {isLastStep ? "완료" : "다음"}
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/common/OnboardingTooltip.tsx
+++ b/src/components/common/OnboardingTooltip.tsx
@@ -16,7 +16,7 @@ export default function OnboardingTooltip({
   return (
     <div
       {...tooltipProps}
-      className="bg-surface-100 rounded-3xl shadow-Soft p-6 w-84 flex flex-col gap-4"
+      className="animate-tooltip-enter bg-surface-100 rounded-3xl shadow-Soft p-6 w-84 flex flex-col gap-4"
     >
       <div className="flex items-start justify-between gap-4">
         {step.title && (
@@ -27,7 +27,7 @@ export default function OnboardingTooltip({
         </span>
       </div>
 
-      <p className="font-body2 text-text-body leading-relaxed">
+      <p className="font-body2 text-text-body leading-relaxed break-keep">
         {step.content}
       </p>
 

--- a/src/components/common/OnboardingTooltip.tsx
+++ b/src/components/common/OnboardingTooltip.tsx
@@ -16,18 +16,22 @@ export default function OnboardingTooltip({
   return (
     <div
       {...tooltipProps}
-      className="bg-surface-100 rounded-3xl shadow-Soft p-6 w-80 flex flex-col gap-5"
+      className="bg-surface-100 rounded-3xl shadow-Soft p-6 w-84 flex flex-col gap-4"
     >
       <div className="flex items-start justify-between gap-4">
-        <p className="font-body2 text-text-body leading-relaxed flex-1">
-          {step.content}
-        </p>
-        <span className="font-caption text-text-muted shrink-0 pt-0.5">
+        {step.title && (
+          <h3 className="font-heading4 text-text-title">{step.title}</h3>
+        )}
+        <span className="font-caption text-text-muted shrink-0 pt-1">
           {index + 1} / {size}
         </span>
       </div>
 
-      <div className="flex items-center justify-between pt-1 border-t border-surface-300">
+      <p className="font-body2 text-text-body leading-relaxed">
+        {step.content}
+      </p>
+
+      <div className="flex items-center justify-between pt-3 border-t border-surface-300">
         {!isLastStep ? (
           <button
             {...skipProps}

--- a/src/components/common/OnboardingTooltip.tsx
+++ b/src/components/common/OnboardingTooltip.tsx
@@ -16,7 +16,7 @@ export default function OnboardingTooltip({
   return (
     <div
       {...tooltipProps}
-      className="animate-tooltip-enter bg-surface-100 rounded-3xl shadow-Soft p-6 w-84 flex flex-col gap-4"
+      className="animate-tooltip-enter bg-surface-100 rounded-3xl shadow-tooltip p-6 w-84 flex flex-col gap-4"
     >
       <div className="flex items-start justify-between gap-4">
         {step.title && (

--- a/src/components/common/OnboardingTooltip.tsx
+++ b/src/components/common/OnboardingTooltip.tsx
@@ -24,18 +24,20 @@ export default function OnboardingTooltip({
       >
         <div className="flex items-start justify-between gap-4">
           {step.title && (
-            <h3 className="font-heading4 text-text-title">{step.title}</h3>
+            <h3 className="font-heading4 text-text-title whitespace-pre-line">
+              {step.title}
+            </h3>
           )}
           <span className="font-caption text-text-muted shrink-0 pt-1">
             {index + 1} / {size}
           </span>
         </div>
 
-        <p className="font-body2 text-text-body leading-relaxed break-keep">
+        <p className="font-body2 text-text-body leading-relaxed break-keep whitespace-pre-line">
           {step.content}
         </p>
 
-        <div className="flex items-center justify-between pt-3 border-t border-surface-300">
+        <div className="flex items-center justify-between pt-3 ">
           {!isLastStep ? (
             <button
               {...skipProps}

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import Joyride from "react-joyride";
+
+import { useOnboardingTour } from "@/hooks/common/useOnboardingTour";
+
+interface IOnboardingTourProps {
+  autoStart?: boolean;
+}
+
+export default function OnboardingTour({
+  autoStart = false,
+}: IOnboardingTourProps) {
+  const { run, startTour, handleEvent, steps } = useOnboardingTour();
+
+  useEffect(() => {
+    if (autoStart) startTour();
+  }, [autoStart, startTour]);
+
+  return (
+    <Joyride
+      steps={steps}
+      run={run}
+      onEvent={handleEvent}
+      continuous
+      scrollToFirstStep
+      locale={{
+        back: "이전",
+        close: "닫기",
+        last: "완료",
+        next: "다음",
+        skip: "건너뛰기",
+      }}
+      options={{
+        primaryColor: "#2f5bea",
+        zIndex: 1000,
+        showProgress: true,
+        buttons: ["back", "close", "primary", "skip"],
+      }}
+    />
+  );
+}

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -3,6 +3,8 @@ import { Joyride } from "react-joyride";
 
 import { useOnboardingTour } from "@/hooks/common/useOnboardingTour";
 
+import OnboardingTooltip from "@/components/common/OnboardingTooltip";
+
 interface IOnboardingTourProps {
   autoStart?: boolean;
 }
@@ -23,18 +25,10 @@ export default function OnboardingTour({
       onEvent={handleEvent}
       continuous
       scrollToFirstStep
-      locale={{
-        back: "이전",
-        close: "닫기",
-        last: "완료",
-        next: "다음",
-        skip: "건너뛰기",
-      }}
+      tooltipComponent={OnboardingTooltip}
       options={{
-        primaryColor: "#2f5bea",
+        overlayColor: "rgba(17, 24, 39, 0.5)",
         zIndex: 1000,
-        showProgress: true,
-        buttons: ["back", "close", "primary", "skip"],
       }}
     />
   );

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -24,6 +24,10 @@ export default function OnboardingTour({
       navigate("/workspace", { replace: true });
       return;
     }
+    if (myRole === "MEMBER" && pathname !== "/dashboard") {
+      navigate("/dashboard", { replace: true });
+      return;
+    }
     tourStarted.current = true;
     startTour();
   }, [autoStart, myRole, pathname, navigate, startTour]);

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Joyride } from "react-joyride";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { useOnboardingTour } from "@/hooks/common/useOnboardingTour";
 
@@ -12,11 +13,20 @@ interface IOnboardingTourProps {
 export default function OnboardingTour({
   autoStart = false,
 }: IOnboardingTourProps) {
-  const { run, startTour, handleEvent, steps } = useOnboardingTour();
+  const { run, startTour, handleEvent, steps, myRole } = useOnboardingTour();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const tourStarted = useRef(false);
 
   useEffect(() => {
-    if (autoStart) startTour();
-  }, [autoStart, startTour]);
+    if (!autoStart || tourStarted.current) return;
+    if (myRole === "ADMIN" && pathname !== "/workspace") {
+      navigate("/workspace", { replace: true });
+      return;
+    }
+    tourStarted.current = true;
+    startTour();
+  }, [autoStart, myRole, pathname, navigate, startTour]);
 
   return (
     <Joyride

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -27,7 +27,7 @@ export default function OnboardingTour({
       scrollToFirstStep
       tooltipComponent={OnboardingTooltip}
       options={{
-        overlayColor: "rgba(17, 24, 39, 0.5)",
+        overlayColor: "rgba(0, 0, 0, 0.5)",
         zIndex: 1000,
       }}
     />

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -20,7 +20,7 @@ export default function OnboardingTour({
 
   useEffect(() => {
     if (!autoStart || tourStarted.current) return;
-    if (myRole === "ADMIN" && pathname !== "/workspace") {
+    if ((myRole === "ADMIN" || myRole === null) && pathname !== "/workspace") {
       navigate("/workspace", { replace: true });
       return;
     }

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -26,6 +26,12 @@ export default function OnboardingTour({
       continuous
       scrollToFirstStep
       tooltipComponent={OnboardingTooltip}
+      styles={{
+        spotlight: {
+          style: { transition: "d 280ms cubic-bezier(0.4, 0, 0.2, 1)" },
+        },
+        overlay: { transition: "opacity 200ms ease-out" },
+      }}
       options={{
         overlayColor: "rgba(0, 0, 0, 0.5)",
         zIndex: 1000,

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import Joyride from "react-joyride";
+import { Joyride } from "react-joyride";
 
 import { useOnboardingTour } from "@/hooks/common/useOnboardingTour";
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -200,14 +200,16 @@ export default function Sidebar() {
               <div
                 key={item.id}
                 className="relative flex flex-col"
-                data-tour={`tour-${item.id}`}
                 {...collapsedSubmenuInteractionProps(
                   isCollapsed && !!item.children?.length,
                   item.id,
                   setOpenId,
                 )}
               >
-                <div className={getMainItemClass(isParentActive, isCollapsed)}>
+                <div
+                  className={getMainItemClass(isParentActive, isCollapsed)}
+                  data-tour={`tour-${item.id}`}
+                >
                   <SidebarItem
                     item={item}
                     isCollapsed={isCollapsed}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -52,7 +52,7 @@ function getMainItemClass(isActive: boolean, isCollapsed: boolean) {
     "flex cursor-pointer items-center rounded-2xl px-3 font-body2 transition-colors duration-200",
     isCollapsed
       ? "h-[55px] w-[55px] mx-auto flex justify-center"
-      : "h-[55px] gap-4 px-3",
+      : "h-[55px] w-full gap-4 px-3",
     isActive
       ? "bg-primary-400 text-surface-100"
       : "text-text-auth-sub hover:bg-surface-200",

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -171,7 +171,7 @@ export default function Sidebar() {
       transition={{ type: "spring", stiffness: 320, damping: 34 }}
     >
       <div className="mx-auto mt-5 flex w-full max-w-58 flex-1 flex-col min-h-0">
-        <div className="px-2">
+        <div className="px-2" data-tour="tour-workspace-switcher">
           <WorkspaceSwitcher isCollapsed={isCollapsed} />
         </div>
 
@@ -200,6 +200,7 @@ export default function Sidebar() {
               <div
                 key={item.id}
                 className="relative flex flex-col"
+                data-tour={`tour-${item.id}`}
                 {...collapsedSubmenuInteractionProps(
                   isCollapsed && !!item.children?.length,
                   item.id,
@@ -266,6 +267,7 @@ export default function Sidebar() {
               <div
                 key={item.id}
                 className={getFooterItemClass(isActive, isCollapsed)}
+                data-tour={`tour-${item.id}`}
               >
                 <SidebarItem
                   item={item}

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -132,7 +132,12 @@ export function useOnboardingTour() {
     }
   }, []);
 
-  const steps = myRole === "MEMBER" ? MEMBER_STEPS : ADMIN_STEPS;
+  const steps =
+    myRole === "MEMBER"
+      ? MEMBER_STEPS
+      : myRole === "ADMIN"
+        ? ADMIN_STEPS
+        : ADMIN_STEPS;
 
   return { run, startTour, handleEvent, steps, myRole };
 }

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -38,7 +38,7 @@ const TOUR_STEPS: Step[] = [
   },
   {
     target: "[data-tour='tour-workspace']",
-    title: "워크스페이스 설정",
+    title: "워크스페이스 관리",
     content:
       "멤버 초대, 역할 관리, 플랜과 결제를 여기서 모두 처리할 수 있어요.",
     placement: "right",

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react";
+import type { EventData, Step } from "react-joyride";
+import { EVENTS, STATUS } from "react-joyride";
+
+const ONBOARDING_KEY = "hasSeenOnboarding";
+
+const TOUR_STEPS: Step[] = [
+  {
+    target: "body",
+    content:
+      "WhereYouAd의 주요 기능을 간단히 소개할게요. Google, Naver, Meta 광고 성과를 한눈에 관리할 수 있어요.",
+    placement: "center",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-workspace-switcher']",
+    content:
+      "팀 단위로 광고 데이터를 관리하는 공간이에요. 멤버를 초대하고 역할을 나눌 수 있어요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-dashboard']",
+    content:
+      "연동 완료 후 여기서 Google·Naver·Meta 통합 성과를 한눈에 볼 수 있어요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-ads']",
+    content: "캠페인 목록을 조회하고 광고 상태를 관리할 수 있어요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-workspace']",
+    content: "워크스페이스 설정, 멤버 관리, 플랜 및 결제를 여기서 관리해요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-integrations']",
+    content:
+      "지금 여기예요. 광고 계정을 연동해야 대시보드에 데이터가 표시돼요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-platform-google']",
+    content:
+      "Google Ads 계정을 연동하면 검색·디스플레이 광고 성과를 볼 수 있어요.",
+    placement: "bottom",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-platform-naver']",
+    content: "Naver 광고 계정을 연동하면 검색 광고 성과를 확인할 수 있어요.",
+    placement: "bottom",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-platform-meta']",
+    content:
+      "Meta 광고 계정을 연동하면 Facebook·Instagram 광고 성과를 볼 수 있어요.",
+    placement: "bottom",
+    skipBeacon: true,
+  },
+];
+
+export function useOnboardingTour() {
+  const [run, setRun] = useState(false);
+
+  const startTour = useCallback(() => {
+    setRun(true);
+  }, []);
+
+  const handleEvent = useCallback((data: EventData) => {
+    const { status, type } = data;
+
+    const isFinished = status === STATUS.FINISHED || status === STATUS.SKIPPED;
+    const isError = type === EVENTS.TARGET_NOT_FOUND;
+
+    if (isFinished || isError) {
+      setRun(false);
+      localStorage.setItem(ONBOARDING_KEY, "true");
+    }
+  }, []);
+
+  return { run, startTour, handleEvent, steps: TOUR_STEPS };
+}

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -2,9 +2,11 @@ import { useCallback, useState } from "react";
 import type { EventData, Step } from "react-joyride";
 import { EVENTS, STATUS } from "react-joyride";
 
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
 const ONBOARDING_KEY = "hasSeenOnboarding";
 
-const TOUR_STEPS: Step[] = [
+const ADMIN_STEPS: Step[] = [
   {
     target: "body",
     title: "WhereYouAd에 오신 걸 환영해요",
@@ -83,7 +85,55 @@ const TOUR_STEPS: Step[] = [
   },
 ];
 
+const MEMBER_STEPS: Step[] = [
+  {
+    target: "body",
+    title: "WhereYouAd에 오신 걸 환영해요",
+    content:
+      "Google, Naver, Meta 광고 성과를 한 곳에서 관리하는 방법을 안내해 드릴게요.",
+    placement: "center",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-workspace-switcher']",
+    title: "워크스페이스",
+    content: "팀원들과 광고 데이터를 함께 확인하는 공간이에요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-dashboard']",
+    title: "통합·플랫폼 대시보드",
+    content:
+      "Google, Naver, Meta 성과를 한 화면에서 확인하고 AI 분석 리포트도 받아볼 수 있어요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-ads']",
+    title: "캠페인 관리",
+    content: "운영 중인 캠페인 목록을 조회하고 상태를 한눈에 파악할 수 있어요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "[data-tour='tour-workspace']",
+    title: "워크스페이스",
+    content: "팀원 목록과 기본 정보를 여기서 확인할 수 있어요.",
+    placement: "right",
+    skipBeacon: true,
+  },
+  {
+    target: "body",
+    title: "이제 시작할 준비가 됐어요!",
+    content: "대시보드에서 광고 성과를 바로 확인해보세요.",
+    placement: "center",
+    skipBeacon: true,
+  },
+];
+
 export function useOnboardingTour() {
+  const myRole = useWorkspaceStore((s) => s.myRole);
   const [run, setRun] = useState(false);
 
   const startTour = useCallback(() => {
@@ -102,5 +152,7 @@ export function useOnboardingTour() {
     }
   }, []);
 
-  return { run, startTour, handleEvent, steps: TOUR_STEPS };
+  const steps = myRole === "MEMBER" ? MEMBER_STEPS : ADMIN_STEPS;
+
+  return { run, startTour, handleEvent, steps };
 }

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { EventData, Step } from "react-joyride";
-import { EVENTS, STATUS } from "react-joyride";
+import { STATUS } from "react-joyride";
 
 const ONBOARDING_KEY = "hasSeenOnboarding";
 
@@ -91,12 +91,11 @@ export function useOnboardingTour() {
   }, []);
 
   const handleEvent = useCallback((data: EventData) => {
-    const { status, type } = data;
+    const { status } = data;
 
     const isFinished = status === STATUS.FINISHED || status === STATUS.SKIPPED;
-    const isError = type === EVENTS.TARGET_NOT_FOUND;
 
-    if (isFinished || isError) {
+    if (isFinished) {
       setRun(false);
       localStorage.setItem(ONBOARDING_KEY, "true");
     }

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -7,13 +7,15 @@ const ONBOARDING_KEY = "hasSeenOnboarding";
 const TOUR_STEPS: Step[] = [
   {
     target: "body",
+    title: "WhereYouAd에 오신 걸 환영해요",
     content:
-      "WhereYouAd의 주요 기능을 간단히 소개할게요. Google, Naver, Meta 광고 성과를 한눈에 관리할 수 있어요.",
+      "주요 기능을 간단히 소개할게요. Google, Naver, Meta 광고 성과를 한눈에 관리할 수 있어요.",
     placement: "center",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-workspace-switcher']",
+    title: "워크스페이스",
     content:
       "팀 단위로 광고 데이터를 관리하는 공간이에요. 멤버를 초대하고 역할을 나눌 수 있어요.",
     placement: "right",
@@ -21,48 +23,62 @@ const TOUR_STEPS: Step[] = [
   },
   {
     target: "[data-tour='tour-dashboard']",
+    title: "통합 대시보드",
     content:
-      "연동 완료 후 여기서 Google·Naver·Meta 통합 성과를 한눈에 볼 수 있어요.",
+      "Google·Naver·Meta 성과를 한 화면에서 확인하고 AI 분석 리포트를 받아볼 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-ads']",
-    content: "캠페인 목록을 조회하고 광고 상태를 관리할 수 있어요.",
+    title: "캠페인 관리",
+    content: "운영 중인 캠페인 목록을 조회하고 상태를 한눈에 파악할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-workspace']",
-    content: "워크스페이스 설정, 멤버 관리, 플랜 및 결제를 여기서 관리해요.",
+    title: "워크스페이스 설정",
+    content:
+      "멤버 초대, 역할 관리, 플랜 및 결제를 여기서 모두 처리할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-integrations']",
+    title: "플랫폼 연동",
     content:
-      "지금 여기예요. 광고 계정을 연동해야 대시보드에 데이터가 표시돼요.",
+      "지금 바로 시작해요. 광고 계정을 연동해야 대시보드에 데이터가 표시돼요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-platform-google']",
-    content:
-      "Google Ads 계정을 연동하면 검색·디스플레이 광고 성과를 볼 수 있어요.",
+    title: "Google Ads 연동",
+    content: "검색·디스플레이·쇼핑 광고 성과를 실시간으로 확인할 수 있어요.",
     placement: "bottom",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-platform-naver']",
-    content: "Naver 광고 계정을 연동하면 검색 광고 성과를 확인할 수 있어요.",
+    title: "Naver 광고 연동",
+    content: "네이버 검색 광고 성과를 대시보드에서 바로 볼 수 있어요.",
     placement: "bottom",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-platform-meta']",
-    content:
-      "Meta 광고 계정을 연동하면 Facebook·Instagram 광고 성과를 볼 수 있어요.",
+    title: "Meta 광고 연동",
+    content: "Facebook·Instagram 광고 성과를 통합해서 분석할 수 있어요.",
     placement: "bottom",
+    skipBeacon: true,
+  },
+  {
+    target: "body",
+    title: "이제 시작할 준비가 됐어요!",
+    content:
+      "광고 계정을 연동하면 모든 성과 데이터를 한눈에 확인할 수 있어요. 지금 바로 연동해보세요.",
+    placement: "center",
     skipBeacon: true,
   },
 ];

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -11,15 +11,14 @@ const ADMIN_STEPS: Step[] = [
     target: "body",
     title: "WhereYouAd에 오신 걸 환영해요",
     content:
-      "Google, Naver, Meta 광고 성과를 한 곳에서 관리하는 방법을 안내해 드릴게요.",
+      "Google, Naver, Meta 광고 성과를\n한 곳에서 관리하는 방법을 안내해 드릴게요.",
     placement: "center",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-workspace-switcher']",
     title: "워크스페이스",
-    content:
-      "팀 단위로 광고 데이터를 관리하는 공간이에요. 멤버를 초대하고 역할을 나눌 수 있어요.",
+    content: "여러 워크스페이스를 만들고 자유롭게 전환할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
@@ -34,14 +33,15 @@ const ADMIN_STEPS: Step[] = [
   {
     target: "[data-tour='tour-ads']",
     title: "캠페인 관리",
-    content: "운영 중인 캠페인 목록을 조회하고 상태를 한눈에 파악할 수 있어요.",
+    content:
+      "운영 중인 캠페인 목록을 조회하고\n상태를 한눈에 파악할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-workspace']",
     title: "워크스페이스 관리",
-    content: "멤버 초대, 역할 관리를 여기서 모두 처리할 수 있어요.",
+    content: "멤버 초대·역할 관리를 모두 여기서\n처리할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
@@ -49,39 +49,18 @@ const ADMIN_STEPS: Step[] = [
     target: "[data-tour='tour-integrations']",
     title: "플랫폼 연동",
     content:
-      "광고 계정을 연동해야 대시보드에 데이터가 표시돼요. 지금 바로 시작해볼게요.",
+      "광고 계정을 연동하면 대시보드에서\n성과 데이터를 바로 확인할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
   {
-    target: "[data-tour='tour-platform-meta']",
-    title: "Meta 광고 연동",
-    content: "Facebook과 Instagram 광고 성과를 통합해서 분석할 수 있어요.",
-    placement: "bottom",
-    skipBeacon: true,
-  },
-  {
-    target: "[data-tour='tour-platform-google']",
-    title: "Google Ads 연동",
-    content: "검색, 디스플레이, 쇼핑 광고 성과를 실시간으로 확인할 수 있어요.",
-    placement: "bottom",
-    skipBeacon: true,
-  },
-  {
-    target: "[data-tour='tour-platform-naver']",
-    title: "Naver 광고 연동",
-    content: "네이버 검색 광고 성과를 대시보드에서 바로 확인할 수 있어요.",
-    placement: "bottom",
-    skipBeacon: true,
-    floatingOptions: { flipOptions: false },
-  },
-  {
-    target: "body",
-    title: "이제 시작할 준비가 됐어요!",
+    target: "[data-tour='tour-create-workspace']",
+    title: "워크스페이스를 만들고\n시작해볼까요?",
     content:
-      "지금 광고 계정을 연동하고 모든 성과 데이터를 한눈에 확인해보세요.",
-    placement: "center",
+      "워크스페이스를 생성하면 멤버를 초대하고\n광고 계정을 연동할 수 있어요.",
+    placement: "bottom",
     skipBeacon: true,
+    skipScroll: true,
   },
 ];
 
@@ -90,7 +69,7 @@ const MEMBER_STEPS: Step[] = [
     target: "body",
     title: "WhereYouAd에 오신 걸 환영해요",
     content:
-      "Google, Naver, Meta 광고 성과를 한 곳에서 관리하는 방법을 안내해 드릴게요.",
+      "Google, Naver, Meta 광고 성과를\n한 곳에서 관리하는 방법을 안내해 드릴게요.",
     placement: "center",
     skipBeacon: true,
   },
@@ -112,13 +91,14 @@ const MEMBER_STEPS: Step[] = [
   {
     target: "[data-tour='tour-ads']",
     title: "캠페인 관리",
-    content: "운영 중인 캠페인 목록을 조회하고 상태를 한눈에 파악할 수 있어요.",
+    content:
+      "운영 중인 캠페인 목록을 조회하고\n상태를 한눈에 파악할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-workspace']",
-    title: "워크스페이스",
+    title: "워크스페이스 설정",
     content: "팀원 목록과 기본 정보를 여기서 확인할 수 있어요.",
     placement: "right",
     skipBeacon: true,
@@ -154,5 +134,5 @@ export function useOnboardingTour() {
 
   const steps = myRole === "MEMBER" ? MEMBER_STEPS : ADMIN_STEPS;
 
-  return { run, startTour, handleEvent, steps };
+  return { run, startTour, handleEvent, steps, myRole };
 }

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -9,7 +9,7 @@ const TOUR_STEPS: Step[] = [
     target: "body",
     title: "WhereYouAd에 오신 걸 환영해요",
     content:
-      "주요 기능을 간단히 소개할게요. Google, Naver, Meta 광고 성과를 한눈에 관리할 수 있어요.",
+      "Google, Naver, Meta 광고 성과를 한 곳에서 관리하는 방법을 안내해 드릴게요.",
     placement: "center",
     skipBeacon: true,
   },
@@ -25,7 +25,7 @@ const TOUR_STEPS: Step[] = [
     target: "[data-tour='tour-dashboard']",
     title: "통합 대시보드",
     content:
-      "Google·Naver·Meta 성과를 한 화면에서 확인하고 AI 분석 리포트를 받아볼 수 있어요.",
+      "Google, Naver, Meta 성과를 한 화면에서 확인하고 AI 분석 리포트도 받아볼 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
@@ -40,7 +40,7 @@ const TOUR_STEPS: Step[] = [
     target: "[data-tour='tour-workspace']",
     title: "워크스페이스 설정",
     content:
-      "멤버 초대, 역할 관리, 플랜 및 결제를 여기서 모두 처리할 수 있어요.",
+      "멤버 초대, 역할 관리, 플랜과 결제를 여기서 모두 처리할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },
@@ -48,28 +48,28 @@ const TOUR_STEPS: Step[] = [
     target: "[data-tour='tour-integrations']",
     title: "플랫폼 연동",
     content:
-      "지금 바로 시작해요. 광고 계정을 연동해야 대시보드에 데이터가 표시돼요.",
+      "광고 계정을 연동해야 대시보드에 데이터가 표시돼요. 지금 바로 시작해볼게요.",
     placement: "right",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-platform-google']",
     title: "Google Ads 연동",
-    content: "검색·디스플레이·쇼핑 광고 성과를 실시간으로 확인할 수 있어요.",
+    content: "검색, 디스플레이, 쇼핑 광고 성과를 실시간으로 확인할 수 있어요.",
     placement: "bottom",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-platform-naver']",
     title: "Naver 광고 연동",
-    content: "네이버 검색 광고 성과를 대시보드에서 바로 볼 수 있어요.",
+    content: "네이버 검색 광고 성과를 대시보드에서 바로 확인할 수 있어요.",
     placement: "bottom",
     skipBeacon: true,
   },
   {
     target: "[data-tour='tour-platform-meta']",
     title: "Meta 광고 연동",
-    content: "Facebook·Instagram 광고 성과를 통합해서 분석할 수 있어요.",
+    content: "Facebook과 Instagram 광고 성과를 통합해서 분석할 수 있어요.",
     placement: "bottom",
     skipBeacon: true,
   },
@@ -77,7 +77,7 @@ const TOUR_STEPS: Step[] = [
     target: "body",
     title: "이제 시작할 준비가 됐어요!",
     content:
-      "광고 계정을 연동하면 모든 성과 데이터를 한눈에 확인할 수 있어요. 지금 바로 연동해보세요.",
+      "지금 광고 계정을 연동하고 모든 성과 데이터를 한눈에 확인해보세요.",
     placement: "center",
     skipBeacon: true,
   },

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -23,7 +23,7 @@ const TOUR_STEPS: Step[] = [
   },
   {
     target: "[data-tour='tour-dashboard']",
-    title: "통합 대시보드",
+    title: "통합·플랫폼 대시보드",
     content:
       "Google, Naver, Meta 성과를 한 화면에서 확인하고 AI 분석 리포트도 받아볼 수 있어요.",
     placement: "right",

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { EventData, Step } from "react-joyride";
-import { STATUS } from "react-joyride";
+import { EVENTS, STATUS } from "react-joyride";
 
 const ONBOARDING_KEY = "hasSeenOnboarding";
 
@@ -91,11 +91,12 @@ export function useOnboardingTour() {
   }, []);
 
   const handleEvent = useCallback((data: EventData) => {
-    const { status } = data;
+    const { status, type } = data;
 
     const isFinished = status === STATUS.FINISHED || status === STATUS.SKIPPED;
+    const isError = type === EVENTS.TARGET_NOT_FOUND;
 
-    if (isFinished) {
+    if (isFinished || isError) {
       setRun(false);
       localStorage.setItem(ONBOARDING_KEY, "true");
     }

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -65,6 +65,7 @@ const TOUR_STEPS: Step[] = [
     content: "네이버 검색 광고 성과를 대시보드에서 바로 확인할 수 있어요.",
     placement: "bottom",
     skipBeacon: true,
+    floatingOptions: { flipOptions: false },
   },
   {
     target: "[data-tour='tour-platform-meta']",

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -39,8 +39,7 @@ const TOUR_STEPS: Step[] = [
   {
     target: "[data-tour='tour-workspace']",
     title: "워크스페이스 관리",
-    content:
-      "멤버 초대, 역할 관리, 플랜과 결제를 여기서 모두 처리할 수 있어요.",
+    content: "멤버 초대, 역할 관리를 여기서 모두 처리할 수 있어요.",
     placement: "right",
     skipBeacon: true,
   },

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -52,6 +52,13 @@ const TOUR_STEPS: Step[] = [
     skipBeacon: true,
   },
   {
+    target: "[data-tour='tour-platform-meta']",
+    title: "Meta 광고 연동",
+    content: "Facebook과 Instagram 광고 성과를 통합해서 분석할 수 있어요.",
+    placement: "bottom",
+    skipBeacon: true,
+  },
+  {
     target: "[data-tour='tour-platform-google']",
     title: "Google Ads 연동",
     content: "검색, 디스플레이, 쇼핑 광고 성과를 실시간으로 확인할 수 있어요.",
@@ -65,13 +72,6 @@ const TOUR_STEPS: Step[] = [
     placement: "bottom",
     skipBeacon: true,
     floatingOptions: { flipOptions: false },
-  },
-  {
-    target: "[data-tour='tour-platform-meta']",
-    title: "Meta 광고 연동",
-    content: "Facebook과 Instagram 광고 성과를 통합해서 분석할 수 있어요.",
-    placement: "bottom",
-    skipBeacon: true,
   },
   {
     target: "body",

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -18,6 +18,7 @@ import {
 
 import { useCoreQuery } from "@/hooks/customQuery";
 
+import OnboardingTour from "@/components/common/OnboardingTour";
 import Sidebar from "@/components/sidebar/Sidebar";
 
 import { getMyInfo } from "@/api/auth/auth";
@@ -157,6 +158,11 @@ export default function MainLayout() {
 
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-surface-200">
+      {myRole === "MEMBER" && (
+        <OnboardingTour
+          autoStart={!localStorage.getItem("hasSeenOnboarding")}
+        />
+      )}
       <div className="flex h-full shrink-0">
         <Sidebar />
       </div>

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -158,7 +158,7 @@ export default function MainLayout() {
 
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-surface-200">
-      {myRole === "MEMBER" && (
+      {myRole !== null && (
         <OnboardingTour
           autoStart={!localStorage.getItem("hasSeenOnboarding")}
         />
@@ -166,7 +166,7 @@ export default function MainLayout() {
       <div className="flex h-full shrink-0">
         <Sidebar />
       </div>
-      <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
+      <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-y-auto scroll-pt-14">
         <header className="sticky top-0 z-30 shrink-0 border-b border-surface-300 bg-surface-100">
           <div className="flex h-14 items-center justify-between px-6 tablet:px-4">
             <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -158,7 +158,8 @@ export default function MainLayout() {
 
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-surface-200">
-      {myRole !== null && (
+      {(myRole !== null ||
+        (workspaces !== undefined && workspaces.length === 0)) && (
         <OnboardingTour
           autoStart={!localStorage.getItem("hasSeenOnboarding")}
         />

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -35,7 +35,10 @@ export default function Login() {
   const onSubmit: SubmitHandler<TLoginFormValues> = (data) => {
     useLogin.mutate(data, {
       onSuccess: () => {
-        navigate("/dashboard", { replace: true });
+        const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
+        navigate(isFirstLogin ? "/integrations" : "/dashboard", {
+          replace: true,
+        });
       },
       onError: (error) => {
         toast.error(error.message ?? "로그인에 실패했습니다.");

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -45,7 +45,7 @@ export default function Login() {
       onSuccess: () => {
         const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
         if (isFirstLogin) {
-          navigate("/integrations", { replace: true });
+          navigate("/workspace", { replace: true });
         } else {
           navigate(getSafeReturnUrl(returnUrl), { replace: true });
         }

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -44,9 +44,11 @@ export default function Login() {
     useLogin.mutate(data, {
       onSuccess: () => {
         const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
-        navigate(isFirstLogin ? "/integrations" : "/dashboard", {
-          replace: true,
-        });
+        if (isFirstLogin) {
+          navigate("/integrations", { replace: true });
+        } else {
+          navigate(getSafeReturnUrl(returnUrl), { replace: true });
+        }
       },
       onError: (error) => {
         toast.error(error.message ?? "로그인에 실패했습니다.");

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -31,7 +31,10 @@ export default function RedirectPage() {
       setAccessToken(accessToken);
 
       toast.success("소셜 로그인되었습니다.");
-      navigate("/dashboard", { replace: true });
+      const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
+      navigate(isFirstLogin ? "/integrations" : "/dashboard", {
+        replace: true,
+      });
     } else {
       toast.error("소셜 로그인에 실패했습니다. 다시 시도해주세요.");
       navigate("/login", { replace: true });

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -42,7 +42,7 @@ export default function RedirectPage() {
       toast.success("소셜 로그인되었습니다.");
       const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
       if (isFirstLogin) {
-        navigate("/integrations", { replace: true });
+        navigate("/workspace", { replace: true });
       } else {
         navigate(getSafeReturnUrl(storedReturnUrl), { replace: true });
       }

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -41,9 +41,11 @@ export default function RedirectPage() {
 
       toast.success("소셜 로그인되었습니다.");
       const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
-      navigate(isFirstLogin ? "/integrations" : "/dashboard", {
-        replace: true,
-      });
+      if (isFirstLogin) {
+        navigate("/integrations", { replace: true });
+      } else {
+        navigate(getSafeReturnUrl(storedReturnUrl), { replace: true });
+      }
     } else {
       toast.error("소셜 로그인에 실패했습니다. 다시 시도해주세요.");
       navigate(buildPathWithReturnUrl("/login", storedReturnUrl), {

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -183,8 +183,7 @@ export default function PlatformIntegrationsPage() {
 
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
-      {/* TODO: 디자인 확인용 임시 — 배포 전 isFirstLogin으로 교체 */}
-      <OnboardingTour autoStart={!isLoading} />
+      <OnboardingTour autoStart={!localStorage.getItem("hasSeenOnboarding")} />
       {isLoading ? (
         <PlatformIntegrationsPageSkeleton />
       ) : isError ? (

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -181,11 +181,10 @@ export default function PlatformIntegrationsPage() {
     });
   };
 
-  const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
-
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
-      <OnboardingTour autoStart={isFirstLogin} />
+      {/* TODO: 디자인 확인용 임시 — 배포 전 isFirstLogin으로 교체 */}
+      <OnboardingTour autoStart />
       {isLoading ? (
         <PlatformIntegrationsPageSkeleton />
       ) : isError ? (

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -16,6 +16,7 @@ import { usePlatformConnections } from "@/hooks/integration/usePlatformConnectio
 
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
+import OnboardingTour from "@/components/common/OnboardingTour";
 import NaverConnectModal from "@/components/integration/NaverConnectModal";
 import PlatformDisconnectModal from "@/components/integration/PlatformDisconnectModal";
 import PlatformIntegrationCard from "@/components/integration/PlatformIntegrationCard";
@@ -180,8 +181,11 @@ export default function PlatformIntegrationsPage() {
     });
   };
 
+  const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
+
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
+      <OnboardingTour autoStart={isFirstLogin} />
       {isLoading ? (
         <PlatformIntegrationsPageSkeleton />
       ) : isError ? (
@@ -202,6 +206,7 @@ export default function PlatformIntegrationsPage() {
                 <li
                   key={item.provider}
                   className="flex h-full min-h-0 w-full min-w-0"
+                  data-tour={`tour-platform-${item.provider.toLowerCase()}`}
                 >
                   <PlatformIntegrationCard
                     {...item}

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -16,7 +16,6 @@ import { usePlatformConnections } from "@/hooks/integration/usePlatformConnectio
 
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
-import OnboardingTour from "@/components/common/OnboardingTour";
 import NaverConnectModal from "@/components/integration/NaverConnectModal";
 import PlatformDisconnectModal from "@/components/integration/PlatformDisconnectModal";
 import PlatformIntegrationCard from "@/components/integration/PlatformIntegrationCard";
@@ -183,7 +182,6 @@ export default function PlatformIntegrationsPage() {
 
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
-      <OnboardingTour autoStart={!localStorage.getItem("hasSeenOnboarding")} />
       {isLoading ? (
         <PlatformIntegrationsPageSkeleton />
       ) : isError ? (

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -184,7 +184,7 @@ export default function PlatformIntegrationsPage() {
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
       {/* TODO: 디자인 확인용 임시 — 배포 전 isFirstLogin으로 교체 */}
-      <OnboardingTour autoStart />
+      <OnboardingTour autoStart={!isLoading} />
       {isLoading ? (
         <PlatformIntegrationsPageSkeleton />
       ) : isError ? (

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -207,6 +207,7 @@ export default function WorkspacePage() {
           size="big"
           variant="primary"
           className="flex shrink-0 items-center justify-center gap-2 whitespace-nowrap tablet:w-full tablet:justify-center"
+          data-tour="tour-create-workspace"
         >
           <PlusIcon className="w-3 h-3 fill-white" />
           <span className="tablet:hidden">워크스페이스 생성하기</span>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -132,8 +132,8 @@
 
   .shadow-tooltip {
     box-shadow:
-      0 4px 6px rgba(0, 0, 0, 0.06),
-      0 12px 32px rgba(0, 0, 0, 0.14);
+      0 4px 6px color-mix(in srgb, var(--color-text-400) 6%, transparent),
+      0 12px 32px color-mix(in srgb, var(--color-text-400) 14%, transparent);
   }
 
   /* UI 트랜지션  */

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -258,7 +258,7 @@
   }
 
   .animate-tooltip-enter {
-    animation: tooltip-enter 120ms var(--ease-out) forwards;
+    animation: tooltip-enter 160ms var(--ease-out) forwards;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -130,6 +130,12 @@
       0 4px 20px color-mix(in srgb, var(--color-text-400) 6%, transparent);
   }
 
+  .shadow-tooltip {
+    box-shadow:
+      0 4px 6px rgba(0, 0, 0, 0.06),
+      0 12px 32px rgba(0, 0, 0, 0.14);
+  }
+
   /* UI 트랜지션  */
   .transition-ui-smooth {
     transition-property: transform, opacity, background-color, border-color, color,

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -238,6 +238,28 @@
       animation: none;
     }
   }
+
+  /* 온보딩 툴팁 등장 애니메이션 */
+  @keyframes tooltip-enter {
+    from {
+      opacity: 0;
+      transform: scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .animate-tooltip-enter {
+    animation: tooltip-enter 120ms var(--ease-out) forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-tooltip-enter {
+      animation: none;
+    }
+  }
 }
 
 /* 플랫폼 상세 테이블 스크롤바 — @theme 팔레트만 사용 */


### PR DESCRIPTION
## 🚨 관련 이슈

#373 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

</br>

<details>
<summary> ✏️ 1차 작업 내용</summary>

최초 로그인 사용자에게 주요 기능을 안내하는 온보딩 투어를 구현했습니다.

**리다이렉트 로직**
- ~최초 로그인(일반/소셜) 시 `/integrations`로 자동 이동~
- ~재로그인 시 기존대로 `/dashboard`로 이동~
- `hasSeenOnboarding` localStorage 플래그로 최초 여부 판단

**온보딩 투어 (react-joyride)**
- ~10단계 투어: 워크스페이스 switcher → 대시보드 → 캠페인 → 워크스페이스 관리 → 플랫폼 연동 → Meta/Google/Naver 카드 → 완료~
- 투어 완료 또는 건너뛰기 시 `hasSeenOnboarding` 저장 → 이후 로그인부터 투어 미노출
- 타겟 찾기 실패 시에도 플래그 저장 후 종료

**커스텀 툴팁 디자인**
- 디자인 시스템 토큰 기반 (`bg-surface-100`, `rounded-3xl`, `shadow-tooltip`)
- 소제목 + 설명 구조, 진행 단계 표시 (`1 / 10`)
- 이전 / 다음 / 건너뛰기 버튼

**UX 개선**
- 툴팁 콘텐츠 스텝 전환 시 fade-in 재실행
- 스포트라이트 타겟 간 부드러운 모핑 (`d 280ms cubic-bezier`)
- 오버레이 fade (`opacity 200ms ease-out`)
- 사이드바 `data-tour` 타겟을 버튼 요소로 이동 → 화살표 정렬 정확도 개선
- Naver 카드 툴팁 flip 비활성화 → 정렬 일관성 확보
</details>

</br>

## ✏️ 2차 작업 내용
 
### 역할별 온보딩 투어 분기
- `useOnboardingTour` 훅에서 `myRole` 기반으로 `ADMIN_STEPS` / `MEMBER_STEPS` 반환
- **ADMIN**: `/workspace` 진입 후 투어 시작, 마지막 스텝을 워크스페이스 생성 버튼에 포커스
- **MEMBER**: `/dashboard` 진입 후 투어 시작, 플랫폼 연동 관련 스텝 제거

### 투어 마운트 위치 변경
- 기존: `PlatformIntegrationsPage` (ADMIN만 접근 가능한 페이지)
- 변경: `MainLayout` (역할 무관 공통 마운트, `myRole` 확정 후 자동 시작)

### 툴팁 UX 개선
- 커스텀 툴팁 디자인, 페이드인 애니메이션, 스포트라이트 모핑 전환 효과 적용
- `whitespace-pre-line` 적용으로 문구 줄바꿈 제어
- 사이드바 main 아이템에 `w-full` 추가 → 스포트라이트 크기 통일
- 툴팁 그림자 강화, Naver 카드 tooltip `flip` 비활성화

### returnUrl 처리
- 로그인/회원가입 후 이전 페이지로 복귀하는 `returnUrl` 처리 구현
- 외부 도메인으로의 리다이렉트 차단 (오픈 리다이렉트 방지)

## 📋 ADMIN 온보딩 투어 순서 (7 Steps)
 
> ADMIN (워크스페이스 생성자)
최초 로그인 → /workspace
→ 온보딩 투어 시작 (/workspace)
→ 워크스페이스 생성 버튼 CTA로 투어 마무리
→ 워크스페이스 생성 → 멤버 초대 / 플랫폼 연동

</br>

| # | 타겟 | 제목 |
|---|------|------|
| 1 | 화면 중앙 | WhereYouAd에 오신 걸 환영해요 |
| 2 | 워크스페이스 switcher | 워크스페이스 |
| 3 | 대시보드 사이드바 | 통합·플랫폼 대시보드 |
| 4 | 캠페인 사이드바 | 캠페인 관리 |
| 5 | 워크스페이스 사이드바 | 워크스페이스 관리 |
| 6 | 플랫폼 연동 사이드바 | 플랫폼 연동 |
| 7 | 워크스페이스 생성하기 버튼 | 워크스페이스를 만들고 시작해볼까요? |
 
https://github.com/user-attachments/assets/366cc2fa-da87-46d3-ada1-7dec2864ec85
 

</br>

## 📋 MEMBER 온보딩 투어 순서 (6 Steps)

> MEMBER (초대받은 사용자)
최초 로그인 → /dashboard
→ 온보딩 투어 시작 (/dashboard)
→ 대시보드 CTA로 투어 마무리
→ 광고 성과 바로 확인 

</br>

| # | 타겟 | 제목 |
|---|------|------|
| 1 | 화면 중앙 | WhereYouAd에 오신 걸 환영해요 |
| 2 | 워크스페이스 switcher | 워크스페이스 |
| 3 | 대시보드 사이드바 | 통합·플랫폼 대시보드 |
| 4 | 캠페인 사이드바 | 캠페인 관리 |
| 5 | 워크스페이스 사이드바 | 워크스페이스 설정 |
| 6 | 화면 중앙 | 이제 시작할 준비가 됐어요! |
 
https://github.com/user-attachments/assets/847ecc1f-3183-40bb-9ac6-84b089c5e0e7



## 😅 미완성 작업
N/A



## 📢 논의 사항 및 참고 사항

WhereYouAd는 RBAC 기반 서비스로 ADMIN과 MEMBER의 경험이 달라 피드백 기반으로 온보딩 투어에서부터 분리해 구현하였습니다.

- ADMIN: 워크스페이스를 직접 생성한 사용자입니다. 최초 로그인 시 아직 워크스페이스가 없는 상태이므로, 워크스페이스 생성이 모든 기능의 선행 조건입니다. 광고 계정 연동도, 멤버 초대도 워크스페이스 없이는 불가능하기 때문에 온보딩을 /workspace에서 시작하고 마지막 스텝에서 워크스페이스 생성 버튼을 직접 안내합니다.

- MEMBER: 이미 ADMIN에게 초대받아 워크스페이스에 소속된 사용자입니다. 별도의 설정 없이 바로 서비스를 사용할 수 있는 상태이므로, 온보딩을 /dashboard에서 시작해 통합 대시보드에서 광고 성과를 바로 확인할 수 있도록 안내합니다. 플랫폼 연동 등 ADMIN 전용 기능 스텝은 제거했습니다.



> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


</br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 신규 사용자를 위한 온보딩 투어를 추가했습니다.
  * 워크스페이스, 대시보드, 캠페인 및 연동 플랫폼의 주요 기능을 단계별로 안내합니다.
  * 투어에서 진행률 확인, 이전·다음 이동, 건너뛰기 및 완료가 가능합니다.
  * 최초 로그인 시 연동 플랫폼 화면으로 이동하며, 이후에는 대시보드로 이동합니다.
  * 온보딩 완료 또는 건너뛰기 상태를 저장해 반복 표시를 방지합니다.

* **스타일**
  * 온보딩 툴팁에 진입 애니메이션과 그림자 효과를 적용했습니다.
  * 모션 감소 설정을 사용하는 환경에서는 애니메이션을 비활성화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->