### PR TITLE
[Feature/#382] 회원  탈퇴 UI 및 API 연동

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -169,3 +169,8 @@ export const postLogout = async () => {
   );
   return response.data;
 };
+
+export const deleteMyAccount = async (): Promise<ICommonResponse<string>> => {
+  const { data } = await axiosInstance.delete("/api/users/my");
+  return data;
+};

--- a/src/components/setting/WithdrawConfirmModal.tsx
+++ b/src/components/setting/WithdrawConfirmModal.tsx
@@ -66,7 +66,7 @@ export default function WithdrawConfirmModal({
             className="flex-1"
             onClick={handleConfirm}
             disabled={isLoading}
-            aria-label="회원 탈퇴 확인"
+            aria-label={isLoading ? "탈퇴 진행 중" : "회원 탈퇴 확인"}
           >
             {isLoading ? "탈퇴 진행 중..." : "회원 탈퇴"}
           </Button>

--- a/src/components/setting/WithdrawConfirmModal.tsx
+++ b/src/components/setting/WithdrawConfirmModal.tsx
@@ -35,7 +35,7 @@ export default function WithdrawConfirmModal({
       hideCloseButton={isLoading}
       disableOverlayClick={isLoading}
     >
-      <div className="px-2 py-6 text-center">
+      <div className="px-2 text-center">
         <div className="mb-6 flex justify-center">
           <WarnIcon className="h-15 w-15 text-info-red" aria-hidden="true" />
         </div>

--- a/src/components/setting/WithdrawConfirmModal.tsx
+++ b/src/components/setting/WithdrawConfirmModal.tsx
@@ -1,0 +1,77 @@
+import Button from "../common/button/Button";
+import Modal from "../common/modal/Modal";
+
+import WarnIcon from "@/assets/icon/common/warn-circle.svg?react";
+
+interface IWithdrawConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+}
+
+export default function WithdrawConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading = false,
+}: IWithdrawConfirmModalProps) {
+  const handleConfirm = () => {
+    if (isLoading) return;
+    onConfirm();
+  };
+
+  const handleClose = () => {
+    if (isLoading) return;
+    onClose();
+  };
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      padding="lg"
+      title="회원 탈퇴 확인"
+      hideCloseButton={isLoading}
+      disableOverlayClick={isLoading}
+    >
+      <div className="px-2 py-6 text-center">
+        <div className="mb-6 flex justify-center">
+          <WarnIcon className="h-15 w-15 text-info-red" aria-hidden="true" />
+        </div>
+
+        <h3 className="mb-3 font-heading2 text-text-title">
+          정말로 회원탈퇴하시겠습니까?
+        </h3>
+
+        <p className="mb-7 font-body1 text-text-auth-sub">
+          탈퇴 요청 시 계정은 바로 비활성화되며, <br /> 30일 후 서버에서 완전히
+          삭제됩니다. <br />이 작업은 되돌리기 어려우니 신중히 결정해 주세요
+        </p>
+        <div className="flex gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            size="big"
+            className="flex-1"
+            onClick={handleClose}
+            disabled={isLoading}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            size="big"
+            className="flex-1"
+            onClick={handleConfirm}
+            disabled={isLoading}
+            aria-label="회원 탈퇴 확인"
+          >
+            {isLoading ? "탈퇴 진행 중..." : "회원 탈퇴"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/hooks/auth/useDeleteMyAccount.ts
+++ b/src/hooks/auth/useDeleteMyAccount.ts
@@ -1,0 +1,43 @@
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import type { IApiErrorResponse } from "@/types/common/common";
+
+import { useCoreMutation } from "../customQuery";
+
+import { deleteMyAccount } from "@/api/auth/auth";
+import useAuthStore from "@/store/useAuthStore";
+
+const WITHDRAW_ERROR_MESSAGES: Record<string, string> = {
+  USER_400_9: "조직 소유권 양도를 진행한 후 탈퇴를 시도해주세요",
+  USER_409_1:
+    "소셜 정보가 없습니다. 소셜 계정으로 다시 로그인한 뒤 시도해주세요",
+  USER_502_1: "소셜 연동 해제에 실패했습니다. 잠시 후 다시 시도해주세요",
+  USER_404_1: "사용자 정보를 찾을 수 없습니다",
+};
+
+export function useDeleteMyAccount() {
+  const nav = useNavigate();
+  const queryClient = useQueryClient();
+  const logout = useAuthStore((s) => s.logout);
+
+  return useCoreMutation(deleteMyAccount, {
+    userOnSuccess: () => {
+      toast.success(
+        "회원 탈퇴가 완료되었습니다. 30일 후 계정이 완전히 삭제됩니다",
+      );
+      queryClient.clear();
+      logout();
+      nav("/", { replace: true });
+    },
+    userOnError: (error) => {
+      const apiError = error as IApiErrorResponse;
+      const message =
+        WITHDRAW_ERROR_MESSAGES[apiError.code] ??
+        apiError.message ??
+        "회원 탈퇴에 실패했습니다. 다시 시도해주세요";
+      toast.error(message);
+    },
+  });
+}

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import type { IApiErrorResponse } from "@/types/common/common";
 import type { IUpdateOrgNotificationSettingsRequest } from "@/types/setting/notification";
 
+import { useDeleteMyAccount } from "@/hooks/auth/useDeleteMyAccount";
 import { useImageUploader } from "@/hooks/common/useImageUploader";
 import { useCoreQuery } from "@/hooks/customQuery";
 import { useMyNotificationSettings } from "@/hooks/setting/useMyNotificationSettings";
@@ -20,6 +21,7 @@ import PasswordSection from "@/components/setting/PasswordSection";
 import PasswordSectionSkeleton from "@/components/setting/PasswordSectionSkeleton";
 import ProfileSection from "@/components/setting/ProfileSection";
 import ProfileSectionSkeleton from "@/components/setting/ProfileSectionSkeleton";
+import WithdrawConfirmModal from "@/components/setting/WithdrawConfirmModal";
 
 import { getMyInfo, updateMyInfo } from "@/api/auth/auth";
 import { getMyWorkspaces } from "@/api/workspace/org";
@@ -111,6 +113,8 @@ export default function Setting() {
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
+
   const {
     fileRef,
     file,
@@ -156,6 +160,9 @@ export default function Setting() {
   const updateAlerts = useUpdateAlertsNotificationSettings();
   const updateOrg = useUpdateOrgNotificationSettings();
   const updateMaster = useUpdateMasterNotificationSettings();
+
+  const { mutate: deleteMyAccountMutate, isPending: isWithdrawPending } =
+    useDeleteMyAccount();
 
   const buildOrgBody = (
     overrides: Partial<IUpdateOrgNotificationSettingsRequest> = {},
@@ -724,7 +731,15 @@ export default function Setting() {
         )}
       </div>
 
-      <div className="flex justify-end">
+      <div className="flex items-start justify-between">
+        <button
+          type="button"
+          className="ml-3 font-caption text-text-muted underline decoration-surface-400 underline-offset-2 transition-colors hover:text-text-title"
+          onClick={() => setIsWithdrawModalOpen(true)}
+          aria-label="회원 탈퇴"
+        >
+          회원 탈퇴
+        </button>
         <Button
           variant="primary"
           type="button"
@@ -738,6 +753,12 @@ export default function Setting() {
           변경사항 저장하기
         </Button>
       </div>
+      <WithdrawConfirmModal
+        isOpen={isWithdrawModalOpen}
+        onClose={() => setIsWithdrawModalOpen(false)}
+        onConfirm={() => deleteMyAccountMutate(undefined)}
+        isLoading={isWithdrawPending}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #382 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 설정 페이지에서 회원 탈퇴 진입점 및 확인 모달 추가
- `DELETE /api/users/my` API/훅 연동
- 성공시 toast+세션 정리 후 랜딩페이지로 이동
- 에러 코드별 안내 (소유권자 탈퇴 에러는 소유권 양도후 재시도만 안내)

## 💻 작업 화면
<img width="1838" height="870" alt="image" src="https://github.com/user-attachments/assets/d0218fdd-d7c2-455e-b9be-27084c5fbb1e" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- 소유권자 탈퇴시에는 소유권 양도 페이지로 이동하는것이 아니라, 양도해야합니다 안내문구만 나타냅니다. 양도를 하기위해서는 사용자가 멤버관리에 직접 이동하는 방식으로 추후 조직양도와 이어집니다.


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 설정 페이지에서 회원 탈퇴 기능을 제공합니다.
  * 탈퇴 전 확인 모달에서 안내 내용을 확인하고 취소하거나 탈퇴를 진행할 수 있습니다.
  * 탈퇴 처리 중에는 중복 작업을 방지하고 진행 상태를 표시합니다.
  * 탈퇴 완료 후 성공 안내와 함께 자동으로 로그아웃됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->