### PR TITLE
[Feature/#377] AI 분석 결과 조직 공유 조회 API 연동

### DIFF
--- a/src/api/dashboard/aiAnalysis.ts
+++ b/src/api/dashboard/aiAnalysis.ts
@@ -1,5 +1,7 @@
 import type { ICommonResponse } from "@/types/common/common";
 import type {
+  IAiReportListParams,
+  IAiReportListResponse,
   IAnalysisRequest,
   IReportStatusResponse,
 } from "@/types/dashboard/aiAnalysis";
@@ -29,5 +31,16 @@ export const getAiReportByAccessToken = async (
   const { data } = await axiosInstance.get<
     ICommonResponse<IReportStatusResponse>
   >(`/api/ai/reports/${encodeURIComponent(accessToken)}`);
+  return data.data;
+};
+
+/** 조직 단위 AI 분석 리포트 목록 조회 (최신순, 본문 제외) */
+export const getOrgAiReports = async (
+  orgId: number,
+  params?: IAiReportListParams,
+): Promise<IAiReportListResponse> => {
+  const { data } = await axiosInstance.get<
+    ICommonResponse<IAiReportListResponse>
+  >(`/api/ai/organizations/${orgId}/reports`, { params });
   return data.data;
 };

--- a/src/components/dashboard/ai-report/components/AiSummaryCard.tsx
+++ b/src/components/dashboard/ai-report/components/AiSummaryCard.tsx
@@ -294,17 +294,15 @@ export default function AiSummaryCard({
   );
 
   const handleToggle = useCallback(() => {
-    setIsExpanded((prev) => {
-      const next = !prev;
-      if (next) {
-        onExpand?.();
-        if (!data) autoExpandOnResultRef.current = true;
-      } else if (isLoading) {
-        autoExpandOnResultRef.current = false;
-      }
-      return next;
-    });
-  }, [data, isLoading, onExpand]);
+    const next = !isExpanded;
+    setIsExpanded(next);
+    if (next) {
+      onExpand?.();
+      if (!data) autoExpandOnResultRef.current = true;
+    } else if (isLoading) {
+      autoExpandOnResultRef.current = false;
+    }
+  }, [isExpanded, data, isLoading, onExpand]);
 
   const handleDownloadPdf = useCallback(() => {
     if (!printDocument) return;

--- a/src/components/dashboard/ai-report/components/DashboardAiSummarySection.tsx
+++ b/src/components/dashboard/ai-report/components/DashboardAiSummarySection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import type { TAiAnalysisProvider } from "@/types/dashboard/aiAnalysis";
 import { PLATFORM_MAP } from "@/types/dashboard/provider";
@@ -34,10 +34,18 @@ export default function DashboardAiSummarySection({
     requestAnalysis,
     isLoading,
     isCheckingSharedReport,
+    sharedReportCreatedAt,
     loadingMessage,
     isError,
     errorMessage,
   } = useAiAnalysisReport(provider);
+
+  const periodLabel = useMemo(() => {
+    const base = formatAiAnalysisPeriodLabel();
+    if (!sharedReportCreatedAt) return base;
+    const date = sharedReportCreatedAt.slice(0, 10).replaceAll("-", ".");
+    return `${base} · 팀 공유 분석 (${date})`;
+  }, [sharedReportCreatedAt]);
 
   /** 공유 조회 중에 카드를 펼쳤을 때 POST를 보류했음을 기록 */
   const pendingExpandRef = useRef(false);
@@ -80,7 +88,7 @@ export default function DashboardAiSummarySection({
       title={title ?? getAiSummaryTitle(provider)}
       idPrefix={idPrefix}
       print={{ documentTitle: getAiSummaryDocumentTitle(provider) }}
-      periodLabel={formatAiAnalysisPeriodLabel()}
+      periodLabel={periodLabel}
     />
   );
 }

--- a/src/components/dashboard/ai-report/components/DashboardAiSummarySection.tsx
+++ b/src/components/dashboard/ai-report/components/DashboardAiSummarySection.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import type { TAiAnalysisProvider } from "@/types/dashboard/aiAnalysis";
 import { PLATFORM_MAP } from "@/types/dashboard/provider";
@@ -32,23 +32,41 @@ export default function DashboardAiSummarySection({
   const {
     reportData,
     requestAnalysis,
-    reset,
     isLoading,
+    isCheckingSharedReport,
     loadingMessage,
     isError,
     errorMessage,
   } = useAiAnalysisReport(provider);
 
+  /** 공유 조회 중에 카드를 펼쳤을 때 POST를 보류했음을 기록 */
+  const pendingExpandRef = useRef(false);
+
   const handleExpand = useCallback(() => {
     if (!reportData && !isLoading && !isError) {
       requestAnalysis();
+    } else if (isCheckingSharedReport) {
+      pendingExpandRef.current = true;
     }
-  }, [reportData, isLoading, isError, requestAnalysis]);
+  }, [reportData, isLoading, isError, isCheckingSharedReport, requestAnalysis]);
+
+  /** 공유 조회가 끝났을 때 결과가 없으면 POST fallback 실행 */
+  useEffect(() => {
+    if (
+      pendingExpandRef.current &&
+      !isCheckingSharedReport &&
+      !reportData &&
+      !isLoading &&
+      !isError
+    ) {
+      pendingExpandRef.current = false;
+      requestAnalysis();
+    }
+  }, [isCheckingSharedReport, reportData, isLoading, isError, requestAnalysis]);
 
   const handleRetry = useCallback(() => {
-    reset();
     requestAnalysis();
-  }, [reset, requestAnalysis]);
+  }, [requestAnalysis]);
 
   return (
     <AiSummaryCard

--- a/src/components/dashboard/ai-report/components/DashboardAiSummarySection.tsx
+++ b/src/components/dashboard/ai-report/components/DashboardAiSummarySection.tsx
@@ -34,11 +34,16 @@ export default function DashboardAiSummarySection({
     requestAnalysis,
     isLoading,
     isCheckingSharedReport,
+    hasUsableSharedReport,
     sharedReportCreatedAt,
     loadingMessage,
     isError,
     errorMessage,
   } = useAiAnalysisReport(provider);
+
+  /** ref로 유지해 fallback effect deps에 포함하지 않음 */
+  const hasUsableSharedReportRef = useRef(false);
+  hasUsableSharedReportRef.current = hasUsableSharedReport;
 
   const periodLabel = useMemo(() => {
     const base = formatAiAnalysisPeriodLabel();
@@ -65,7 +70,8 @@ export default function DashboardAiSummarySection({
       !isCheckingSharedReport &&
       !reportData &&
       !isLoading &&
-      !isError
+      !isError &&
+      !hasUsableSharedReportRef.current
     ) {
       pendingExpandRef.current = false;
       requestAnalysis();

--- a/src/constants/dashboard/overviewMetricsRange.ts
+++ b/src/constants/dashboard/overviewMetricsRange.ts
@@ -1,11 +1,14 @@
 /** 통합 대시보드 — 일별 지표 ROAS 순위 등 */
 export const OVERVIEW_DAILY_METRICS_RANGE = {
   startDate: "2026-06-15",
-  endDate: "2026-07-15",
+  endDate: "2026-07-07",
 } as const;
 
-/** AI 분석 — ROAS 동일 구간 말일 기준 최근 30일(한 달), 구간 시작일 이전으로는 확장하지 않음 */
-const AI_ANALYSIS_LOOKBACK_DAYS = 30;
+/**
+ * AI 분석 — ROAS 동일 구간 말일 기준 최근 14일(2주), 구간 시작일 이전으로는 확장하지 않음
+ * 백엔드 확인 결과 조회 기간이 너무 길면(예: 30일) AI 처리 단계에서 실패해 1~2주 범위로 제한
+ */
+const AI_ANALYSIS_LOOKBACK_DAYS = 14;
 
 function toApiDateString(date: Date): string {
   const y = date.getFullYear();
@@ -18,7 +21,7 @@ function parseApiDate(dateStr: string): Date {
   return new Date(`${dateStr}T12:00:00`);
 }
 
-/** AI 요약 POST body용 — 통합 ROAS 말일 기준 최근 한 달 */
+/** AI 요약 POST body용 — 통합 ROAS 말일 기준 최근 2주 */
 export function getAiAnalysisDateRange(): {
   startDate: string;
   endDate: string;

--- a/src/hooks/dashboard/useAiAnalysisReport.ts
+++ b/src/hooks/dashboard/useAiAnalysisReport.ts
@@ -14,6 +14,7 @@ import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import {
   getAiReportByAccessToken,
+  getOrgAiReports,
   requestAiAnalysis,
 } from "@/api/dashboard/aiAnalysis";
 import { QUERY_KEYS } from "@/lib/queryKeys";
@@ -38,25 +39,64 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [pollStartedAt, setPollStartedAt] = useState<number | null>(null);
   const [workspaceErrorShown, setWorkspaceErrorShown] = useState(false);
+  /** true면 조직 공유 리포트 조회를 건너뛰고 POST 플로우로 직행 (명시적 요청) */
+  const [skipSharedLookup, setSkipSharedLookup] = useState(false);
 
   /** 재요청 전 상태 초기화 */
   const reset = useCallback(() => {
     setAccessToken(null);
     setPollStartedAt(null);
     setWorkspaceErrorShown(false);
+    setSkipSharedLookup(false);
   }, []);
 
   useEffect(() => {
     reset();
-  }, [provider, reset]);
+  }, [provider, orgId, reset]);
 
   useEffect(() => {
     return () => {
       void queryClient.removeQueries({
         queryKey: QUERY_KEYS.ai.report(provider, orgId),
       });
+      void queryClient.removeQueries({
+        queryKey: QUERY_KEYS.ai.reportList(provider, orgId),
+      });
     };
   }, [provider, orgId]);
+
+  /* 조직 공유 최신 리포트 우선 조회 */
+  const sharedReportListQuery = useCoreQuery(
+    QUERY_KEYS.ai.reportList(provider, orgId),
+    () =>
+      getOrgAiReports(orgId!, {
+        reportType: provider === "ALL" ? undefined : provider,
+        size: 1,
+      }),
+    {
+      enabled: !!orgId && !skipSharedLookup && !accessToken,
+      staleTime: 0,
+      gcTime: AI_REPORT_GC_TIME_MS,
+    },
+  );
+
+  /* 조회된 공유 리포트가 있으면 POST 없이 그 accessToken으로 바로 렌더링 */
+  useEffect(() => {
+    if (skipSharedLookup || accessToken) return;
+    if (!sharedReportListQuery.isSuccess) return;
+
+    const latest = sharedReportListQuery.data.reports[0];
+    /** 과거에 실패한 리포트는 채택하지 않고 미조회 상태로 둔다 (펼치면 새 POST로 폴백) */
+    if (!latest || latest.status === "FAILED") return;
+
+    setAccessToken(latest.reportAccessToken);
+    setPollStartedAt(Date.now());
+  }, [
+    accessToken,
+    skipSharedLookup,
+    sharedReportListQuery.isSuccess,
+    sharedReportListQuery.data,
+  ]);
 
   /** POST /analysis — accessToken 발급 */
   const requestMutation = useCoreMutation(
@@ -131,16 +171,19 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
         return;
       }
       reset();
+      /** 명시적 POST 요청은 조직 공유 리포트 조회 결과로 덮어써지지 않도록 건너뜀 */
+      setSkipSharedLookup(true);
       requestMutation.mutate(params ?? {});
     },
     [orgId, reset, requestMutation],
   );
 
   const isSubmitting = requestMutation.isPending;
+  const isCheckingSharedReport = sharedReportListQuery.isLoading;
   const isPolling =
     !!accessToken && reportStatus === "PENDING" && !pollTimedOut;
 
-  const isLoading = isSubmitting || isPolling;
+  const isLoading = isCheckingSharedReport || isSubmitting || isPolling;
 
   const queryError = reportQuery.error as IApiErrorResponse | null;
   const isWorkspaceMissing = !orgId && workspaceErrorShown;
@@ -156,11 +199,12 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     pollTimedOut;
 
   const loadingMessage = useMemo(() => {
+    if (isCheckingSharedReport) return "이전 분석 결과를 확인하고 있어요…";
     if (isSubmitting) return "분석을 요청하고 있어요…";
     if (isPolling)
       return "AI가 광고 성과를 분석 중이에요. 보통 10~30초 걸려요.";
     return null;
-  }, [isSubmitting, isPolling]);
+  }, [isCheckingSharedReport, isSubmitting, isPolling]);
 
   const errorMessage = useMemo(() => {
     if (isWorkspaceMissing) return WORKSPACE_REQUIRED_MESSAGE;
@@ -195,6 +239,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     requestAnalysis,
     reset,
     isLoading,
+    isCheckingSharedReport,
     loadingMessage,
     isError,
     errorMessage,

--- a/src/hooks/dashboard/useAiAnalysisReport.ts
+++ b/src/hooks/dashboard/useAiAnalysisReport.ts
@@ -41,6 +41,10 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
   const [workspaceErrorShown, setWorkspaceErrorShown] = useState(false);
   /** true면 조직 공유 리포트 조회를 건너뛰고 POST 플로우로 직행 (명시적 요청) */
   const [skipSharedLookup, setSkipSharedLookup] = useState(false);
+  /** 공유 리포트 채택 시 해당 리포트의 생성일 (ISO 문자열) */
+  const [sharedReportCreatedAt, setSharedReportCreatedAt] = useState<
+    string | null
+  >(null);
 
   /** 재요청 전 상태 초기화 */
   const reset = useCallback(() => {
@@ -48,6 +52,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     setPollStartedAt(null);
     setWorkspaceErrorShown(false);
     setSkipSharedLookup(false);
+    setSharedReportCreatedAt(null);
   }, []);
 
   useEffect(() => {
@@ -90,6 +95,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     if (!latest || latest.status === "FAILED") return;
 
     setAccessToken(latest.reportAccessToken);
+    setSharedReportCreatedAt(latest.createdAt);
     setPollStartedAt(Date.now());
   }, [
     accessToken,
@@ -240,6 +246,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     reset,
     isLoading,
     isCheckingSharedReport,
+    sharedReportCreatedAt,
     loadingMessage,
     isError,
     errorMessage,

--- a/src/hooks/dashboard/useAiAnalysisReport.ts
+++ b/src/hooks/dashboard/useAiAnalysisReport.ts
@@ -104,6 +104,12 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     sharedReportListQuery.data,
   ]);
 
+  /** 사용 가능한 공유 리포트가 있는지 여부 (query data 기반 — 렌더 시점에 즉시 반영) */
+  const hasUsableSharedReport =
+    sharedReportListQuery.isSuccess &&
+    !!sharedReportListQuery.data?.reports[0] &&
+    sharedReportListQuery.data.reports[0].status !== "FAILED";
+
   /** POST /analysis — accessToken 발급 */
   const requestMutation = useCoreMutation(
     (params: TRequestAiAnalysisParams) => {
@@ -246,6 +252,7 @@ export function useAiAnalysisReport(provider: TAiAnalysisProvider = "ALL") {
     reset,
     isLoading,
     isCheckingSharedReport,
+    hasUsableSharedReport,
     sharedReportCreatedAt,
     loadingMessage,
     isError,

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -73,6 +73,9 @@ export const QUERY_KEYS = {
     /** AI 분석 리포트 폴링 쿼리 */
     report: (provider: string, orgId: number | null) =>
       ["ai", "report", provider, orgId] as const,
+    /** 조직 단위 최신 AI 분석 리포트 목록 조회 (공유 결과 확인용) */
+    reportList: (provider: string, orgId: number | null) =>
+      ["ai", "reportList", provider, orgId] as const,
   },
 
   timeline: {

--- a/src/types/dashboard/aiAnalysis.ts
+++ b/src/types/dashboard/aiAnalysis.ts
@@ -1,4 +1,4 @@
-import type { TAiAnalysisProvider } from "./provider";
+import type { TAiAnalysisProvider, TProviderType } from "./provider";
 
 export type { TAiAnalysisProvider };
 export type TAiReportJobStatus = "PENDING" | "SUCCESS" | "FAILED";
@@ -24,4 +24,29 @@ export interface IReportStatusResponse {
   accessToken: string;
   status: TAiReportJobStatus;
   result: IAnalysisResponse | null;
+}
+
+/** GET /organizations/{orgId}/reports 조회 파라미터 */
+export interface IAiReportListParams {
+  /** 생략하면 전체 유형 조회 */
+  reportType?: TProviderType;
+  cursor?: string;
+  size?: number;
+}
+
+/** 리포트 목록 항목 (분석 결과 본문 제외) */
+export interface IAiReportListItem {
+  reportId: number;
+  reportAccessToken: string;
+  title: string;
+  status: TAiReportJobStatus;
+  isShared: boolean;
+  createdAt: string;
+}
+
+/** GET /organizations/{orgId}/reports 응답 data */
+export interface IAiReportListResponse {
+  hasNext: boolean;
+  nextCursor: string | null;
+  reports: IAiReportListItem[];
 }

--- a/tests/ai-analysis.spec.ts
+++ b/tests/ai-analysis.spec.ts
@@ -1,4 +1,10 @@
-import { expect, type Page, test } from "./fixtures/auth";
+import {
+  expect,
+  loginAndReachDashboard,
+  type Page,
+  test,
+  waitForDashboardReady,
+} from "./fixtures/auth";
 
 const CARD_TITLE = "통합 광고 성과 AI 요약";
 const MOCK_TOKEN = "mock-ai-token-e2e";
@@ -44,6 +50,70 @@ async function mockAiAnalysisResult(page: Page) {
         }),
       }),
   );
+}
+
+const SHARED_TOKEN = "shared-report-token";
+
+/**
+ * /organizations/{orgId}/reports 응답을 지연시킨다.
+ * release()를 호출하면 지정한 status의 공유 리포트가 반환된다.
+ */
+async function setupDelayedSharedReport(
+  page: Page,
+  reportStatus: "PENDING" | "SUCCESS",
+): Promise<{ release: () => void }> {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+
+  await page.route(
+    (url) =>
+      url.pathname.includes("/api/ai/organizations/") &&
+      url.pathname.endsWith("/reports"),
+    async (route) => {
+      await gate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "OK",
+          data: {
+            hasNext: false,
+            nextCursor: null,
+            reports: [
+              {
+                reportId: 1,
+                reportAccessToken: SHARED_TOKEN,
+                title: "팀 공유 분석",
+                status: reportStatus,
+                isShared: true,
+                createdAt: "2026-08-01T00:00:00Z",
+              },
+            ],
+          },
+        }),
+      });
+    },
+  );
+
+  // 공유 토큰 폴링 — PENDING 고정으로 추가 POST 없이 유지
+  await page.route(
+    (url) =>
+      url.pathname.includes("/api/ai/reports/") &&
+      !url.pathname.includes("/organizations/"),
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "OK",
+          data: { accessToken: SHARED_TOKEN, status: "PENDING", result: null },
+        }),
+      }),
+  );
+
+  return { release };
 }
 
 test.describe("AI 분석 요청 E2E", () => {
@@ -102,4 +172,43 @@ test.describe("AI 분석 요청 E2E", () => {
       page.getByRole("heading", { name: "분석 인사이트" }),
     ).toBeVisible();
   });
+});
+
+test.describe("공유 리포트 fallback 회귀", () => {
+  for (const reportStatus of ["PENDING", "SUCCESS"] as const) {
+    test(`공유 리포트(${reportStatus}) 조회 중 카드를 펼쳐도 POST를 보내지 않는다`, async ({
+      page,
+    }) => {
+      test.skip(
+        !process.env.E2E_USER_EMAIL || !process.env.E2E_USER_PASSWORD,
+        "E2E_USER_EMAIL / E2E_USER_PASSWORD 가 .env 에 필요합니다.",
+      );
+
+      const { release } = await setupDelayedSharedReport(page, reportStatus);
+
+      let analysisPostCount = 0;
+      await page.route(
+        (url) =>
+          url.pathname.includes("/api/ai/organizations/") &&
+          url.pathname.endsWith("/analysis"),
+        (route) => {
+          analysisPostCount++;
+          void route.abort();
+        },
+      );
+
+      await loginAndReachDashboard(page);
+      await waitForDashboardReady(page);
+
+      // 공유 리포트 응답이 아직 오지 않은 상태(isCheckingSharedReport=true)에서 카드를 펼침
+      await page.getByRole("button", { name: `${CARD_TITLE} 펼치기` }).click();
+
+      // 이제 공유 리포트 응답을 해제 — 사용 가능한 리포트가 있으므로 POST 없어야 함
+      release();
+
+      await page.waitForTimeout(600);
+
+      expect(analysisPostCount).toBe(0);
+    });
+  }
 });


### PR DESCRIPTION
## 🚨 관련 이슈

#377 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `GET /api/ai/organizations/{orgId}/reports` 연동(대시보드 진입 시 조직 공유 최신 리포트 우선 조회)
      - 조회 결과 있을 때: POST 없이 해당 accessToken으로 바로 렌더링 (FAILED 건은 채택 안 함)
      - 조회 결과 없을 때: 카드 펼침 시 기존 POST → 폴링 플로우로 자동 fallback
- 사용자가 "다시 분석" 요청 시: skipSharedLookup = true 설정으로 POST 플로우 명시 실행
- 공유 리포트 렌더링 시 카드에 팀 공유 분석 생성일 표시 (예: `분석 기준 2026.06.24 ~ 2026.07.07 · 팀 공유 분석 (2026.07.05)`)
- 공유 조회 진행 중 카드 펼침 시 결과 없으면 POST fallback 미실행되던 버그 수정

## 😅 미완성 작업
N/A


## 📢 논의 사항 및 참고 사항
N/A

## 스크린샷
<img width="1612" height="1242" alt="스크린샷 2026-08-04 오후 1 37 54" src="https://github.com/user-attachments/assets/34c96098-ba18-4a2f-be4a-8108aabaa77b" />


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 최신 팀 공유 분석 결과가 있으면 해당 결과와 생성 날짜를 우선 표시합니다.
  * 공유 분석 결과를 확인하는 동안 불필요한 분석 요청이 발생하지 않도록 개선했습니다.
  * 공유 결과가 없을 때만 새로운 분석을 실행하며, 재시도 시 기존 상태를 유지합니다.
  * 제공자 또는 워크스페이스 변경 시 분석 상태가 올바르게 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->