### PR TITLE
[Bugfix/#379] 회원가입 완료 후 로그인 페이지로 이동되지 않는 문제 해결

### DIFF
--- a/src/components/auth/flows/signup/ProfileSetupStep.tsx
+++ b/src/components/auth/flows/signup/ProfileSetupStep.tsx
@@ -29,7 +29,7 @@ export default function ProfileSetupStep({ password }: IProfileSetupStepProps) {
 
   const [searchParams] = useSearchParams();
   const returnUrl = searchParams.get("returnUrl");
-  const { email, resetAuth } = useAuthStore();
+  const { email } = useAuthStore();
   const { openModal } = useModalStore();
   const { useSignUp } = useAuth();
 
@@ -63,7 +63,6 @@ export default function ProfileSetupStep({ password }: IProfileSetupStepProps) {
           toast.success("회원가입이 완료되었습니다!", {
             description: `${data.name}님, 환영합니다!`,
           });
-          resetAuth();
           navigate(buildPathWithReturnUrl("/login", returnUrl), {
             replace: true,
           });


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #379 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 회원가입 프로필 단계 성공시에 `resetAuth()`를 먼저 호출하게 되면서, store의 email이 비워지고, 그다음 `navigate(buildPathWithReturnUrl("/login", returnUrl)` 단계에서 같은 컴포넌트의 guard `useEffect`가 `!email`을 먼저 감지해서 `/signup`으로 다시 이동하는 에러를 수정했습니다.
- 성공 콜백에서는 `login`으로만 이동하고(returnUrl이 있다면 그 Url로 이동), `email`과 `socialId` 초기화는 `Signup`페이지에서 `resetAuth` 실행됩니다.

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- `resetAuth()는 폼 전체 지우는 것이 아니라 Zustand의 `email`, `socialId`만 초기화합니다. 나머지 입력값은 페이지 언마운트시 함께 사라지는 구조입니다.
- 기존 `!email || !password`은 그대로 동작 유지됩니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 프로필 설정 완료 후 인증 상태가 불필요하게 초기화되던 문제를 수정했습니다.
  * 회원가입 성공 알림 표시 후 로그인 페이지로 이동하는 흐름은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->