### PR TITLE
[Bugfix/#397] 알림 Slack/Discord ADMIN에게만 노출

### DIFF
--- a/src/components/setting/NotificationSection.tsx
+++ b/src/components/setting/NotificationSection.tsx
@@ -13,6 +13,7 @@ import SlackIcon from "@/assets/logo/social-logo/plain/slack.svg?react";
 
 type TNotificationSectionProps = {
   email: string;
+  isAdmin: boolean;
   masterEnabled: boolean;
   onMasterEnabledChange: (value: boolean) => void;
   //channel
@@ -48,6 +49,7 @@ type TNotificationSectionProps = {
 
 export default function NotificationSection({
   email,
+  isAdmin,
   masterEnabled,
   onMasterEnabledChange,
   browserPush,
@@ -158,140 +160,145 @@ export default function NotificationSection({
               />
             </div>
           </div>
-
-          <div className="flex items-center gap-4 py-5">
-            <div className="flex min-w-0 flex-1 items-center gap-4">
-              <SlackIcon className={rowIconClass} />
-              <div className="min-w-0">
-                <p className="font-body1 text-text-title">슬랙 연동하기</p>
-                <p className="font-body2 text-text-muted">
-                  {slackConnected
-                    ? "연동됨 • 알림 on/off는 저장 시 반영"
-                    : "Webhook URL로 연동"}
-                </p>
+          {isAdmin && (
+            <div className="flex items-center gap-4 py-5">
+              <div className="flex min-w-0 flex-1 items-center gap-4">
+                <SlackIcon className={rowIconClass} />
+                <div className="min-w-0">
+                  <p className="font-body1 text-text-title">슬랙 연동하기</p>
+                  <p className="font-body2 text-text-muted">
+                    {slackConnected
+                      ? "연동됨 • 알림 on/off는 저장 시 반영"
+                      : "Webhook URL로 연동"}
+                  </p>
+                </div>
               </div>
+              {slackConnected ? (
+                <div className="flex shrink-0 items-center gap-3">
+                  {slackEnabled && !channelDisabled && (
+                    <Badge variant="infoBlue">켜짐</Badge>
+                  )}
+                  <Toggle
+                    checked={slackEnabled}
+                    disabled={channelDisabled || isAnyOrgPending}
+                    onToggle={() => onSlackEnabledChange(!slackEnabled)}
+                    ariaLabel="슬랙 알림 켜기/끄기"
+                  />
+                  <Button
+                    variant="outline"
+                    size="small"
+                    type="button"
+                    disabled={channelDisabled || isAnyOrgPending}
+                    isLoading={isSlackPending}
+                    onClick={onDisconnectSlack}
+                  >
+                    연동 해제
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <Input
+                    aria-label="슬랙 Webhook URL"
+                    placeholder="https://hooks.slack.com/..."
+                    value={slackWebhookUrl}
+                    onChange={(e) => onSlackWebhookUrlChange(e.target.value)}
+                    error={!!slackWebhookError}
+                    helperText={slackWebhookError}
+                    disabled={channelDisabled || isAnyOrgPending}
+                    wrapperClassName="w-1/4 shrink-0"
+                    containerClassName="h-10 rounded-lg"
+                    inputClassName="px-3 font-body2"
+                  />
+                  <Button
+                    variant="outline"
+                    size="small"
+                    type="button"
+                    className="shrink-0"
+                    disabled={
+                      channelDisabled ||
+                      isAnyOrgPending ||
+                      !slackWebhookUrl.trim()
+                    }
+                    isLoading={isSlackPending}
+                    onClick={onConnectSlack}
+                  >
+                    연동
+                  </Button>
+                </>
+              )}
             </div>
-            {slackConnected ? (
-              <div className="flex shrink-0 items-center gap-3">
-                {slackEnabled && !channelDisabled && (
-                  <Badge variant="infoBlue">켜짐</Badge>
-                )}
-                <Toggle
-                  checked={slackEnabled}
-                  disabled={channelDisabled || isAnyOrgPending}
-                  onToggle={() => onSlackEnabledChange(!slackEnabled)}
-                  ariaLabel="슬랙 알림 켜기/끄기"
-                />
-                <Button
-                  variant="outline"
-                  size="small"
-                  type="button"
-                  disabled={channelDisabled || isAnyOrgPending}
-                  isLoading={isSlackPending}
-                  onClick={onDisconnectSlack}
-                >
-                  연동 해제
-                </Button>
-              </div>
-            ) : (
-              <>
-                <Input
-                  aria-label="슬랙 Webhook URL"
-                  placeholder="https://hooks.slack.com/..."
-                  value={slackWebhookUrl}
-                  onChange={(e) => onSlackWebhookUrlChange(e.target.value)}
-                  error={!!slackWebhookError}
-                  helperText={slackWebhookError}
-                  disabled={channelDisabled || isAnyOrgPending}
-                  wrapperClassName="w-1/4 shrink-0"
-                  containerClassName="h-10 rounded-lg"
-                  inputClassName="px-3 font-body2"
-                />
-                <Button
-                  variant="outline"
-                  size="small"
-                  type="button"
-                  className="shrink-0"
-                  disabled={
-                    channelDisabled ||
-                    isAnyOrgPending ||
-                    !slackWebhookUrl.trim()
-                  }
-                  isLoading={isSlackPending}
-                  onClick={onConnectSlack}
-                >
-                  연동
-                </Button>
-              </>
-            )}
-          </div>
+          )}
 
-          <div className="flex items-center gap-4 py-5 last:pb-0">
-            <div className="flex min-w-0 flex-1 items-center gap-4">
-              <DiscordIcon className={rowIconClass} />
-              <div className="min-w-0">
-                <p className="font-body1 text-text-title">디스코드 연동하기</p>
-                <p className="font-body2 text-text-muted">
-                  {discordConnected
-                    ? "연동됨 • 알림 on/off는 저장 시 반영"
-                    : "Webhook URL로 연동"}
-                </p>
+          {isAdmin && (
+            <div className="flex items-center gap-4 py-5 last:pb-0">
+              <div className="flex min-w-0 flex-1 items-center gap-4">
+                <DiscordIcon className={rowIconClass} />
+                <div className="min-w-0">
+                  <p className="font-body1 text-text-title">
+                    디스코드 연동하기
+                  </p>
+                  <p className="font-body2 text-text-muted">
+                    {discordConnected
+                      ? "연동됨 • 알림 on/off는 저장 시 반영"
+                      : "Webhook URL로 연동"}
+                  </p>
+                </div>
               </div>
+              {discordConnected ? (
+                <div className="flex shrink-0 items-center gap-3">
+                  {discordEnabled && !channelDisabled && (
+                    <Badge variant="infoBlue">켜짐</Badge>
+                  )}
+                  <Toggle
+                    checked={discordEnabled}
+                    disabled={channelDisabled || isAnyOrgPending}
+                    onToggle={() => onDiscordEnabledChange(!discordEnabled)}
+                    ariaLabel="디스코드 알림 켜기/끄기"
+                  />
+                  <Button
+                    variant="outline"
+                    size="small"
+                    type="button"
+                    disabled={channelDisabled || isAnyOrgPending}
+                    isLoading={isDiscordPending}
+                    onClick={onDisconnectDiscord}
+                  >
+                    연동 해제
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <Input
+                    aria-label="디스코드 Webhook URL"
+                    placeholder="https://discord.com/api/webhooks/..."
+                    value={discordWebhookUrl}
+                    onChange={(e) => onDiscordWebhookUrlChange(e.target.value)}
+                    error={!!discordWebhookError}
+                    helperText={discordWebhookError}
+                    disabled={channelDisabled || isAnyOrgPending}
+                    wrapperClassName="w-1/4 shrink-0"
+                    containerClassName="h-10 rounded-lg"
+                    inputClassName="px-3 font-body2"
+                  />
+                  <Button
+                    variant="outline"
+                    size="small"
+                    type="button"
+                    className="shrink-0"
+                    disabled={
+                      channelDisabled ||
+                      isAnyOrgPending ||
+                      !discordWebhookUrl.trim()
+                    }
+                    isLoading={isDiscordPending}
+                    onClick={onConnectDiscord}
+                  >
+                    연동
+                  </Button>
+                </>
+              )}
             </div>
-            {discordConnected ? (
-              <div className="flex shrink-0 items-center gap-3">
-                {discordEnabled && !channelDisabled && (
-                  <Badge variant="infoBlue">켜짐</Badge>
-                )}
-                <Toggle
-                  checked={discordEnabled}
-                  disabled={channelDisabled || isAnyOrgPending}
-                  onToggle={() => onDiscordEnabledChange(!discordEnabled)}
-                  ariaLabel="디스코드 알림 켜기/끄기"
-                />
-                <Button
-                  variant="outline"
-                  size="small"
-                  type="button"
-                  disabled={channelDisabled || isAnyOrgPending}
-                  isLoading={isDiscordPending}
-                  onClick={onDisconnectDiscord}
-                >
-                  연동 해제
-                </Button>
-              </div>
-            ) : (
-              <>
-                <Input
-                  aria-label="디스코드 Webhook URL"
-                  placeholder="https://discord.com/api/webhooks/..."
-                  value={discordWebhookUrl}
-                  onChange={(e) => onDiscordWebhookUrlChange(e.target.value)}
-                  error={!!discordWebhookError}
-                  helperText={discordWebhookError}
-                  disabled={channelDisabled || isAnyOrgPending}
-                  wrapperClassName="w-1/4 shrink-0"
-                  containerClassName="h-10 rounded-lg"
-                  inputClassName="px-3 font-body2"
-                />
-                <Button
-                  variant="outline"
-                  size="small"
-                  type="button"
-                  className="shrink-0"
-                  disabled={
-                    channelDisabled ||
-                    isAnyOrgPending ||
-                    !discordWebhookUrl.trim()
-                  }
-                  isLoading={isDiscordPending}
-                  onClick={onConnectDiscord}
-                >
-                  연동
-                </Button>
-              </>
-            )}
-          </div>
+          )}
         </div>
       </section>
 

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -131,6 +131,9 @@ export default function Setting() {
     getMyWorkspaces,
   );
 
+  const myRole = useWorkspaceStore((s) => s.myRole);
+  const isAdmin = myRole === "ADMIN";
+
   const {
     data: notificationSettings,
     isLoading: isNotificationLoading,
@@ -419,7 +422,10 @@ export default function Setting() {
       const shouldSaveMaster =
         canSaveNotification && hasMasterChanges && selectedOrgId != null;
       const shouldSaveOrg =
-        canSaveNotification && hasOrgToggleChanges && selectedOrgId != null;
+        canSaveNotification &&
+        hasOrgToggleChanges &&
+        selectedOrgId != null &&
+        isAdmin;
 
       if (
         shouldSaveChannel ||
@@ -648,6 +654,7 @@ export default function Setting() {
           >
             <NotificationSection
               email={draftProfile.email}
+              isAdmin={isAdmin}
               masterEnabled={draftOrgNotif.masterEnabled}
               onMasterEnabledChange={(value) => {
                 if (!value) {


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #397 

## ✨ 변경사항

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 설정 > 알림의 Slack/Discord 연동 UI를 ADMIN에게만 노출
- MEMBER는 해당 영역 미표시
- ADMIN이 아닌 경우 Slack/Discord 설정 저장 요청이 나가지 않도록 가드 추가
- ADMIN만 조작 가능하다는 설명 추가

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- Slack/Discord는 조직 공용이며 조작 권한은 ADMIN에게만 있습니다. 따라서, ADMIN에게만 보이도록 수정작업 진행하였습니다.
- 신규 가입자의 알림은
   - 현재: 마스터/이메일/주간 리포트 ON. 나머지 OFF.
   - 신규: 신규: 멤버 알림 기본값 all OFF **(8/5 10:00 기준 기본값 전부 OFF로 수정작업 진행하기로 백엔드와 논의완료)** 
   => **(8/6 12:20 기준 기본값 전부 OFF로 수정완료)**


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
