### PR TITLE
[Feature/#385] 캠페인 상세 플랫폼 예산 수정 및 ads 훅 패턴 정리

### DIFF
--- a/src/api/ads/budget.ts
+++ b/src/api/ads/budget.ts
@@ -1,0 +1,53 @@
+import type {
+  IMetaGoogleBudgetUpdateData,
+  IMetaGoogleBudgetUpdateRequest,
+  INaverBudgetUpdateData,
+  INaverBudgetUpdateRequest,
+} from "@/types/ads/budget";
+import type { ICommonResponse } from "@/types/common/common";
+
+import { axiosInstance } from "@/lib/axiosInstance";
+
+/**
+ * Meta 캠페인 예산 수정
+ * PATCH /api/meta/campaigns/{adCampaignId}/budget
+ * — daily / lifetime 중 하나만 수정 가능, 기존 유형과 동일해야 함
+ */
+export async function updateMetaCampaignBudget(
+  adCampaignId: number,
+  body: IMetaGoogleBudgetUpdateRequest,
+): Promise<IMetaGoogleBudgetUpdateData> {
+  const { data } = await axiosInstance.patch<
+    ICommonResponse<IMetaGoogleBudgetUpdateData>
+  >(`/api/meta/campaigns/${adCampaignId}/budget`, body);
+  return data.data;
+}
+
+/**
+ * Naver 캠페인 예산 수정
+ * PUT /api/naver/{connectionId}/campaigns/{campaignId}/budget
+ */
+export async function updateNaverCampaignBudget(
+  connectionId: number,
+  campaignId: string,
+  body: INaverBudgetUpdateRequest,
+): Promise<INaverBudgetUpdateData> {
+  const { data } = await axiosInstance.put<
+    ICommonResponse<INaverBudgetUpdateData>
+  >(`/api/naver/${connectionId}/campaigns/${campaignId}/budget`, body);
+  return data.data;
+}
+
+/**
+ * Google 캠페인 예산 수정
+ * PATCH /api/google/campaigns/{adCampaignId}/budget
+ */
+export async function updateGoogleCampaignBudget(
+  adCampaignId: number,
+  body: IMetaGoogleBudgetUpdateRequest,
+): Promise<IMetaGoogleBudgetUpdateData> {
+  const { data } = await axiosInstance.patch<
+    ICommonResponse<IMetaGoogleBudgetUpdateData>
+  >(`/api/google/campaigns/${adCampaignId}/budget`, body);
+  return data.data;
+}

--- a/src/api/ads/budget.ts
+++ b/src/api/ads/budget.ts
@@ -1,8 +1,8 @@
 import type {
   IMetaGoogleBudgetUpdateData,
-  IMetaGoogleBudgetUpdateRequest,
   INaverBudgetUpdateData,
   INaverBudgetUpdateRequest,
+  TMetaGoogleBudgetUpdateRequest,
 } from "@/types/ads/budget";
 import type { ICommonResponse } from "@/types/common/common";
 
@@ -15,7 +15,7 @@ import { axiosInstance } from "@/lib/axiosInstance";
  */
 export async function updateMetaCampaignBudget(
   adCampaignId: number,
-  body: IMetaGoogleBudgetUpdateRequest,
+  body: TMetaGoogleBudgetUpdateRequest,
 ): Promise<IMetaGoogleBudgetUpdateData> {
   const { data } = await axiosInstance.patch<
     ICommonResponse<IMetaGoogleBudgetUpdateData>
@@ -44,7 +44,7 @@ export async function updateNaverCampaignBudget(
  */
 export async function updateGoogleCampaignBudget(
   adCampaignId: number,
-  body: IMetaGoogleBudgetUpdateRequest,
+  body: TMetaGoogleBudgetUpdateRequest,
 ): Promise<IMetaGoogleBudgetUpdateData> {
   const { data } = await axiosInstance.patch<
     ICommonResponse<IMetaGoogleBudgetUpdateData>

--- a/src/components/ads/AdDetailContent.tsx
+++ b/src/components/ads/AdDetailContent.tsx
@@ -4,32 +4,33 @@ import { toast } from "sonner";
 import type { IAd } from "@/types/ads/campaign";
 
 import { useControlModal } from "@/hooks/ads/useControlModal";
+import { useCreateTrackingUrl } from "@/hooks/ads/useCreateTrackingUrl";
 
 import Badge from "../common/badge/Badge";
 import Button from "../common/button/Button";
 import Modal from "../common/modal/Modal";
 import ModalContent from "../common/modal/ModalContent";
 
-import { createTrackingUrl } from "@/api/ads/ads";
 import LinkIcon from "@/assets/icon/common/link.svg?react";
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 
-export default function AdDetailContent({
-  ad,
-  refetchAds,
-}: {
-  ad: IAd;
-  refetchAds: () => void;
-}) {
-  const { orgId } = useParams<{
+export default function AdDetailContent({ ad }: { ad: IAd }) {
+  const { orgId, projectId } = useParams<{
     orgId: string;
     projectId: string;
   }>();
 
+  const orgIdNum = orgId ? Number(orgId) : null;
+  const projectIdNum = projectId ? Number(projectId) : null;
+
+  const { mutateAsync: mutateCreateTrackingUrl } = useCreateTrackingUrl(
+    orgIdNum,
+    projectIdNum,
+  );
+
   const trackControl = useControlModal({
     successMessage: "트래킹 링크가 발급되었습니다.",
     errorMessage: "트래킹 링크 발급에 실패했습니다.",
-    onSuccess: refetchAds,
   });
 
   const isTrackingActive = !!ad.trackingUrl && ad.trackingUrl.length > 0;
@@ -179,7 +180,10 @@ export default function AdDetailContent({
                 );
                 throw new Error("랜딩 URL이 없습니다.");
               }
-              await createTrackingUrl(Number(orgId), ad.id, ad.landingUrl);
+              await mutateCreateTrackingUrl({
+                adContentId: ad.id,
+                landingUrl: ad.landingUrl,
+              });
             })
           }
           isLoading={trackControl.isLoading}

--- a/src/components/ads/AdListTable.tsx
+++ b/src/components/ads/AdListTable.tsx
@@ -13,7 +13,6 @@ import AdRow, {
 
 interface IAdsListTableProps {
   ads: IAd[];
-  refetchAds: () => void;
   embedded?: boolean;
   hidePlatformColumn?: boolean;
   selectedAdIds: ReadonlySet<number>;
@@ -23,7 +22,6 @@ interface IAdsListTableProps {
 
 export default function AdListTable({
   ads,
-  refetchAds,
   embedded = false,
   hidePlatformColumn = false,
   selectedAdIds,
@@ -152,7 +150,7 @@ export default function AdListTable({
 
               {isOpen ? (
                 <div className="w-full min-w-0 origin-top border-b-2 border-surface-400 bg-surface-300">
-                  <AdDetailContent ad={ad} refetchAds={refetchAds} />
+                  <AdDetailContent ad={ad} />
                 </div>
               ) : null}
             </div>

--- a/src/components/ads/CampaignPlatformSection.tsx
+++ b/src/components/ads/CampaignPlatformSection.tsx
@@ -91,7 +91,7 @@ export default function CampaignPlatformSection({
                   size="small"
                   variant="outline"
                   className={twMerge(
-                    "shrink-0",
+                    "h-9 shrink-0 px-3.5",
                     isBudgetEditDisabled && "opacity-60",
                   )}
                   onClick={onEditBudget}

--- a/src/components/ads/CampaignPlatformSection.tsx
+++ b/src/components/ads/CampaignPlatformSection.tsx
@@ -1,10 +1,16 @@
 import type { ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
 
 import type { IPlatformProjectBudget, TPlatform } from "@/types/ads/campaign";
 
+import {
+  BUDGET_EDIT_BLOCK_MESSAGES,
+  canSubmitPlatformBudgetEdit,
+} from "@/utils/ads/budgetEdit";
 import { mapPlatformProjectBudgetToGauges } from "@/utils/ads/projectBudget";
 
 import PlatformBudgetItem from "@/components/ads/PlatformBudgetItem";
+import Button from "@/components/common/button/Button";
 
 import GoogleLogo from "@/assets/logo/social-logo/circle/google-circle.svg?react";
 import MetaLogo from "@/assets/logo/social-logo/circle/meta-circle.svg?react";
@@ -22,21 +28,28 @@ const PLATFORM_LABEL: Record<TPlatform, string> = {
   naver: "NAVER",
 };
 
-const budgetGridClass =
-  "grid grid-cols-2 items-start gap-x-6 gap-y-3 tablet:grid-cols-1 tablet:gap-x-0";
-
 interface ICampaignPlatformSectionProps {
   platform: TPlatform;
   platformBudget?: IPlatformProjectBudget;
+  onEditBudget?: () => void;
 }
 
 export default function CampaignPlatformSection({
   platform,
   platformBudget,
+  onEditBudget,
 }: ICampaignPlatformSectionProps) {
   const gauges = platformBudget
     ? mapPlatformProjectBudgetToGauges(platformBudget)
     : [];
+
+  const editCheck = canSubmitPlatformBudgetEdit(platformBudget);
+  const isBudgetEditDisabled = !onEditBudget || !editCheck.ok;
+  const budgetEditDisabledReason = !onEditBudget
+    ? undefined
+    : editCheck.ok
+      ? undefined
+      : BUDGET_EDIT_BLOCK_MESSAGES[editCheck.reason];
 
   return (
     <section className="flex flex-col gap-4">
@@ -67,9 +80,28 @@ export default function CampaignPlatformSection({
           예산 정보가 없습니다.
         </p>
       ) : (
-        <div className={budgetGridClass}>
+        <div className="w-full min-w-0">
           {gauges.map((gauge) => (
-            <PlatformBudgetItem key={`${platform}-${gauge.label}`} {...gauge} />
+            <PlatformBudgetItem
+              key={`${platform}-${gauge.label}`}
+              {...gauge}
+              headerAction={
+                <Button
+                  type="button"
+                  size="small"
+                  variant="outline"
+                  className={twMerge(
+                    "shrink-0",
+                    isBudgetEditDisabled && "opacity-60",
+                  )}
+                  onClick={onEditBudget}
+                  disabled={isBudgetEditDisabled}
+                  title={budgetEditDisabledReason}
+                >
+                  예산 수정
+                </Button>
+              }
+            />
           ))}
         </div>
       )}

--- a/src/components/ads/CampaignPlatformSection.tsx
+++ b/src/components/ads/CampaignPlatformSection.tsx
@@ -50,6 +50,36 @@ export default function CampaignPlatformSection({
     : editCheck.ok
       ? undefined
       : BUDGET_EDIT_BLOCK_MESSAGES[editCheck.reason];
+  const budgetEditHintId = `budget-edit-hint-${platform}`;
+
+  const budgetEditAction = (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        type="button"
+        size="small"
+        variant="outline"
+        className={twMerge(
+          "h-9 shrink-0 px-3.5",
+          isBudgetEditDisabled && "opacity-60",
+        )}
+        onClick={onEditBudget}
+        disabled={isBudgetEditDisabled}
+        aria-describedby={
+          budgetEditDisabledReason ? budgetEditHintId : undefined
+        }
+      >
+        예산 수정
+      </Button>
+      {budgetEditDisabledReason ? (
+        <p
+          id={budgetEditHintId}
+          className="max-w-48 text-right font-caption text-text-muted"
+        >
+          {budgetEditDisabledReason}
+        </p>
+      ) : null}
+    </div>
+  );
 
   return (
     <section className="flex flex-col gap-4">
@@ -85,22 +115,7 @@ export default function CampaignPlatformSection({
             <PlatformBudgetItem
               key={`${platform}-${gauge.label}`}
               {...gauge}
-              headerAction={
-                <Button
-                  type="button"
-                  size="small"
-                  variant="outline"
-                  className={twMerge(
-                    "h-9 shrink-0 px-3.5",
-                    isBudgetEditDisabled && "opacity-60",
-                  )}
-                  onClick={onEditBudget}
-                  disabled={isBudgetEditDisabled}
-                  title={budgetEditDisabledReason}
-                >
-                  예산 수정
-                </Button>
-              }
+              headerAction={budgetEditAction}
             />
           ))}
         </div>

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -177,9 +177,9 @@ export default function EditPlatformBudgetModal({
       disableOverlayClick={isPending}
     >
       <div className="flex w-full flex-col items-start">
-        <h2 className="mb-2 font-heading3 text-text-title">
+        <p aria-hidden className="mb-2 font-heading3 text-text-title">
           {PROVIDER_LABEL[budget.providerType]} 예산 수정
-        </h2>
+        </p>
         {budget.adCampaignName ? (
           <p className="mb-1 max-w-full truncate font-body2 text-text-muted">
             {budget.adCampaignName}

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -16,6 +16,7 @@ import {
   resolveBudgetEditDefaultValues,
   resolveBudgetEditFieldMeta,
   resolveBudgetEditFormSchema,
+  resolveEffectivePlatformBudget,
   type TBudgetEditModalFormValues,
 } from "@/utils/ads/budgetEdit";
 import {
@@ -139,6 +140,9 @@ export default function EditPlatformBudgetModal({
   const fieldMeta = activeBudget
     ? resolveBudgetEditFieldMeta(activeBudget)
     : null;
+  const effectiveBudget = activeBudget
+    ? resolveEffectivePlatformBudget(activeBudget)
+    : null;
   const budgetFieldName = fieldMeta?.fieldName ?? "dailyBudget";
   const fieldError =
     budgetFieldName === "lifetimeBudget"
@@ -171,13 +175,7 @@ export default function EditPlatformBudgetModal({
 
   if (!activeBudget) return null;
 
-  const currentBudgetAmount =
-    fieldMeta?.fieldName === "lifetimeBudget"
-      ? activeBudget.lifetime.totalBudget
-      : activeBudget.providerType === "NAVER"
-        ? (activeBudget.daily?.totalBudget ?? 0)
-        : (activeBudget.daily?.totalBudget ??
-          activeBudget.lifetime.totalBudget);
+  const currentBudgetAmount = effectiveBudget?.totalBudget ?? 0;
 
   return (
     <Modal
@@ -203,7 +201,7 @@ export default function EditPlatformBudgetModal({
         </p>
 
         <form
-          key={`${activeBudget.providerType}-${activeBudget.activeBudgetType ?? "daily"}`}
+          key={`${activeBudget.providerType}-${effectiveBudget?.activeBudgetType ?? "daily"}`}
           onSubmit={handleSubmit(onSubmit)}
           className="flex w-full flex-col gap-8"
           noValidate

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useMemo } from "react";
-import { type Resolver, type SubmitHandler, useForm } from "react-hook-form";
+import { forwardRef, useEffect, useMemo, useState } from "react";
+import {
+  Controller,
+  type Resolver,
+  type SubmitHandler,
+  useForm,
+} from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 
@@ -13,13 +18,75 @@ import {
   resolveBudgetEditFormSchema,
   type TBudgetEditModalFormValues,
 } from "@/utils/ads/budgetEdit";
+import {
+  extractBudgetInputDigits,
+  formatBudgetInputDisplay,
+  parseBudgetInput,
+} from "@/utils/ads/formatBudgetInput";
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 
 import { useUpdatePlatformBudget } from "@/hooks/ads/useUpdatePlatformBudget";
 
 import Button from "@/components/common/button/Button";
-import Input from "@/components/common/input/Input";
+import Input, { type IInputProps } from "@/components/common/input/Input";
 import Modal from "@/components/common/modal/Modal";
+
+interface IBudgetAmountInputProps extends Omit<
+  IInputProps,
+  "value" | "onChange" | "onBlur" | "type" | "inputMode"
+> {
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+  onBlur?: () => void;
+}
+
+/** 포커스 중: 숫자만 편집, blur: 천 단위 콤마 표시 */
+const BudgetAmountInput = forwardRef<HTMLInputElement, IBudgetAmountInputProps>(
+  function BudgetAmountInput(
+    { value, onChange, onBlur, onFocus, ...props },
+    ref,
+  ) {
+    const [isFocused, setIsFocused] = useState(false);
+    const [editText, setEditText] = useState("");
+
+    useEffect(() => {
+      if (isFocused) return;
+      setEditText(
+        value === undefined || Number.isNaN(value) ? "" : String(value),
+      );
+    }, [isFocused, value]);
+
+    const displayValue = isFocused ? editText : formatBudgetInputDisplay(value);
+
+    return (
+      <Input
+        ref={ref}
+        type="text"
+        inputMode="numeric"
+        {...props}
+        value={displayValue}
+        onFocus={(event) => {
+          setIsFocused(true);
+          setEditText(
+            value === undefined || Number.isNaN(value) ? "" : String(value),
+          );
+          onFocus?.(event);
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          const parsed = parseBudgetInput(editText);
+          onChange(parsed);
+          onBlur?.();
+        }}
+        onChange={(event) => {
+          const digits = extractBudgetInputDigits(event.target.value);
+          setEditText(digits);
+          onChange(parseBudgetInput(digits));
+        }}
+      />
+    );
+  },
+);
 
 const PROVIDER_LABEL: Record<IPlatformProjectBudget["providerType"], string> = {
   META: "Meta",
@@ -51,7 +118,7 @@ export default function EditPlatformBudgetModal({
   );
 
   const {
-    register,
+    control,
     handleSubmit,
     reset,
     formState: { errors },
@@ -61,7 +128,11 @@ export default function EditPlatformBudgetModal({
   });
 
   const fieldMeta = budget ? resolveBudgetEditFieldMeta(budget) : null;
-  const isLifetimeField = fieldMeta?.fieldName === "lifetimeBudget";
+  const budgetFieldName = fieldMeta?.fieldName ?? "dailyBudget";
+  const fieldError =
+    budgetFieldName === "lifetimeBudget"
+      ? errors.lifetimeBudget
+      : errors.dailyBudget;
 
   useEffect(() => {
     if (!isOpen || !budget) return;
@@ -122,33 +193,24 @@ export default function EditPlatformBudgetModal({
           className="flex w-full flex-col gap-8"
           noValidate
         >
-          {isLifetimeField ? (
-            <Input
-              label={fieldMeta?.label}
-              type="number"
-              min={1}
-              step={1}
-              inputMode="numeric"
-              placeholder="금액을 입력해 주세요"
-              disabled={isPending}
-              error={!!errors.lifetimeBudget}
-              helperText={errors.lifetimeBudget?.message}
-              {...register("lifetimeBudget", { valueAsNumber: true })}
-            />
-          ) : (
-            <Input
-              label={fieldMeta?.label}
-              type="number"
-              min={1}
-              step={1}
-              inputMode="numeric"
-              placeholder="금액을 입력해 주세요"
-              disabled={isPending}
-              error={!!errors.dailyBudget}
-              helperText={errors.dailyBudget?.message}
-              {...register("dailyBudget", { valueAsNumber: true })}
-            />
-          )}
+          <Controller
+            name={budgetFieldName}
+            control={control}
+            render={({ field: { onChange, value, onBlur, ref } }) => (
+              <BudgetAmountInput
+                ref={ref}
+                label={fieldMeta?.label}
+                autoComplete="off"
+                placeholder="금액을 입력해 주세요"
+                disabled={isPending}
+                error={!!fieldError}
+                helperText={fieldError?.message}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+              />
+            )}
+          />
 
           <div className="flex w-full gap-3">
             <Button

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import {
   Controller,
   type Resolver,
@@ -97,6 +97,7 @@ const PROVIDER_LABEL: Record<IPlatformProjectBudget["providerType"], string> = {
 interface IEditPlatformBudgetModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onClosed?: () => void;
   budget: IPlatformProjectBudget | null;
   orgId: number;
   projectId: number;
@@ -105,16 +106,24 @@ interface IEditPlatformBudgetModalProps {
 export default function EditPlatformBudgetModal({
   isOpen,
   onClose,
+  onClosed,
   budget,
   orgId,
   projectId,
 }: IEditPlatformBudgetModalProps) {
+  const budgetRef = useRef<IPlatformProjectBudget | null>(null);
+  if (budget) budgetRef.current = budget;
+
+  const activeBudget = budget ?? budgetRef.current;
+
   const { mutate, isPending } = useUpdatePlatformBudget(orgId, projectId);
 
   const schema = useMemo(
     () =>
-      budget ? resolveBudgetEditFormSchema(budget) : dailyBudgetFormSchema,
-    [budget],
+      activeBudget
+        ? resolveBudgetEditFormSchema(activeBudget)
+        : dailyBudgetFormSchema,
+    [activeBudget],
   );
 
   const {
@@ -127,7 +136,9 @@ export default function EditPlatformBudgetModal({
     resolver: zodResolver(schema) as Resolver<TBudgetEditModalFormValues>,
   });
 
-  const fieldMeta = budget ? resolveBudgetEditFieldMeta(budget) : null;
+  const fieldMeta = activeBudget
+    ? resolveBudgetEditFieldMeta(activeBudget)
+    : null;
   const budgetFieldName = fieldMeta?.fieldName ?? "dailyBudget";
   const fieldError =
     budgetFieldName === "lifetimeBudget"
@@ -135,9 +146,9 @@ export default function EditPlatformBudgetModal({
       : errors.dailyBudget;
 
   useEffect(() => {
-    if (!isOpen || !budget) return;
-    reset(resolveBudgetEditDefaultValues(budget));
-  }, [isOpen, budget, reset]);
+    if (!isOpen || !activeBudget) return;
+    reset(resolveBudgetEditDefaultValues(activeBudget));
+  }, [isOpen, activeBudget, reset]);
 
   const handleClose = () => {
     if (isPending) return;
@@ -145,9 +156,9 @@ export default function EditPlatformBudgetModal({
   };
 
   const onSubmit: SubmitHandler<TBudgetEditModalFormValues> = (values) => {
-    if (!budget) return;
+    if (!activeBudget) return;
 
-    mutate(buildUpdatePlatformBudgetVariables(budget, values), {
+    mutate(buildUpdatePlatformBudgetVariables(activeBudget, values), {
       onSuccess: () => {
         toast.success("예산이 수정되었습니다.");
         onClose();
@@ -158,31 +169,33 @@ export default function EditPlatformBudgetModal({
     });
   };
 
-  if (!budget) return null;
+  if (!activeBudget) return null;
 
   const currentBudgetAmount =
     fieldMeta?.fieldName === "lifetimeBudget"
-      ? budget.lifetime.totalBudget
-      : budget.providerType === "NAVER"
-        ? (budget.daily?.totalBudget ?? 0)
-        : (budget.daily?.totalBudget ?? budget.lifetime.totalBudget);
+      ? activeBudget.lifetime.totalBudget
+      : activeBudget.providerType === "NAVER"
+        ? (activeBudget.daily?.totalBudget ?? 0)
+        : (activeBudget.daily?.totalBudget ??
+          activeBudget.lifetime.totalBudget);
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={handleClose}
+      onExitComplete={onClosed}
       size="md"
       padding="lg"
-      title={`${PROVIDER_LABEL[budget.providerType]} 예산 수정`}
+      title={`${PROVIDER_LABEL[activeBudget.providerType]} 예산 수정`}
       disableOverlayClick={isPending}
     >
       <div className="flex w-full flex-col items-start">
         <p aria-hidden className="mb-2 font-heading3 text-text-title">
-          {PROVIDER_LABEL[budget.providerType]} 예산 수정
+          {PROVIDER_LABEL[activeBudget.providerType]} 예산 수정
         </p>
-        {budget.adCampaignName ? (
+        {activeBudget.adCampaignName ? (
           <p className="mb-1 max-w-full truncate font-body2 text-text-muted">
-            {budget.adCampaignName}
+            {activeBudget.adCampaignName}
           </p>
         ) : null}
         <p className="mb-5 font-body2 text-text-muted">
@@ -190,7 +203,7 @@ export default function EditPlatformBudgetModal({
         </p>
 
         <form
-          key={`${budget.providerType}-${budget.activeBudgetType ?? "daily"}`}
+          key={`${activeBudget.providerType}-${activeBudget.activeBudgetType ?? "daily"}`}
           onSubmit={handleSubmit(onSubmit)}
           className="flex w-full flex-col gap-8"
           noValidate

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo } from "react";
+import { type Resolver, type SubmitHandler, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+
+import type { IPlatformProjectBudget } from "@/types/ads/campaign";
+
+import {
+  buildUpdatePlatformBudgetVariables,
+  dailyBudgetFormSchema,
+  resolveBudgetEditDefaultValues,
+  resolveBudgetEditFieldMeta,
+  resolveBudgetEditFormSchema,
+  type TBudgetEditModalFormValues,
+} from "@/utils/ads/budgetEdit";
+import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
+
+import { useUpdatePlatformBudget } from "@/hooks/ads/useUpdatePlatformBudget";
+
+import Button from "@/components/common/button/Button";
+import Input from "@/components/common/input/Input";
+import Modal from "@/components/common/modal/Modal";
+
+const PROVIDER_LABEL: Record<IPlatformProjectBudget["providerType"], string> = {
+  META: "Meta",
+  GOOGLE: "Google",
+  NAVER: "NAVER",
+};
+
+interface IEditPlatformBudgetModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  budget: IPlatformProjectBudget | null;
+  orgId: number;
+  projectId: number;
+}
+
+export default function EditPlatformBudgetModal({
+  isOpen,
+  onClose,
+  budget,
+  orgId,
+  projectId,
+}: IEditPlatformBudgetModalProps) {
+  const { mutate, isPending } = useUpdatePlatformBudget(orgId, projectId);
+
+  const schema = useMemo(
+    () =>
+      budget ? resolveBudgetEditFormSchema(budget) : dailyBudgetFormSchema,
+    [budget],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<TBudgetEditModalFormValues>({
+    mode: "onChange",
+    resolver: zodResolver(schema) as Resolver<TBudgetEditModalFormValues>,
+  });
+
+  const fieldMeta = budget ? resolveBudgetEditFieldMeta(budget) : null;
+  const isLifetimeField = fieldMeta?.fieldName === "lifetimeBudget";
+
+  useEffect(() => {
+    if (!isOpen || !budget) return;
+    reset(resolveBudgetEditDefaultValues(budget));
+  }, [isOpen, budget, reset]);
+
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const onSubmit: SubmitHandler<TBudgetEditModalFormValues> = (values) => {
+    if (!budget) return;
+
+    mutate(buildUpdatePlatformBudgetVariables(budget, values), {
+      onSuccess: () => {
+        toast.success("예산이 수정되었습니다.");
+        onClose();
+      },
+      onError: (error) => {
+        toast.error(error.message ?? "예산 수정에 실패했습니다.");
+      },
+    });
+  };
+
+  if (!budget) return null;
+
+  const currentBudgetAmount =
+    fieldMeta?.fieldName === "lifetimeBudget"
+      ? budget.lifetime.totalBudget
+      : (budget.daily?.totalBudget ?? budget.lifetime.totalBudget);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="md"
+      padding="lg"
+      title={`${PROVIDER_LABEL[budget.providerType]} 예산 수정`}
+      disableOverlayClick={isPending}
+    >
+      <div className="flex w-full flex-col items-start">
+        <h2 className="mb-2 font-heading3 text-text-title">
+          {PROVIDER_LABEL[budget.providerType]} 예산 수정
+        </h2>
+        {budget.adCampaignName ? (
+          <p className="mb-1 max-w-full truncate font-body2 text-text-muted">
+            {budget.adCampaignName}
+          </p>
+        ) : null}
+        <p className="mb-5 font-body2 text-text-muted">
+          현재 {fieldMeta?.label}: {M.spend.format(currentBudgetAmount)}
+        </p>
+
+        <form
+          key={`${budget.providerType}-${budget.activeBudgetType ?? "daily"}`}
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex w-full flex-col gap-8"
+          noValidate
+        >
+          {isLifetimeField ? (
+            <Input
+              label={fieldMeta?.label}
+              type="number"
+              min={1}
+              step={1}
+              inputMode="numeric"
+              placeholder="금액을 입력해 주세요"
+              disabled={isPending}
+              error={!!errors.lifetimeBudget}
+              helperText={errors.lifetimeBudget?.message}
+              {...register("lifetimeBudget", { valueAsNumber: true })}
+            />
+          ) : (
+            <Input
+              label={fieldMeta?.label}
+              type="number"
+              min={1}
+              step={1}
+              inputMode="numeric"
+              placeholder="금액을 입력해 주세요"
+              disabled={isPending}
+              error={!!errors.dailyBudget}
+              helperText={errors.dailyBudget?.message}
+              {...register("dailyBudget", { valueAsNumber: true })}
+            />
+          )}
+
+          <div className="flex w-full gap-3">
+            <Button
+              type="button"
+              size="big"
+              variant="outline"
+              fullWidth
+              disabled={isPending}
+              onClick={handleClose}
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              size="big"
+              variant="primary"
+              fullWidth
+              isLoading={isPending}
+              disabled={isPending}
+            >
+              {isPending ? "저장 중..." : "저장하기"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -163,7 +163,9 @@ export default function EditPlatformBudgetModal({
   const currentBudgetAmount =
     fieldMeta?.fieldName === "lifetimeBudget"
       ? budget.lifetime.totalBudget
-      : (budget.daily?.totalBudget ?? budget.lifetime.totalBudget);
+      : budget.providerType === "NAVER"
+        ? (budget.daily?.totalBudget ?? 0)
+        : (budget.daily?.totalBudget ?? budget.lifetime.totalBudget);
 
   return (
     <Modal

--- a/src/components/ads/PlatformBudgetItem.tsx
+++ b/src/components/ads/PlatformBudgetItem.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 
 import type { IBudgetGaugeProps } from "@/types/dashboard/budget";
@@ -10,12 +11,15 @@ import { useIsMounted } from "@/hooks/common/useIsMounted";
 interface IPlatformBudgetItemProps extends Pick<
   IBudgetGaugeProps,
   "label" | "totalBudget" | "spent"
-> {}
+> {
+  headerAction?: ReactNode;
+}
 
 export default function PlatformBudgetItem({
   label,
   totalBudget,
   spent,
+  headerAction,
 }: IPlatformBudgetItemProps) {
   const mounted = useIsMounted();
 
@@ -31,14 +35,19 @@ export default function PlatformBudgetItem({
       className="flex min-w-0 flex-col gap-3 rounded-xl border border-surface-400/70 bg-surface-100 px-4 py-4"
       aria-label={`${label} 예산`}
     >
-      <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
-        <span className="font-caption text-text-placeholder">{label}</span>
-        <div className="flex items-baseline gap-2">
-          <span className="font-heading4 text-text-title tabular-nums leading-none">
-            {remainingPct}%
-          </span>
-          <span className="font-caption text-text-body tabular-nums">남음</span>
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="font-caption text-text-placeholder">{label}</span>
+          <div className="flex items-baseline gap-2">
+            <span className="font-heading4 text-text-title tabular-nums leading-none">
+              {remainingPct}%
+            </span>
+            <span className="font-caption text-text-body tabular-nums">
+              남음
+            </span>
+          </div>
         </div>
+        {headerAction ? <div className="shrink-0">{headerAction}</div> : null}
       </div>
 
       <div

--- a/src/components/ads/PlatformBudgetItem.tsx
+++ b/src/components/ads/PlatformBudgetItem.tsx
@@ -32,19 +32,25 @@ export default function PlatformBudgetItem({
 
   return (
     <article
-      className="flex min-w-0 flex-col gap-3 rounded-xl border border-surface-400/70 bg-surface-100 px-4 py-4"
+      className={twMerge(
+        "flex min-w-0 flex-col rounded-xl border border-surface-400/70 bg-surface-100 px-4 py-4",
+        headerAction ? "gap-2" : "gap-3",
+      )}
       aria-label={`${label} 예산`}
     >
-      <div className="flex min-w-0 items-start justify-between gap-3">
-        <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
-          <span className="font-caption text-text-placeholder">{label}</span>
+      <div
+        className={twMerge(
+          "flex min-w-0 justify-between gap-3",
+          headerAction ? "items-center" : "items-start",
+        )}
+      >
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="font-body2 text-text-placeholder">{label}</span>
           <div className="flex items-baseline gap-2">
             <span className="font-heading4 text-text-title tabular-nums leading-none">
               {remainingPct}%
             </span>
-            <span className="font-caption text-text-body tabular-nums">
-              남음
-            </span>
+            <span className="font-body2 text-text-body tabular-nums">남음</span>
           </div>
         </div>
         {headerAction ? <div className="shrink-0">{headerAction}</div> : null}
@@ -56,7 +62,7 @@ export default function PlatformBudgetItem({
         aria-valuenow={remainingPct}
         aria-valuemin={0}
         aria-valuemax={100}
-        className="relative h-2 w-full overflow-hidden rounded-full bg-surface-200"
+        className="relative h-2.5 w-full overflow-hidden rounded-full bg-surface-200"
       >
         <div
           className="absolute top-0 left-0 h-full w-full origin-left rounded-full bg-info-blue transition-transform duration-700 ease-smooth"

--- a/src/components/ads/skeleton/AdsSkeleton.tsx
+++ b/src/components/ads/skeleton/AdsSkeleton.tsx
@@ -210,10 +210,7 @@ export function CampaignDetailAdsSectionSkeleton() {
             <Skeleton className="h-6 w-24" />
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-3 tablet:grid-cols-1 tablet:gap-x-0">
-          <Skeleton className="h-28 rounded-xl border border-surface-400/70" />
-          <Skeleton className="h-28 rounded-xl border border-surface-400/70" />
-        </div>
+        <Skeleton className="h-28 w-full rounded-xl border border-surface-400/70" />
         <AdListTableSkeleton hidePlatformColumn embedded />
       </div>
     </Card>

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -46,6 +46,7 @@ export interface IModalProps {
   hideCloseButton?: boolean;
   disableOverlayClick?: boolean;
   title?: string;
+  onExitComplete?: () => void;
 }
 
 const easeOut = [0, 0, 0.2, 1] as const;
@@ -61,6 +62,7 @@ function Modal({
   hideCloseButton = false,
   disableOverlayClick = false,
   title,
+  onExitComplete,
 }: IModalProps) {
   const reduceMotion = useReducedMotion();
   const modalRef = useRef<HTMLDivElement>(null);
@@ -87,7 +89,8 @@ function Modal({
   const handleExitComplete = useCallback(() => {
     setScrollLocked(false);
     previousActiveElement.current?.focus();
-  }, []);
+    onExitComplete?.();
+  }, [onExitComplete]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/hooks/ads/useAdList.ts
+++ b/src/hooks/ads/useAdList.ts
@@ -1,34 +1,35 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { toast } from "sonner";
 
 import type { IAd } from "@/types/ads/campaign";
-import type { IApiErrorResponse } from "@/types/common/common";
+
+import { useCoreQuery } from "@/hooks/customQuery";
 
 import { getAdList } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 
 export const useAdList = (orgId: number | null, projectId: number | null) => {
-  const [ads, setAds] = useState<IAd[]>([]);
-  const [isAdLoading, setIsAdLoading] = useState(false);
+  const isValid =
+    orgId != null &&
+    projectId != null &&
+    Number.isFinite(orgId) &&
+    orgId > 0 &&
+    Number.isFinite(projectId) &&
+    projectId > 0;
 
-  const fetchAds = async () => {
-    if (!orgId || !projectId) return;
-    try {
-      setIsAdLoading(true);
-      const result = await getAdList(orgId, projectId);
-      setAds(result);
-    } catch (e) {
-      toast.error(
-        (e as IApiErrorResponse).message ??
-          "연결된 광고를 불러오지 못했습니다.",
-      );
-    } finally {
-      setIsAdLoading(false);
-    }
-  };
+  const { data, isLoading, error, isError } = useCoreQuery<IAd[]>(
+    QUERY_KEYS.campaign.ads(orgId!, projectId!),
+    () => getAdList(orgId!, projectId!),
+    { enabled: isValid },
+  );
 
   useEffect(() => {
-    fetchAds();
-  }, [orgId, projectId]);
+    if (!isError) return;
+    toast.error(error.message ?? "연결된 광고를 불러오지 못했습니다.");
+  }, [isError, error]);
 
-  return { ads, isAdLoading, refetchAds: fetchAds };
+  return {
+    ads: data ?? [],
+    isAdLoading: isLoading,
+  };
 };

--- a/src/hooks/ads/useCreateTrackingUrl.ts
+++ b/src/hooks/ads/useCreateTrackingUrl.ts
@@ -1,0 +1,31 @@
+import { useCoreMutation } from "@/hooks/customQuery";
+
+import { createTrackingUrl } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+
+/** AdDetailContent — 트래킹 URL 발급 */
+export interface ICreateTrackingUrlVariables {
+  adContentId: number;
+  landingUrl: string;
+}
+
+export function useCreateTrackingUrl(
+  orgId: number | null,
+  projectId: number | null,
+) {
+  return useCoreMutation<void, ICreateTrackingUrlVariables>(
+    async (vars) => {
+      if (orgId == null) {
+        throw new Error("워크스페이스 정보가 없습니다.");
+      }
+
+      await createTrackingUrl(orgId, vars.adContentId, vars.landingUrl);
+    },
+    {
+      invalidateKeys:
+        orgId != null && projectId != null
+          ? [QUERY_KEYS.campaign.ads(orgId, projectId)]
+          : [],
+    },
+  );
+}

--- a/src/hooks/ads/useUpdateAdStatus.ts
+++ b/src/hooks/ads/useUpdateAdStatus.ts
@@ -1,4 +1,11 @@
+import { useQueryClient } from "@tanstack/react-query";
+
 import type { TStatus } from "@/types/ads/campaign";
+
+import {
+  assertBulkSettleResult,
+  settleBulkRequests,
+} from "@/utils/ads/settleBulkRequests";
 
 import { useCoreMutation } from "@/hooks/customQuery";
 
@@ -15,6 +22,8 @@ export function useUpdateAdStatus(
   orgId: number | null,
   projectId: number | null,
 ) {
+  const queryClient = useQueryClient();
+
   return useCoreMutation<void, IUpdateAdStatusVariables>(
     async (vars) => {
       if (orgId == null || projectId == null) {
@@ -23,11 +32,22 @@ export function useUpdateAdStatus(
 
       if (vars.adContentIds.length === 0) return;
 
-      await Promise.all(
+      const result = await settleBulkRequests(
         vars.adContentIds.map((adContentId) =>
           updateAdStatus(orgId, projectId, adContentId, vars.status),
         ),
       );
+
+      if (result.successCount > 0 && result.successCount < result.total) {
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.campaign.ads(orgId, projectId),
+        });
+      }
+
+      assertBulkSettleResult(result, {
+        partial: (successCount, total) =>
+          `${total}개 중 ${successCount}개 광고 소재만 반영되었습니다.`,
+      });
     },
     {
       invalidateKeys:

--- a/src/hooks/ads/useUpdateAdStatus.ts
+++ b/src/hooks/ads/useUpdateAdStatus.ts
@@ -1,0 +1,39 @@
+import type { TStatus } from "@/types/ads/campaign";
+
+import { useCoreMutation } from "@/hooks/customQuery";
+
+import { updateAdStatus } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+
+/** CampaignDetail — 선택/전체 광고 소재 status 변경 (id 목록은 페이지에서 계산) */
+export interface IUpdateAdStatusVariables {
+  adContentIds: number[];
+  status: Extract<TStatus, "ON_GOING" | "PAUSED">;
+}
+
+export function useUpdateAdStatus(
+  orgId: number | null,
+  projectId: number | null,
+) {
+  return useCoreMutation<void, IUpdateAdStatusVariables>(
+    async (vars) => {
+      if (orgId == null || projectId == null) {
+        throw new Error("캠페인 정보가 없습니다.");
+      }
+
+      if (vars.adContentIds.length === 0) return;
+
+      await Promise.all(
+        vars.adContentIds.map((adContentId) =>
+          updateAdStatus(orgId, projectId, adContentId, vars.status),
+        ),
+      );
+    },
+    {
+      invalidateKeys:
+        orgId != null && projectId != null
+          ? [QUERY_KEYS.campaign.ads(orgId, projectId)]
+          : [],
+    },
+  );
+}

--- a/src/hooks/ads/useUpdateCampaignStatus.ts
+++ b/src/hooks/ads/useUpdateCampaignStatus.ts
@@ -1,4 +1,11 @@
+import { useQueryClient } from "@tanstack/react-query";
+
 import type { TStatus } from "@/types/ads/campaign";
+
+import {
+  assertBulkSettleResult,
+  settleBulkRequests,
+} from "@/utils/ads/settleBulkRequests";
 
 import { useCoreMutation } from "@/hooks/customQuery";
 
@@ -13,6 +20,8 @@ export interface IUpdateCampaignStatusVariables {
 }
 
 export function useUpdateCampaignStatus(orgId: number | null) {
+  const queryClient = useQueryClient();
+
   return useCoreMutation<void, IUpdateCampaignStatusVariables>(
     async (vars) => {
       if (orgId == null) {
@@ -27,11 +36,22 @@ export function useUpdateCampaignStatus(orgId: number | null) {
       const projectIds = vars.projectIds ?? [];
       if (projectIds.length === 0) return;
 
-      await Promise.all(
+      const result = await settleBulkRequests(
         projectIds.map((projectId) =>
           updateCampaignStatus(orgId, projectId, vars.status),
         ),
       );
+
+      if (result.successCount > 0 && result.successCount < result.total) {
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.campaign.list(orgId),
+        });
+      }
+
+      assertBulkSettleResult(result, {
+        partial: (successCount, total) =>
+          `${total}개 중 ${successCount}개 캠페인만 반영되었습니다.`,
+      });
     },
     {
       invalidateKeys: orgId != null ? [QUERY_KEYS.campaign.list(orgId)] : [],

--- a/src/hooks/ads/useUpdateCampaignStatus.ts
+++ b/src/hooks/ads/useUpdateCampaignStatus.ts
@@ -1,0 +1,40 @@
+import type { TStatus } from "@/types/ads/campaign";
+
+import { useCoreMutation } from "@/hooks/customQuery";
+
+import { updateAllCampaignStatus, updateCampaignStatus } from "@/api/ads/ads";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+
+/** AdsListPage — 일괄 / 선택 캠페인 status 변경 */
+export interface IUpdateCampaignStatusVariables {
+  scope: "all" | "selection";
+  status: Extract<TStatus, "ON_GOING" | "PAUSED">;
+  projectIds?: number[];
+}
+
+export function useUpdateCampaignStatus(orgId: number | null) {
+  return useCoreMutation<void, IUpdateCampaignStatusVariables>(
+    async (vars) => {
+      if (orgId == null) {
+        throw new Error("워크스페이스 정보가 없습니다.");
+      }
+
+      if (vars.scope === "all") {
+        await updateAllCampaignStatus(orgId, vars.status);
+        return;
+      }
+
+      const projectIds = vars.projectIds ?? [];
+      if (projectIds.length === 0) return;
+
+      await Promise.all(
+        projectIds.map((projectId) =>
+          updateCampaignStatus(orgId, projectId, vars.status),
+        ),
+      );
+    },
+    {
+      invalidateKeys: orgId != null ? [QUERY_KEYS.campaign.list(orgId)] : [],
+    },
+  );
+}

--- a/src/hooks/ads/useUpdatePlatformBudget.ts
+++ b/src/hooks/ads/useUpdatePlatformBudget.ts
@@ -1,0 +1,75 @@
+import type { TPlatformBudgetType } from "@/types/ads/budget";
+import type { TProvider } from "@/types/ads/campaign";
+
+import {
+  buildMetaGoogleBudgetPayload,
+  buildNaverBudgetPayload,
+} from "@/utils/ads/budgetEdit";
+
+import { useCoreMutation } from "@/hooks/customQuery";
+
+import {
+  updateGoogleCampaignBudget,
+  updateMetaCampaignBudget,
+  updateNaverCampaignBudget,
+} from "@/api/ads/budget";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+
+/** Step 6 모달 submit → mutation 변수 */
+export interface IUpdatePlatformBudgetVariables {
+  providerType: TProvider;
+  adCampaignId?: number;
+  activeBudgetType?: TPlatformBudgetType;
+  naverConnectionId?: number;
+  naverCampaignId?: string;
+  dailyBudget?: number;
+  lifetimeBudget?: number;
+}
+
+export function useUpdatePlatformBudget(orgId: number, projectId: number) {
+  return useCoreMutation<void, IUpdatePlatformBudgetVariables>(
+    async (vars) => {
+      switch (vars.providerType) {
+        case "META": {
+          if (!vars.adCampaignId || !vars.activeBudgetType) {
+            throw new Error("Meta 예산 수정 정보가 부족합니다.");
+          }
+          await updateMetaCampaignBudget(
+            vars.adCampaignId,
+            buildMetaGoogleBudgetPayload(vars.activeBudgetType, vars),
+          );
+          return;
+        }
+        case "GOOGLE": {
+          if (!vars.adCampaignId || !vars.activeBudgetType) {
+            throw new Error("Google 예산 수정 정보가 부족합니다.");
+          }
+          await updateGoogleCampaignBudget(
+            vars.adCampaignId,
+            buildMetaGoogleBudgetPayload(vars.activeBudgetType, vars),
+          );
+          return;
+        }
+        case "NAVER": {
+          if (!vars.naverConnectionId || !vars.naverCampaignId) {
+            throw new Error("Naver 예산 수정 정보가 부족합니다.");
+          }
+          if (vars.dailyBudget === undefined) {
+            throw new Error("일일 예산을 입력해 주세요.");
+          }
+          await updateNaverCampaignBudget(
+            vars.naverConnectionId,
+            vars.naverCampaignId,
+            buildNaverBudgetPayload(vars.dailyBudget),
+          );
+          return;
+        }
+        default:
+          throw new Error("지원하지 않는 플랫폼입니다.");
+      }
+    },
+    {
+      invalidateKeys: [QUERY_KEYS.campaign.detail(orgId, projectId)],
+    },
+  );
+}

--- a/src/hooks/ads/useUpdatePlatformBudget.ts
+++ b/src/hooks/ads/useUpdatePlatformBudget.ts
@@ -34,6 +34,18 @@ export function useUpdatePlatformBudget(orgId: number, projectId: number) {
           if (!vars.adCampaignId || !vars.activeBudgetType) {
             throw new Error("Meta 예산 수정 정보가 부족합니다.");
           }
+          if (
+            vars.activeBudgetType === "DAILY" &&
+            vars.dailyBudget === undefined
+          ) {
+            throw new Error("일일 예산을 입력해 주세요.");
+          }
+          if (
+            vars.activeBudgetType === "LIFETIME" &&
+            vars.lifetimeBudget === undefined
+          ) {
+            throw new Error("전체 예산을 입력해 주세요.");
+          }
           await updateMetaCampaignBudget(
             vars.adCampaignId,
             buildMetaGoogleBudgetPayload(vars.activeBudgetType, vars),
@@ -43,6 +55,18 @@ export function useUpdatePlatformBudget(orgId: number, projectId: number) {
         case "GOOGLE": {
           if (!vars.adCampaignId || !vars.activeBudgetType) {
             throw new Error("Google 예산 수정 정보가 부족합니다.");
+          }
+          if (
+            vars.activeBudgetType === "DAILY" &&
+            vars.dailyBudget === undefined
+          ) {
+            throw new Error("일일 예산을 입력해 주세요.");
+          }
+          if (
+            vars.activeBudgetType === "LIFETIME" &&
+            vars.lifetimeBudget === undefined
+          ) {
+            throw new Error("전체 예산을 입력해 주세요.");
           }
           await updateGoogleCampaignBudget(
             vars.adCampaignId,

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -31,6 +31,9 @@ export const QUERY_KEYS = {
     /** 캠페인 그룹 상세 */
     detail: (orgId: number, projectId: number) =>
       ["campaignDetail", orgId, projectId] as const,
+    /** 프로젝트별(캠페인) 광고 소재 목록 (CampaignDetail · useAdList) */
+    ads: (orgId: number, projectId: number) =>
+      ["adList", orgId, projectId] as const,
     /** 플랫폼별 연결 가능한 캠페인 목록 */
     platformList: (orgId: number | null, platform: string) =>
       ["platformCampaigns", orgId, platform] as const,

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { useControlModal } from "@/hooks/ads/useControlModal";
+import { useUpdateCampaignStatus } from "@/hooks/ads/useUpdateCampaignStatus";
 import { useOverviewCampaignList } from "@/hooks/dashboard/useOverviewCampaignList";
 
 import CampaignTable from "@/components/ads/CampaignTable";
@@ -14,17 +14,15 @@ import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
 
-import { updateAllCampaignStatus, updateCampaignStatus } from "@/api/ads/ads";
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
-import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export default function AdsListPage() {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
   const { data: campaigns = [], isLoading } = useOverviewCampaignList();
+  const { mutateAsync: mutateCampaignStatus } = useUpdateCampaignStatus(orgId);
 
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<number>>(
     () => new Set(),
@@ -32,12 +30,6 @@ export default function AdsListPage() {
 
   const [pauseScope, setPauseScope] = useState<"selection" | "all">("all");
   const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
-
-  const invalidateCampaigns = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.campaign.list(orgId),
-    });
-  }, [queryClient, orgId]);
 
   const clearSelection = useCallback(() => {
     setSelectedIds(new Set());
@@ -103,19 +95,13 @@ export default function AdsListPage() {
   const bulkStop = useControlModal({
     successMessage: "캠페인 운영 상태가 반영되었습니다.",
     errorMessage: "중단 처리에 실패하였습니다.",
-    onSuccess: () => {
-      invalidateCampaigns();
-      clearSelection();
-    },
+    onSuccess: clearSelection,
   });
 
   const bulkResume = useControlModal({
     successMessage: "캠페인 운영 상태가 반영되었습니다.",
     errorMessage: "재개 처리에 실패하였습니다.",
-    onSuccess: () => {
-      invalidateCampaigns();
-      clearSelection();
-    },
+    onSuccess: clearSelection,
   });
 
   const openPauseModal = () => {
@@ -251,18 +237,14 @@ export default function AdsListPage() {
           detailListTitle="중단 대상 캠페인"
           buttonText="중단하기"
           onConfirm={() =>
-            bulkStop.handleConfirm(async () => {
-              if (!orgId) return;
-              if (pauseScope === "all") {
-                await updateAllCampaignStatus(orgId, "PAUSED");
-              } else {
-                await Promise.all(
-                  selectedOngoingIds.map((projectId) =>
-                    updateCampaignStatus(orgId, projectId, "PAUSED"),
-                  ),
-                );
-              }
-            })
+            bulkStop.handleConfirm(() =>
+              mutateCampaignStatus({
+                scope: pauseScope,
+                status: "PAUSED",
+                projectIds:
+                  pauseScope === "selection" ? selectedOngoingIds : undefined,
+              }),
+            )
           }
           isLoading={bulkStop.isLoading}
           variant="danger"
@@ -290,18 +272,14 @@ export default function AdsListPage() {
           detailListTitle="재개 대상 캠페인"
           buttonText="재개하기"
           onConfirm={() =>
-            bulkResume.handleConfirm(async () => {
-              if (!orgId) return;
-              if (resumeScope === "all") {
-                await updateAllCampaignStatus(orgId, "ON_GOING");
-              } else {
-                await Promise.all(
-                  selectedPausedIds.map((projectId) =>
-                    updateCampaignStatus(orgId, projectId, "ON_GOING"),
-                  ),
-                );
-              }
-            })
+            bulkResume.handleConfirm(() =>
+              mutateCampaignStatus({
+                scope: resumeScope,
+                status: "ON_GOING",
+                projectIds:
+                  resumeScope === "selection" ? selectedPausedIds : undefined,
+              }),
+            )
           }
           isLoading={bulkResume.isLoading}
           variant="primary"

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -12,6 +12,7 @@ import {
 import { useAdList } from "@/hooks/ads/useAdList";
 import { useCampaignDetail } from "@/hooks/ads/useCampaignDetail";
 import { useControlModal } from "@/hooks/ads/useControlModal";
+import { useUpdateAdStatus } from "@/hooks/ads/useUpdateAdStatus";
 
 import AdListTable from "@/components/ads/AdListTable";
 import CampaignPlatformSection from "@/components/ads/CampaignPlatformSection";
@@ -28,7 +29,6 @@ import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import Modal from "@/components/common/modal/Modal";
 import ModalContent from "@/components/common/modal/ModalContent";
 
-import { updateAdStatus } from "@/api/ads/ads";
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 import type { TMainLayoutOutletContext } from "@/layout/main/MainLayout";
 
@@ -61,7 +61,11 @@ export default function CampaignDetail() {
 
   const { data, isLoading } = useCampaignDetail();
 
-  const { ads, isAdLoading, refetchAds } = useAdList(orgIdNum, projectIdNum);
+  const { ads, isAdLoading } = useAdList(orgIdNum, projectIdNum);
+  const { mutateAsync: mutateAdStatus } = useUpdateAdStatus(
+    orgIdNum,
+    projectIdNum,
+  );
 
   const { setCampaignDetailHeaderTitle } =
     useOutletContext<TMainLayoutOutletContext>();
@@ -142,19 +146,13 @@ export default function CampaignDetail() {
   const bulkAdPause = useControlModal({
     successMessage: "광고 소재 운영 상태가 반영되었습니다.",
     errorMessage: "중단 처리에 실패했습니다.",
-    onSuccess: () => {
-      void refetchAds();
-      clearAdSelection();
-    },
+    onSuccess: clearAdSelection,
   });
 
   const bulkAdResume = useControlModal({
     successMessage: "광고 소재 운영 상태가 반영되었습니다.",
     errorMessage: "재개 처리에 실패했습니다.",
-    onSuccess: () => {
-      void refetchAds();
-      clearAdSelection();
-    },
+    onSuccess: clearAdSelection,
   });
 
   const openAdPauseModal = () => {
@@ -380,7 +378,6 @@ export default function CampaignDetail() {
                         embedded
                         hidePlatformColumn
                         ads={platformAds}
-                        refetchAds={refetchAds}
                         selectedAdIds={selectedAdIds}
                         onToggleAd={toggleAd}
                         onToggleSelectAllVisible={toggleSelectAllVisible}
@@ -423,20 +420,17 @@ export default function CampaignDetail() {
           detailListTitle="중단 대상 광고"
           buttonText="중단하기"
           onConfirm={() =>
-            bulkAdPause.handleConfirm(async () => {
-              if (orgIdNum == null || projectIdNum == null) return;
-              const ids =
-                pauseScope === "all"
-                  ? adsList
-                      .filter((a) => a.status === "ON_GOING")
-                      .map((a) => a.id)
-                  : selectedOngoingIds;
-              await Promise.all(
-                ids.map((adContentId) =>
-                  updateAdStatus(orgIdNum, projectIdNum, adContentId, "PAUSED"),
-                ),
-              );
-            })
+            bulkAdPause.handleConfirm(() =>
+              mutateAdStatus({
+                adContentIds:
+                  pauseScope === "all"
+                    ? adsList
+                        .filter((a) => a.status === "ON_GOING")
+                        .map((a) => a.id)
+                    : selectedOngoingIds,
+                status: "PAUSED",
+              }),
+            )
           }
           isLoading={bulkAdPause.isLoading}
           variant="danger"
@@ -464,25 +458,17 @@ export default function CampaignDetail() {
           detailListTitle="재개 대상 광고"
           buttonText="재개하기"
           onConfirm={() =>
-            bulkAdResume.handleConfirm(async () => {
-              if (orgIdNum == null || projectIdNum == null) return;
-              const ids =
-                resumeScope === "all"
-                  ? adsList
-                      .filter((a) => a.status === "PAUSED")
-                      .map((a) => a.id)
-                  : selectedPausedIds;
-              await Promise.all(
-                ids.map((adContentId) =>
-                  updateAdStatus(
-                    orgIdNum,
-                    projectIdNum,
-                    adContentId,
-                    "ON_GOING",
-                  ),
-                ),
-              );
-            })
+            bulkAdResume.handleConfirm(() =>
+              mutateAdStatus({
+                adContentIds:
+                  resumeScope === "all"
+                    ? adsList
+                        .filter((a) => a.status === "PAUSED")
+                        .map((a) => a.id)
+                    : selectedPausedIds,
+                status: "ON_GOING",
+              }),
+            )
           }
           isLoading={bulkAdResume.isLoading}
           variant="primary"

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
 
-import type { TPlatform } from "@/types/ads/campaign";
+import type { IPlatformProjectBudget, TPlatform } from "@/types/ads/campaign";
 
 import { AD_PLATFORM_ORDER, groupAdsByPlatform } from "@/utils/ads/adPlatform";
 import {
@@ -15,6 +15,7 @@ import { useControlModal } from "@/hooks/ads/useControlModal";
 
 import AdListTable from "@/components/ads/AdListTable";
 import CampaignPlatformSection from "@/components/ads/CampaignPlatformSection";
+import EditPlatformBudgetModal from "@/components/ads/EditPlatformBudgetModal";
 import {
   CampaignDetailAdsSectionSkeleton,
   CampaignDetailPageSkeleton,
@@ -72,6 +73,9 @@ export default function CampaignDetail() {
   );
   const [pauseScope, setPauseScope] = useState<"selection" | "all">("all");
   const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
+
+  const [budgetEditTarget, setBudgetEditTarget] =
+    useState<IPlatformProjectBudget | null>(null);
 
   const clearAdSelection = useCallback(() => {
     setSelectedAdIds(new Set());
@@ -362,6 +366,10 @@ export default function CampaignDetail() {
                   <CampaignPlatformSection
                     platform={platform}
                     platformBudget={budgetByPlatform.get(platform)}
+                    onEditBudget={() => {
+                      const budget = budgetByPlatform.get(platform);
+                      if (budget) setBudgetEditTarget(budget);
+                    }}
                   />
                   {platformAds.length > 0 ? (
                     <ErrorBoundary
@@ -480,6 +488,17 @@ export default function CampaignDetail() {
           variant="primary"
         />
       </Modal>
+      {orgIdNum != null && projectIdNum != null ? (
+        <EditPlatformBudgetModal
+          isOpen={!!budgetEditTarget}
+          onClose={() => {
+            setBudgetEditTarget(null);
+          }}
+          budget={budgetEditTarget ?? null}
+          orgId={orgIdNum}
+          projectId={projectIdNum}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -80,6 +80,7 @@ export default function CampaignDetail() {
 
   const [budgetEditTarget, setBudgetEditTarget] =
     useState<IPlatformProjectBudget | null>(null);
+  const [isBudgetEditOpen, setIsBudgetEditOpen] = useState(false);
 
   const clearAdSelection = useCallback(() => {
     setSelectedAdIds(new Set());
@@ -366,7 +367,10 @@ export default function CampaignDetail() {
                     platformBudget={budgetByPlatform.get(platform)}
                     onEditBudget={() => {
                       const budget = budgetByPlatform.get(platform);
-                      if (budget) setBudgetEditTarget(budget);
+                      if (budget) {
+                        setBudgetEditTarget(budget);
+                        setIsBudgetEditOpen(true);
+                      }
                     }}
                   />
                   {platformAds.length > 0 ? (
@@ -476,11 +480,14 @@ export default function CampaignDetail() {
       </Modal>
       {orgIdNum != null && projectIdNum != null ? (
         <EditPlatformBudgetModal
-          isOpen={!!budgetEditTarget}
+          isOpen={isBudgetEditOpen}
           onClose={() => {
+            setIsBudgetEditOpen(false);
+          }}
+          onClosed={() => {
             setBudgetEditTarget(null);
           }}
-          budget={budgetEditTarget ?? null}
+          budget={budgetEditTarget}
           orgId={orgIdNum}
           projectId={projectIdNum}
         />

--- a/src/types/ads/budget.ts
+++ b/src/types/ads/budget.ts
@@ -1,0 +1,35 @@
+/** Meta / Google 예산 수정 요청 */
+export interface IMetaGoogleBudgetUpdateRequest {
+  dailyBudget?: number;
+  lifetimeBudget?: number;
+}
+
+/** Naver 예산 수정 요청 */
+export interface INaverBudgetUpdateRequest {
+  useDailyBudget: boolean;
+  dailyBudget: number;
+}
+
+/** 일일 / 총 예산 구분 — 상세 API·수정 응답 공통 */
+export type TPlatformBudgetType = "DAILY" | "LIFETIME";
+
+/** Meta 상세 platformBudgets.activeBudgetType */
+export type TMetaActiveBudgetType = TPlatformBudgetType;
+
+/**
+ * Meta / Google 예산 수정 응답 data
+ * — 성공 toast 등에만 사용, UI 갱신은 detail refetch
+ */
+export interface IMetaGoogleBudgetUpdateData {
+  updatedBudget: number;
+  budgetType: TPlatformBudgetType;
+}
+
+/**
+ * Naver 예산 수정 응답 data
+ * — 성공 확인용, UI 갱신은 detail refetch
+ */
+export interface INaverBudgetUpdateData {
+  dailyBudget: number;
+  useDailyBudget: boolean;
+}

--- a/src/types/ads/budget.ts
+++ b/src/types/ads/budget.ts
@@ -1,8 +1,17 @@
-/** Meta / Google 예산 수정 요청 */
-export interface IMetaGoogleBudgetUpdateRequest {
-  dailyBudget?: number;
-  lifetimeBudget?: number;
+/** Meta / Google 일일 예산 수정 요청 */
+export interface IMetaGoogleDailyBudgetUpdateRequest {
+  dailyBudget: number;
 }
+
+/** Meta / Google 총 예산 수정 요청 */
+export interface IMetaGoogleLifetimeBudgetUpdateRequest {
+  lifetimeBudget: number;
+}
+
+/** Meta / Google 예산 수정 요청 — daily / lifetime 중 하나만 */
+export type TMetaGoogleBudgetUpdateRequest =
+  | IMetaGoogleDailyBudgetUpdateRequest
+  | IMetaGoogleLifetimeBudgetUpdateRequest;
 
 /** Naver 예산 수정 요청 */
 export interface INaverBudgetUpdateRequest {

--- a/src/types/ads/campaign.ts
+++ b/src/types/ads/campaign.ts
@@ -1,3 +1,4 @@
+import type { TPlatformBudgetType } from "@/types/ads/budget";
 import type { IBudgetAmountSlice } from "@/types/dashboard/common";
 
 export type TPlatform = "meta" | "google" | "naver"; //UI
@@ -7,10 +8,18 @@ export type TStatus = "ON_GOING" | "PAUSED" | "OVER";
 /** project 상세 — 플랫폼(매체 캠페인) 단위 예산 */
 export interface IPlatformProjectBudget {
   providerType: TProvider;
+  /** Meta / Google 예산 수정 path param */
   adCampaignId?: number;
   adCampaignName?: string;
   lifetime: IBudgetAmountSlice;
   daily?: IBudgetAmountSlice | null;
+  /** Meta — 기존 daily / lifetime 중 어떤 유형인지 */
+  activeBudgetType?: TPlatformBudgetType;
+  /** Naver — /api/naver/{connectionId}/campaigns/{campaignId}/budget */
+  naverConnectionId?: number;
+  naverCampaignId?: string;
+  /** 소유자 등 수정 가능 여부 */
+  canEditBudget?: boolean;
 }
 
 // Ad List

--- a/src/types/ads/campaign.ts
+++ b/src/types/ads/campaign.ts
@@ -12,10 +12,12 @@ export interface IPlatformProjectBudget {
   adCampaignId?: number;
   adCampaignName?: string;
   lifetime: IBudgetAmountSlice;
+  /** Meta / Google — activeBudgetType에 따라 표시
+   *  Naver — 일일 예산 */
   daily?: IBudgetAmountSlice | null;
   /** Meta / Google — 기존 daily / lifetime 중 어떤 유형인지 */
   activeBudgetType?: TPlatformBudgetType;
-  /** Naver — /api/naver/{connectionId}/campaigns/{campaignId}/budget */
+  /** Naver 일일 예산 수정 — /api/naver/{connectionId}/campaigns/{campaignId}/budget */
   naverConnectionId?: number;
   naverCampaignId?: string;
   /** 소유자 등 수정 가능 여부 */

--- a/src/types/ads/campaign.ts
+++ b/src/types/ads/campaign.ts
@@ -13,7 +13,7 @@ export interface IPlatformProjectBudget {
   adCampaignName?: string;
   lifetime: IBudgetAmountSlice;
   daily?: IBudgetAmountSlice | null;
-  /** Meta — 기존 daily / lifetime 중 어떤 유형인지 */
+  /** Meta / Google — 기존 daily / lifetime 중 어떤 유형인지 */
   activeBudgetType?: TPlatformBudgetType;
   /** Naver — /api/naver/{connectionId}/campaigns/{campaignId}/budget */
   naverConnectionId?: number;

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -91,10 +91,12 @@ export function canSubmitPlatformBudgetEdit(
       return { ok: true };
 
     case "NAVER":
-      if (!budget.naverConnectionId || !budget.naverCampaignId) {
-        return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
-      }
-      return { ok: true };
+      //TODO: BE 확인 후 수정 필요
+      return { ok: false, reason: "NOT_EDITABLE" };
+    //   if (!budget.naverConnectionId || !budget.naverCampaignId) {
+    //     return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
+    //   }
+    //   return { ok: true };
 
     default:
       return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -57,6 +57,11 @@ export type TBudgetEditFormValues =
   | TLifetimeBudgetFormValues
   | TNaverBudgetFormValues;
 
+export type TBudgetEditModalFormValues = {
+  dailyBudget?: number;
+  lifetimeBudget?: number;
+};
+
 /**
  * platformBudget → API 호출 가능 여부
  * BE 필드 없거나 mock이면 ok: false → 수정 버튼 disabled
@@ -129,4 +134,61 @@ export function resolveBudgetEditFormSchema(budget: IPlatformProjectBudget) {
     default:
       return dailyBudgetFormSchema;
   }
+}
+
+/** 모달 input — 필드명·라벨 (게이지 라벨과 동일) */
+export function resolveBudgetEditFieldMeta(budget: IPlatformProjectBudget): {
+  fieldName: "dailyBudget" | "lifetimeBudget";
+  label: string;
+} {
+  if (budget.providerType === "NAVER") {
+    return { fieldName: "dailyBudget", label: "일일 예산" };
+  }
+  if (budget.activeBudgetType === "LIFETIME") {
+    return { fieldName: "lifetimeBudget", label: "전체 예산" };
+  }
+  return { fieldName: "dailyBudget", label: "일일 예산" };
+}
+
+/** platformBudget → 폼 defaultValues */
+export function resolveBudgetEditDefaultValues(
+  budget: IPlatformProjectBudget,
+): TBudgetEditModalFormValues {
+  const { fieldName } = resolveBudgetEditFieldMeta(budget);
+
+  if (fieldName === "lifetimeBudget") {
+    return { lifetimeBudget: budget.lifetime.totalBudget };
+  }
+
+  const dailyAmount = budget.daily?.totalBudget ?? budget.lifetime.totalBudget;
+
+  return { dailyBudget: dailyAmount };
+}
+
+/** budget + form values → mutation variables */
+export function buildUpdatePlatformBudgetVariables(
+  budget: IPlatformProjectBudget,
+  values: TBudgetEditModalFormValues,
+): {
+  providerType: IPlatformProjectBudget["providerType"];
+  adCampaignId?: number;
+  activeBudgetType?: TPlatformBudgetType;
+  naverConnectionId?: number;
+  naverCampaignId?: string;
+  dailyBudget?: number;
+  lifetimeBudget?: number;
+} {
+  const base = {
+    providerType: budget.providerType,
+    adCampaignId: budget.adCampaignId,
+    activeBudgetType: budget.activeBudgetType,
+    naverConnectionId: budget.naverConnectionId,
+    naverCampaignId: budget.naverCampaignId,
+  };
+
+  if (values.lifetimeBudget !== undefined) {
+    return { ...base, lifetimeBudget: values.lifetimeBudget };
+  }
+
+  return { ...base, dailyBudget: values.dailyBudget };
 }

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 import type {
-  IMetaGoogleBudgetUpdateRequest,
   INaverBudgetUpdateRequest,
+  TMetaGoogleBudgetUpdateRequest,
   TPlatformBudgetType,
 } from "@/types/ads/budget";
 import type { IPlatformProjectBudget } from "@/types/ads/campaign";
@@ -108,7 +108,7 @@ export function canSubmitPlatformBudgetEdit(
 export function buildMetaGoogleBudgetPayload(
   activeBudgetType: TPlatformBudgetType,
   values: { dailyBudget?: number; lifetimeBudget?: number },
-): IMetaGoogleBudgetUpdateRequest {
+): TMetaGoogleBudgetUpdateRequest {
   if (activeBudgetType === "DAILY") {
     return { dailyBudget: values.dailyBudget! };
   }

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -91,12 +91,13 @@ export function canSubmitPlatformBudgetEdit(
       return { ok: true };
 
     case "NAVER":
-      //TODO: BE 확인 후 수정 필요
-      return { ok: false, reason: "NOT_EDITABLE" };
-    //   if (!budget.naverConnectionId || !budget.naverCampaignId) {
-    //     return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
-    //   }
-    //   return { ok: true };
+      if (!budget.naverConnectionId || !budget.naverCampaignId) {
+        return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
+      }
+      if (!budget.daily) {
+        return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
+      }
+      return { ok: true };
 
     default:
       return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
@@ -160,6 +161,10 @@ export function resolveBudgetEditDefaultValues(
 
   if (fieldName === "lifetimeBudget") {
     return { lifetimeBudget: budget.lifetime.totalBudget };
+  }
+
+  if (budget.providerType === "NAVER") {
+    return { dailyBudget: budget.daily?.totalBudget ?? 0 };
   }
 
   const dailyAmount = budget.daily?.totalBudget ?? budget.lifetime.totalBudget;

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -62,6 +62,55 @@ export type TBudgetEditModalFormValues = {
   lifetimeBudget?: number;
 };
 
+/** 게이지/모달/payload 공통 — 실제 표시·수정할 예산 필드 */
+export interface IEffectivePlatformBudget {
+  activeBudgetType: TPlatformBudgetType;
+  fieldName: "dailyBudget" | "lifetimeBudget";
+  label: "일일 예산" | "전체 예산";
+  totalBudget: number;
+  totalSpend: number;
+}
+
+/**
+ * activeBudgetType + daily/lifetime 데이터 존재 여부로 실제 활성 예산 결정
+ * — DAILY인데 daily 없으면 LIFETIME fallback
+ */
+export function resolveEffectivePlatformBudget(
+  budget: IPlatformProjectBudget,
+): IEffectivePlatformBudget {
+  if (budget.providerType === "NAVER") {
+    const daily = budget.daily ?? { totalBudget: 0, totalSpend: 0 };
+    return {
+      activeBudgetType: "DAILY",
+      fieldName: "dailyBudget",
+      label: "일일 예산",
+      totalBudget: daily.totalBudget,
+      totalSpend: daily.totalSpend,
+    };
+  }
+
+  const declaredType =
+    budget.activeBudgetType ?? (budget.daily ? "DAILY" : "LIFETIME");
+
+  if (declaredType === "DAILY" && budget.daily) {
+    return {
+      activeBudgetType: "DAILY",
+      fieldName: "dailyBudget",
+      label: "일일 예산",
+      totalBudget: budget.daily.totalBudget,
+      totalSpend: budget.daily.totalSpend,
+    };
+  }
+
+  return {
+    activeBudgetType: "LIFETIME",
+    fieldName: "lifetimeBudget",
+    label: "전체 예산",
+    totalBudget: budget.lifetime.totalBudget,
+    totalSpend: budget.lifetime.totalSpend,
+  };
+}
+
 /**
  * platformBudget → API 호출 가능 여부
  * BE 필드 없거나 mock이면 ok: false → 수정 버튼 disabled
@@ -133,17 +182,14 @@ export function buildNaverBudgetPayload(
  * 모달 — provider + activeBudgetType에 맞는 zod schema
  */
 export function resolveBudgetEditFormSchema(budget: IPlatformProjectBudget) {
-  switch (budget.providerType) {
-    case "META":
-    case "GOOGLE":
-      return budget.activeBudgetType === "LIFETIME"
-        ? lifetimeBudgetFormSchema
-        : dailyBudgetFormSchema;
-    case "NAVER":
-      return naverBudgetFormSchema;
-    default:
-      return dailyBudgetFormSchema;
+  if (budget.providerType === "NAVER") {
+    return naverBudgetFormSchema;
   }
+
+  const { fieldName } = resolveEffectivePlatformBudget(budget);
+  return fieldName === "lifetimeBudget"
+    ? lifetimeBudgetFormSchema
+    : dailyBudgetFormSchema;
 }
 
 /** 모달 input — 필드명·라벨 (게이지 라벨과 동일) */
@@ -151,32 +197,21 @@ export function resolveBudgetEditFieldMeta(budget: IPlatformProjectBudget): {
   fieldName: "dailyBudget" | "lifetimeBudget";
   label: string;
 } {
-  if (budget.providerType === "NAVER") {
-    return { fieldName: "dailyBudget", label: "일일 예산" };
-  }
-  if (budget.activeBudgetType === "LIFETIME") {
-    return { fieldName: "lifetimeBudget", label: "전체 예산" };
-  }
-  return { fieldName: "dailyBudget", label: "일일 예산" };
+  const { fieldName, label } = resolveEffectivePlatformBudget(budget);
+  return { fieldName, label };
 }
 
 /** platformBudget → 폼 defaultValues */
 export function resolveBudgetEditDefaultValues(
   budget: IPlatformProjectBudget,
 ): TBudgetEditModalFormValues {
-  const { fieldName } = resolveBudgetEditFieldMeta(budget);
+  const { fieldName, totalBudget } = resolveEffectivePlatformBudget(budget);
 
   if (fieldName === "lifetimeBudget") {
-    return { lifetimeBudget: budget.lifetime.totalBudget };
+    return { lifetimeBudget: totalBudget };
   }
 
-  if (budget.providerType === "NAVER") {
-    return { dailyBudget: budget.daily?.totalBudget ?? 0 };
-  }
-
-  const dailyAmount = budget.daily?.totalBudget ?? budget.lifetime.totalBudget;
-
-  return { dailyBudget: dailyAmount };
+  return { dailyBudget: totalBudget };
 }
 
 /** budget + form values → mutation variables */
@@ -192,10 +227,12 @@ export function buildUpdatePlatformBudgetVariables(
   dailyBudget?: number;
   lifetimeBudget?: number;
 } {
+  const { activeBudgetType } = resolveEffectivePlatformBudget(budget);
+
   const base = {
     providerType: budget.providerType,
     adCampaignId: budget.adCampaignId,
-    activeBudgetType: budget.activeBudgetType,
+    activeBudgetType,
     naverConnectionId: budget.naverConnectionId,
     naverCampaignId: budget.naverCampaignId,
   };

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+
+import type {
+  IMetaGoogleBudgetUpdateRequest,
+  INaverBudgetUpdateRequest,
+  TPlatformBudgetType,
+} from "@/types/ads/budget";
+import type { IPlatformProjectBudget } from "@/types/ads/campaign";
+
+/** 예산 수정 불가 사유 — canSubmitPlatformBudgetEdit 반환값 */
+export type TBudgetEditBlockReason =
+  | "MISSING_PLATFORM_BUDGET"
+  | "NOT_EDITABLE"
+  | "MISSING_META_CONTEXT"
+  | "MISSING_GOOGLE_CONTEXT"
+  | "MISSING_NAVER_CONTEXT";
+
+export const BUDGET_EDIT_BLOCK_MESSAGES: Record<
+  TBudgetEditBlockReason,
+  string
+> = {
+  MISSING_PLATFORM_BUDGET: "예산 정보를 불러올 수 없습니다.",
+  NOT_EDITABLE: "예산을 수정할 권한이 없습니다.",
+  MISSING_META_CONTEXT: "예산 수정에 필요한 Meta 정보가 없습니다.",
+  MISSING_GOOGLE_CONTEXT: "예산 수정에 필요한 Google 정보가 없습니다.",
+  MISSING_NAVER_CONTEXT: "예산 수정에 필요한 Naver 정보가 없습니다.",
+};
+
+const positiveBudget = z
+  .number({ message: "숫자를 입력해 주세요." })
+  .int("정수만 입력할 수 있습니다.")
+  .min(1, "1원 이상 입력해 주세요.");
+
+/** Meta / Google DAILY / Naver 일일 */
+export const dailyBudgetFormSchema = z.object({
+  dailyBudget: positiveBudget,
+});
+
+/** Meta / Google LIFETIME */
+export const lifetimeBudgetFormSchema = z.object({
+  lifetimeBudget: positiveBudget,
+});
+
+/** Naver */
+export const naverBudgetFormSchema = z.object({
+  dailyBudget: positiveBudget,
+});
+
+export type TDailyBudgetFormValues = z.infer<typeof dailyBudgetFormSchema>;
+export type TLifetimeBudgetFormValues = z.infer<
+  typeof lifetimeBudgetFormSchema
+>;
+export type TNaverBudgetFormValues = z.infer<typeof naverBudgetFormSchema>;
+
+export type TBudgetEditFormValues =
+  | TDailyBudgetFormValues
+  | TLifetimeBudgetFormValues
+  | TNaverBudgetFormValues;
+
+/**
+ * platformBudget → API 호출 가능 여부
+ * BE 필드 없거나 mock이면 ok: false → 수정 버튼 disabled
+ */
+export function canSubmitPlatformBudgetEdit(
+  budget: IPlatformProjectBudget | undefined,
+): { ok: true } | { ok: false; reason: TBudgetEditBlockReason } {
+  if (!budget) {
+    return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
+  }
+
+  if (budget.canEditBudget === false) {
+    return { ok: false, reason: "NOT_EDITABLE" };
+  }
+
+  switch (budget.providerType) {
+    case "META":
+      if (!budget.adCampaignId || !budget.activeBudgetType) {
+        return { ok: false, reason: "MISSING_META_CONTEXT" };
+      }
+      return { ok: true };
+
+    case "GOOGLE":
+      if (!budget.adCampaignId || !budget.activeBudgetType) {
+        return { ok: false, reason: "MISSING_GOOGLE_CONTEXT" };
+      }
+      return { ok: true };
+
+    case "NAVER":
+      if (!budget.naverConnectionId || !budget.naverCampaignId) {
+        return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
+      }
+      return { ok: true };
+
+    default:
+      return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
+  }
+}
+
+/** Meta / Google — activeBudgetType에 맞는 필드 하나만 body에 */
+export function buildMetaGoogleBudgetPayload(
+  activeBudgetType: TPlatformBudgetType,
+  values: { dailyBudget?: number; lifetimeBudget?: number },
+): IMetaGoogleBudgetUpdateRequest {
+  if (activeBudgetType === "DAILY") {
+    return { dailyBudget: values.dailyBudget! };
+  }
+  return { lifetimeBudget: values.lifetimeBudget! };
+}
+
+/** Naver — useDailyBudget 항상 true */
+export function buildNaverBudgetPayload(
+  dailyBudget: number,
+): INaverBudgetUpdateRequest {
+  return { useDailyBudget: true, dailyBudget };
+}
+
+/**
+ * 모달 — provider + activeBudgetType에 맞는 zod schema
+ */
+export function resolveBudgetEditFormSchema(budget: IPlatformProjectBudget) {
+  switch (budget.providerType) {
+    case "META":
+    case "GOOGLE":
+      return budget.activeBudgetType === "LIFETIME"
+        ? lifetimeBudgetFormSchema
+        : dailyBudgetFormSchema;
+    case "NAVER":
+      return naverBudgetFormSchema;
+    default:
+      return dailyBudgetFormSchema;
+  }
+}

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -110,9 +110,16 @@ export function buildMetaGoogleBudgetPayload(
   values: { dailyBudget?: number; lifetimeBudget?: number },
 ): TMetaGoogleBudgetUpdateRequest {
   if (activeBudgetType === "DAILY") {
-    return { dailyBudget: values.dailyBudget! };
+    if (values.dailyBudget === undefined) {
+      throw new Error("일일 예산을 입력해 주세요.");
+    }
+    return { dailyBudget: values.dailyBudget };
   }
-  return { lifetimeBudget: values.lifetimeBudget! };
+
+  if (values.lifetimeBudget === undefined) {
+    throw new Error("전체 예산을 입력해 주세요.");
+  }
+  return { lifetimeBudget: values.lifetimeBudget };
 }
 
 /** Naver — useDailyBudget 항상 true */

--- a/src/utils/ads/formatBudgetInput.ts
+++ b/src/utils/ads/formatBudgetInput.ts
@@ -1,0 +1,23 @@
+const BUDGET_INPUT_LOCALE = "ko-KR" as const;
+
+/** 입력칸 표시 — 1000000 → "1,000,000" */
+export function formatBudgetInputDisplay(value: number | undefined): string {
+  if (value === undefined || Number.isNaN(value)) return "";
+  return value.toLocaleString(BUDGET_INPUT_LOCALE);
+}
+
+/** 입력 파싱 — "1,000,000" / "1000000" → 1000000 */
+export function parseBudgetInput(raw: string): number | undefined {
+  const digits = extractBudgetInputDigits(raw);
+  if (digits === "") return undefined;
+
+  const parsed = Number(digits);
+  if (!Number.isSafeInteger(parsed)) return undefined;
+
+  return parsed;
+}
+
+/** 입력 중 표시 — 숫자만 허용 */
+export function extractBudgetInputDigits(raw: string): string {
+  return raw.replace(/\D/g, "");
+}

--- a/src/utils/ads/projectBudget.ts
+++ b/src/utils/ads/projectBudget.ts
@@ -30,24 +30,40 @@ export function mapPlatformProjectBudgetToGauges(
   budget: IPlatformProjectBudget,
 ): IBudgetGaugeProps[] {
   const provider = budget.providerType as TProviderType;
+  const slice = resolvePlatformBudgetDisplaySlice(budget, provider);
 
-  const slices: IBudgetSlice[] = [
-    {
+  return buildBudgetGaugesFromSlices([slice], { showInsight: true });
+}
+
+/** Meta/Google: activeBudgetType 기준 1개 · Naver: 전체 예산만 */
+function resolvePlatformBudgetDisplaySlice(
+  budget: IPlatformProjectBudget,
+  provider: TProviderType,
+): IBudgetSlice {
+  if (!supportsDailyBudget(provider)) {
+    return {
       label: "전체 예산",
       totalBudget: budget.lifetime.totalBudget,
       spent: budget.lifetime.totalSpend,
-    },
-  ];
+    };
+  }
 
-  if (supportsDailyBudget(provider) && budget.daily) {
-    slices.push({
+  const activeType =
+    budget.activeBudgetType ?? (budget.daily ? "DAILY" : "LIFETIME");
+
+  if (activeType === "DAILY" && budget.daily) {
+    return {
       label: "일일 예산",
       totalBudget: budget.daily.totalBudget,
       spent: budget.daily.totalSpend,
-    });
+    };
   }
 
-  return buildBudgetGaugesFromSlices(slices, { showInsight: true });
+  return {
+    label: "전체 예산",
+    totalBudget: budget.lifetime.totalBudget,
+    spent: budget.lifetime.totalSpend,
+  };
 }
 
 /** API 미준비 시 dev placeholder */
@@ -71,7 +87,10 @@ export function buildPlaceholderPlatformBudgets(
         totalBudget: 50_000,
         totalSpend: 12_000 + index * 2_000,
       };
+      item.activeBudgetType = index % 2 === 0 ? "DAILY" : "LIFETIME";
     }
+
+    item.canEditBudget = false;
 
     return item;
   });

--- a/src/utils/ads/projectBudget.ts
+++ b/src/utils/ads/projectBudget.ts
@@ -3,9 +3,9 @@ import type {
   TPlatform,
   TProvider,
 } from "@/types/ads/campaign";
-import type { IBudgetGaugeProps, IBudgetSlice } from "@/types/dashboard/budget";
-import type { TProviderType } from "@/types/dashboard/provider";
+import type { IBudgetGaugeProps } from "@/types/dashboard/budget";
 
+import { resolveEffectivePlatformBudget } from "@/utils/ads/budgetEdit";
 import {
   buildBudgetGaugesFromSlices,
   supportsDailyBudget,
@@ -29,42 +29,18 @@ export function platformToProviderType(platform: TPlatform): TProvider {
 export function mapPlatformProjectBudgetToGauges(
   budget: IPlatformProjectBudget,
 ): IBudgetGaugeProps[] {
-  const provider = budget.providerType as TProviderType;
-  const slice = resolvePlatformBudgetDisplaySlice(budget, provider);
+  const effective = resolveEffectivePlatformBudget(budget);
 
-  return buildBudgetGaugesFromSlices([slice], { showInsight: true });
-}
-
-/** Meta/Google: activeBudgetType 기준 1개 · Naver: 일일 예산만 */
-function resolvePlatformBudgetDisplaySlice(
-  budget: IPlatformProjectBudget,
-  provider: TProviderType,
-): IBudgetSlice {
-  if (provider === "NAVER") {
-    const daily = budget.daily ?? { totalBudget: 0, totalSpend: 0 };
-    return {
-      label: "일일 예산",
-      totalBudget: daily.totalBudget,
-      spent: daily.totalSpend,
-    };
-  }
-
-  const activeType =
-    budget.activeBudgetType ?? (budget.daily ? "DAILY" : "LIFETIME");
-
-  if (activeType === "DAILY" && budget.daily) {
-    return {
-      label: "일일 예산",
-      totalBudget: budget.daily.totalBudget,
-      spent: budget.daily.totalSpend,
-    };
-  }
-
-  return {
-    label: "전체 예산",
-    totalBudget: budget.lifetime.totalBudget,
-    spent: budget.lifetime.totalSpend,
-  };
+  return buildBudgetGaugesFromSlices(
+    [
+      {
+        label: effective.label,
+        totalBudget: effective.totalBudget,
+        spent: effective.totalSpend,
+      },
+    ],
+    { showInsight: true },
+  );
 }
 
 /** API 미준비 시 dev placeholder */

--- a/src/utils/ads/projectBudget.ts
+++ b/src/utils/ads/projectBudget.ts
@@ -35,16 +35,17 @@ export function mapPlatformProjectBudgetToGauges(
   return buildBudgetGaugesFromSlices([slice], { showInsight: true });
 }
 
-/** Meta/Google: activeBudgetType 기준 1개 · Naver: 전체 예산만 */
+/** Meta/Google: activeBudgetType 기준 1개 · Naver: 일일 예산만 */
 function resolvePlatformBudgetDisplaySlice(
   budget: IPlatformProjectBudget,
   provider: TProviderType,
 ): IBudgetSlice {
-  if (!supportsDailyBudget(provider)) {
+  if (provider === "NAVER") {
+    const daily = budget.daily ?? { totalBudget: 0, totalSpend: 0 };
     return {
-      label: "전체 예산",
-      totalBudget: budget.lifetime.totalBudget,
-      spent: budget.lifetime.totalSpend,
+      label: "일일 예산",
+      totalBudget: daily.totalBudget,
+      spent: daily.totalSpend,
     };
   }
 
@@ -82,15 +83,22 @@ export function buildPlaceholderPlatformBudgets(
       lifetime: { totalBudget, totalSpend },
     };
 
-    if (supportsDailyBudget(providerType)) {
+    if (providerType === "NAVER") {
+      item.daily = {
+        totalBudget: 50_000,
+        totalSpend: 12_000 + index * 2_000,
+      };
+      item.naverConnectionId = 1;
+      item.naverCampaignId = `mock-campaign-${index}`;
+      item.canEditBudget = true;
+    } else if (supportsDailyBudget(providerType)) {
       item.daily = {
         totalBudget: 50_000,
         totalSpend: 12_000 + index * 2_000,
       };
       item.activeBudgetType = index % 2 === 0 ? "DAILY" : "LIFETIME";
+      item.canEditBudget = true;
     }
-
-    item.canEditBudget = providerType !== "NAVER";
 
     return item;
   });

--- a/src/utils/ads/projectBudget.ts
+++ b/src/utils/ads/projectBudget.ts
@@ -90,7 +90,7 @@ export function buildPlaceholderPlatformBudgets(
       item.activeBudgetType = index % 2 === 0 ? "DAILY" : "LIFETIME";
     }
 
-    item.canEditBudget = false;
+    item.canEditBudget = providerType !== "NAVER";
 
     return item;
   });

--- a/src/utils/ads/settleBulkRequests.ts
+++ b/src/utils/ads/settleBulkRequests.ts
@@ -1,0 +1,57 @@
+export interface IBulkSettleResult {
+  successCount: number;
+  total: number;
+  firstError: unknown;
+}
+
+/** Promise.allSettled — 개별 성공·실패 집계 */
+export async function settleBulkRequests<T>(
+  requests: Promise<T>[],
+): Promise<IBulkSettleResult> {
+  if (requests.length === 0) {
+    return { successCount: 0, total: 0, firstError: undefined };
+  }
+
+  const results = await Promise.allSettled(requests);
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+
+  return {
+    successCount: results.length - failures.length,
+    total: results.length,
+    firstError: failures[0]?.reason,
+  };
+}
+
+/** 전부 실패 → throw · 일부 실패 → throw (호출 전 invalidate 필요) */
+export function assertBulkSettleResult(
+  result: IBulkSettleResult,
+  messages?: {
+    partial?: (successCount: number, total: number) => string;
+  },
+): void {
+  if (result.total === 0) return;
+
+  if (result.successCount === 0) {
+    if (
+      result.firstError &&
+      typeof result.firstError === "object" &&
+      "message" in result.firstError
+    ) {
+      throw result.firstError;
+    }
+    throw new Error(
+      result.firstError instanceof Error
+        ? result.firstError.message
+        : "요청에 실패했습니다.",
+    );
+  }
+
+  if (result.successCount < result.total) {
+    throw new Error(
+      messages?.partial?.(result.successCount, result.total) ??
+        `${result.total}개 중 ${result.successCount}개만 반영되었습니다.`,
+    );
+  }
+}


### PR DESCRIPTION
## 🚨 관련 이슈
close #385 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [X] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 플랫폼 예산 수정
캠페인 상세에서 Meta / Google / Naver별 예산을 확인하고, 수정 버튼으로 바로 변경할 수 있게 했습니다.
- 플랫폼마다 **현재 쓰는 예산 타입 1개만** 게이지로 표시 (Meta/Google: 일일 or 총예산 / Naver: 일일 예산)
- 수정 버튼 → 모달에서 금액 입력 → 저장 시 해당 플랫폼 API 호출 → 상세 refetch로 게이지 갱신
- 금액 입력 UX: 입력 중엔 숫자만, blur 시 콤마 포맷

<img width="1699" height="973" alt="스크린샷 2026-08-05 오전 6 59 26" src="https://github.com/user-attachments/assets/c3408a7c-a4ff-4de7-889d-041461f50622" />

<img width="1694" height="975" alt="스크린샷 2026-08-05 오전 6 59 51" src="https://github.com/user-attachments/assets/785bdd21-5b07-42d6-93e0-d73d1c7c9754" />

### ads 훅 패턴 통일

> 이전에 작업했었으나, 빠진 부분이 있어 같이 수정했습니다.

**추가 훅**
- `useUpdateCampaignStatus` — 캠페인 일괄/선택 중단·재개
- `useUpdateAdStatus` — 광고 소재 일괄/선택 중단·재개
- `useCreateTrackingUrl` — 트래킹 URL 발급
**수정**
- `useAdList` — `useCoreQuery` 전환
- `queryKeys.ts` — `campaign.ads` 키 추가
- `AdsListPage`, `CampaignDetail`, `AdDetailContent`, `AdListTable`

## 😅 미완성 작업
- [ ] 캠페인 상세 `platformBudgets` 실데이터 연동 전 mock fallback 사용 중

## 📢 논의 사항 및 참고 사항
- 현재 API 수정 전이라 mock data 사용 중이며 예산 수정이 정상 처리되지 않습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* **새로운 기능**
  * Meta·Google·Naver 캠페인의 플랫폼별 예산을 수정할 수 있습니다.
  * 일일 예산과 전체 예산을 구분해 편집하고 입력값을 검증합니다.
  * 캠페인과 광고 소재 상태를 일괄 변경할 수 있습니다.
  * 광고 트래킹 URL 발급 기능을 제공합니다.

* **개선**
  * 예산 수정 가능 여부와 제한 사유를 표시합니다.
  * 상태 변경 및 트래킹 URL 발급 후 데이터가 자동 갱신됩니다.
  * 예산 표시와 광고 목록 로딩 레이아웃을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->