### PR TITLE
[Feature/#398] 플랫폼 연동 수동 동기화

### DIFF
--- a/src/api/integration/google.ts
+++ b/src/api/integration/google.ts
@@ -1,4 +1,5 @@
 import type { ICommonResponse } from "@/types/common/common";
+import type { IGoogleSyncData } from "@/types/integration/platformSync";
 
 import { axiosInstance } from "@/lib/axiosInstance";
 
@@ -29,4 +30,11 @@ export async function startGoogleOAuthLogin(orgId: number): Promise<void> {
   }
 
   window.location.assign(redirectUrl);
+}
+
+export async function syncGoogleAdData(): Promise<IGoogleSyncData> {
+  const { data } = await axiosInstance.post<ICommonResponse<IGoogleSyncData>>(
+    "/api/google/ad-infos",
+  );
+  return data.data;
 }

--- a/src/api/integration/meta.ts
+++ b/src/api/integration/meta.ts
@@ -1,4 +1,5 @@
 import type { ICommonResponse } from "@/types/common/common";
+import type { IMetaSyncData } from "@/types/integration/platformSync";
 
 import { axiosInstance } from "@/lib/axiosInstance";
 
@@ -29,4 +30,11 @@ export async function startMetaOAuthLogin(orgId: number): Promise<void> {
   }
 
   window.location.assign(authUrl);
+}
+
+export async function syncMetaAdData(orgId: number): Promise<IMetaSyncData> {
+  const { data } = await axiosInstance.post<ICommonResponse<IMetaSyncData>>(
+    `/api/meta/${orgId}/refresh`,
+  );
+  return data.data;
 }

--- a/src/api/integration/naver.ts
+++ b/src/api/integration/naver.ts
@@ -3,6 +3,10 @@ import type {
   INaverConnectResponseData,
   INaverCredentialsRequest,
 } from "@/types/integration/naver";
+import type {
+  INaverSyncData,
+  INaverSyncRequest,
+} from "@/types/integration/platformSync";
 
 import { encryptAesCbcBase64 } from "@/utils/integration/encryptAesCbcBase64";
 
@@ -37,4 +41,15 @@ export async function updateNaverAccount(
     `/api/platform/${orgId}/accounts/naver`,
     toNaverEncryptedBody(body),
   );
+}
+
+export async function syncNaverAdData(
+  orgId: number,
+  body: INaverSyncRequest,
+): Promise<INaverSyncData> {
+  const { data } = await axiosInstance.post<ICommonResponse<INaverSyncData>>(
+    `/api/naver/${orgId}/sync`,
+    body,
+  );
+  return data.data;
 }

--- a/src/assets/icon/common/sync.svg
+++ b/src/assets/icon/common/sync.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 12C3 9.61305 3.94821 7.32387 5.63604 5.63604C7.32387 3.94821 9.61305 3 12 3C14.516 3.00947 16.931 3.99122 18.74 5.74L21 8M16 8H21V3M21 12C21 14.3869 20.0518 16.6761 18.364 18.364C16.6761 20.0518 14.3869 21 12 21C9.48395 20.9905 7.06897 20.0088 5.26 18.26L3 16M3 21V16H8" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/integration/NaverSyncModal.tsx
+++ b/src/components/integration/NaverSyncModal.tsx
@@ -79,7 +79,7 @@ export default function NaverSyncModal({
         className="flex flex-col gap-5"
         noValidate
       >
-        <p className="font-body2 text-text-muted">
+        <p className="font-body1 text-text-muted">
           동기화할 기간을 선택해 주세요.
         </p>
 

--- a/src/components/integration/NaverSyncModal.tsx
+++ b/src/components/integration/NaverSyncModal.tsx
@@ -1,0 +1,143 @@
+import { type MouseEvent, useEffect } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import {
+  naverSyncSchema,
+  type TNaverSyncFormValues,
+} from "@/utils/integration/naverSyncSchema";
+import { getDefaultNaverSyncDateRange } from "@/utils/integration/platformSync";
+
+import Button from "@/components/common/button/Button";
+import Input from "@/components/common/input/Input";
+import Modal from "@/components/common/modal/Modal";
+
+function openDatePickerFromField(event: MouseEvent<HTMLElement>) {
+  const input =
+    event.currentTarget.querySelector<HTMLInputElement>('input[type="date"]');
+  if (!input || input.disabled) return;
+
+  input.focus();
+
+  if (typeof input.showPicker !== "function") return;
+
+  try {
+    input.showPicker();
+  } catch {
+    /* 일부 브라우저나 보안 컨텍스트에서 showPicker 호출 제한될 수 있음 */
+  }
+}
+
+interface INaverSyncModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (values: TNaverSyncFormValues) => void;
+  isLoading?: boolean;
+}
+
+export default function NaverSyncModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isLoading = false,
+}: INaverSyncModalProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<TNaverSyncFormValues>({
+    mode: "onChange",
+    resolver: zodResolver(naverSyncSchema),
+    defaultValues: getDefaultNaverSyncDateRange(),
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    reset(getDefaultNaverSyncDateRange());
+  }, [isOpen, reset]);
+
+  const handleClose = () => {
+    if (isLoading) return;
+    onClose();
+  };
+
+  const onFormSubmit: SubmitHandler<TNaverSyncFormValues> = (values) => {
+    onSubmit(values);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="네이버 데이터 동기화"
+      size="md"
+      disableOverlayClick={isLoading}
+    >
+      <form
+        onSubmit={handleSubmit(onFormSubmit)}
+        className="flex flex-col gap-5"
+        noValidate
+      >
+        <p className="font-body2 text-text-muted">
+          동기화할 기간을 선택해 주세요.
+        </p>
+
+        <div className="grid grid-cols-2 gap-4 tablet:grid-cols-1">
+          <div
+            role="presentation"
+            className={!isLoading ? "cursor-pointer" : undefined}
+            onClick={openDatePickerFromField}
+          >
+            <Input
+              label="시작일"
+              type="date"
+              disabled={isLoading}
+              error={!!errors.startDate}
+              helperText={errors.startDate?.message}
+              inputClassName="cursor-pointer"
+              {...register("startDate")}
+            />
+          </div>
+          <div
+            role="presentation"
+            className={!isLoading ? "cursor-pointer" : undefined}
+            onClick={openDatePickerFromField}
+          >
+            <Input
+              label="종료일"
+              type="date"
+              disabled={isLoading}
+              error={!!errors.endDate}
+              helperText={errors.endDate?.message}
+              inputClassName="cursor-pointer"
+              {...register("endDate")}
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-4 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="big"
+            className="flex-1"
+            onClick={handleClose}
+            disabled={isLoading}
+          >
+            취소
+          </Button>
+          <Button
+            type="submit"
+            size="big"
+            className="flex-1"
+            disabled={!isValid || isLoading}
+            isLoading={isLoading}
+          >
+            {isLoading ? "동기화 중..." : "동기화"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -1,4 +1,5 @@
 import { memo, type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
 
 import { PLATFORM_MAP } from "@/types/dashboard/provider";
 import type {
@@ -16,6 +17,7 @@ import {
 import Badge, { type TBadgeVariant } from "@/components/common/badge/Badge";
 import Button from "@/components/common/button/Button";
 
+import SyncIcon from "@/assets/icon/common/sync.svg?react";
 import GoogleLogo from "@/assets/logo/social-logo/circle/google-circle.svg?react";
 import MetaLogo from "@/assets/logo/social-logo/circle/meta-circle.svg?react";
 import NaverLogo from "@/assets/logo/social-logo/circle/naver-circle.svg?react";
@@ -54,8 +56,13 @@ type TProps = IPlatformConnectionItem & {
   onConnect?: () => void;
   onReconnect?: () => void;
   onDisconnect?: () => void;
+  onSync?: () => void;
   isConnectLoading?: boolean;
+  isSyncLoading?: boolean;
 };
+
+const SYNC_LINK_CLASS =
+  "inline-flex shrink-0 items-center gap-1 font-body2 text-text-muted transition-colors hover:text-primary-400 disabled:cursor-wait disabled:opacity-50";
 
 function PlatformConnectionMeta({
   status,
@@ -63,6 +70,8 @@ function PlatformConnectionMeta({
   externalAccountId,
   platformAccountId,
   tokenExpireAt,
+  onSync,
+  isSyncLoading = false,
 }: Pick<
   IPlatformConnectionItem,
   | "status"
@@ -70,7 +79,10 @@ function PlatformConnectionMeta({
   | "externalAccountId"
   | "platformAccountId"
   | "tokenExpireAt"
->) {
+> & {
+  onSync?: () => void;
+  isSyncLoading?: boolean;
+}) {
   const syncedLabel = formatConnectionDateTime(syncedAt);
   const expireLabel = formatConnectionDate(tokenExpireAt);
   const expireTone = getTokenExpireTone(tokenExpireAt);
@@ -117,6 +129,64 @@ function PlatformConnectionMeta({
             <span>토큰 만료 예정 · </span>
             <span className="text-text-muted/60">—</span>
           </p>
+        </>
+      ) : status === "connected" ? (
+        <>
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <p className="min-w-0 font-body2 text-text-muted">
+              <span>마지막 동기화 · </span>
+              <span className="text-text-title">{syncedLabel ?? "—"}</span>
+            </p>
+            {onSync ? (
+              <button
+                type="button"
+                onClick={onSync}
+                disabled={isSyncLoading}
+                className={SYNC_LINK_CLASS}
+              >
+                <SyncIcon
+                  className={twMerge(
+                    "h-4 w-4 shrink-0",
+                    isSyncLoading && "animate-spin",
+                  )}
+                  aria-hidden
+                />
+                {isSyncLoading ? "동기화 중..." : "동기화"}
+              </button>
+            ) : null}
+          </div>
+
+          {!syncedAt ? (
+            <p className="font-body2 text-text-muted/80">
+              아직 동기화된 데이터가 없습니다. 동기화를 진행해 주세요.
+            </p>
+          ) : null}
+
+          {externalAccountId ? (
+            <p className="min-w-0 font-body2 text-text-muted">
+              <span>연동 계정 · </span>
+              <span
+                className="truncate text-text-title"
+                title={externalAccountId}
+              >
+                {externalAccountId}
+              </span>
+            </p>
+          ) : null}
+
+          {expireLabel ? (
+            <p className="font-body2 text-text-muted">
+              <span>토큰 만료 예정 · </span>
+              <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
+                {expireLabel}
+              </span>
+            </p>
+          ) : (
+            <p className="font-body2 text-text-muted">
+              <span>토큰 만료 예정 · </span>
+              <span className="text-text-muted/60">—</span>
+            </p>
+          )}
         </>
       ) : (
         <>
@@ -169,7 +239,9 @@ function PlatformIntegrationCard({
   onConnect,
   onReconnect,
   onDisconnect,
+  onSync,
   isConnectLoading = false,
+  isSyncLoading = false,
 }: TProps) {
   const label = PLATFORM_MAP[provider] ?? provider;
   const statusLabel =
@@ -200,6 +272,8 @@ function PlatformIntegrationCard({
         externalAccountId={externalAccountId}
         platformAccountId={platformAccountId}
         tokenExpireAt={tokenExpireAt}
+        onSync={status === "connected" ? onSync : undefined}
+        isSyncLoading={isSyncLoading}
       />
 
       {status === "error" && errorMessage ? (
@@ -252,6 +326,7 @@ function PlatformIntegrationCard({
                 size="big"
                 className="min-w-0 flex-1"
                 onClick={onReconnect}
+                disabled={isSyncLoading}
               >
                 재연동
               </Button>
@@ -261,6 +336,7 @@ function PlatformIntegrationCard({
                 size="big"
                 className="min-w-0 flex-1"
                 onClick={onDisconnect}
+                disabled={isSyncLoading}
               >
                 연동 해제
               </Button>

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -7,7 +7,14 @@ import type {
   IPlatformConnectionItem,
   TIntegrationProvider,
 } from "@/types/integration/platformConnection";
+import type {
+  IGoogleSyncData,
+  IMetaSyncData,
+  INaverSyncData,
+} from "@/types/integration/platformSync";
 
+import type { TNaverSyncFormValues } from "@/utils/integration/naverSyncSchema";
+import { getPlatformSyncToast } from "@/utils/integration/platformSync";
 import { startPlatformConnect } from "@/utils/integration/startPlatformConnect";
 
 import { useCoreMutation } from "@/hooks/customQuery";
@@ -17,6 +24,7 @@ import { usePlatformConnections } from "@/hooks/integration/usePlatformConnectio
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
 import NaverConnectModal from "@/components/integration/NaverConnectModal";
+import NaverSyncModal from "@/components/integration/NaverSyncModal";
 import PlatformDisconnectModal from "@/components/integration/PlatformDisconnectModal";
 import PlatformIntegrationCard from "@/components/integration/PlatformIntegrationCard";
 import PlatformIntegrationsPageSkeleton from "@/components/integration/skeleton/PlatformIntegrationsSkeleton";
@@ -25,6 +33,9 @@ import {
   KakaoUpcomingCard,
 } from "@/components/integration/UpcomingPlatformCard";
 
+import { syncGoogleAdData } from "@/api/integration/google";
+import { syncMetaAdData } from "@/api/integration/meta";
+import { syncNaverAdData } from "@/api/integration/naver";
 import {
   disconnectPlatformAccount,
   reconnectPlatformAccount,
@@ -47,6 +58,9 @@ export default function PlatformIntegrationsPage() {
     "connect",
   );
   const [naverCustomerId, setNaverCustomerId] = useState<string | undefined>();
+  const [isNaverSyncModalOpen, setIsNaverSyncModalOpen] = useState(false);
+  const [syncingProvider, setSyncingProvider] =
+    useState<TIntegrationProvider | null>(null);
 
   const [disconnectTarget, setDisconnectTarget] =
     useState<TDisconnectTarget | null>(null);
@@ -96,6 +110,70 @@ export default function PlatformIntegrationsPage() {
       },
     },
   );
+
+  const invalidateConnections = async (requestOrgId: number) => {
+    await queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.platform.connections(requestOrgId),
+    });
+  };
+
+  const metaSyncMutation = useCoreMutation<IMetaSyncData, number>(
+    (requestOrgId) => syncMetaAdData(requestOrgId),
+    {
+      userOnSuccess: async (data, requestOrgId) => {
+        await invalidateConnections(requestOrgId);
+        const { type, message } = getPlatformSyncToast("META", data);
+        if (type === "success") toast.success(message);
+        else toast.warning(message);
+        setSyncingProvider(null);
+      },
+      userOnError: (apiError) => {
+        toast.error(apiError.message ?? "Meta 동기화에 실패했습니다.");
+        setSyncingProvider(null);
+      },
+    },
+  );
+
+  const googleSyncMutation = useCoreMutation<IGoogleSyncData, void>(
+    () => syncGoogleAdData(),
+    {
+      userOnSuccess: async (data) => {
+        if (orgId == null) return;
+        await invalidateConnections(orgId);
+        const { type, message } = getPlatformSyncToast("GOOGLE", data);
+        if (type === "success") toast.success(message);
+        else toast.warning(message);
+        setSyncingProvider(null);
+      },
+      userOnError: (apiError) => {
+        toast.error(apiError.message ?? "Google 동기화에 실패했습니다.");
+        setSyncingProvider(null);
+      },
+    },
+  );
+
+  const naverSyncMutation = useCoreMutation<
+    INaverSyncData,
+    { requestOrgId: number; body: TNaverSyncFormValues }
+  >(({ requestOrgId, body }) => syncNaverAdData(requestOrgId, body), {
+    userOnSuccess: async (data, { requestOrgId }) => {
+      await invalidateConnections(requestOrgId);
+      const { type, message } = getPlatformSyncToast("NAVER", data);
+      if (type === "success") toast.success(message);
+      else toast.warning(message);
+      setSyncingProvider(null);
+      setIsNaverSyncModalOpen(false);
+    },
+    userOnError: (apiError) => {
+      toast.error(apiError.message ?? "네이버 동기화에 실패했습니다.");
+      setSyncingProvider(null);
+    },
+  });
+
+  const isSyncPending =
+    metaSyncMutation.isPending ||
+    googleSyncMutation.isPending ||
+    naverSyncMutation.isPending;
 
   useIntegrationOAuthReturn(orgId);
 
@@ -180,6 +258,41 @@ export default function PlatformIntegrationsPage() {
     });
   };
 
+  const handleSync = (provider: TIntegrationProvider) => {
+    if (orgId == null) {
+      toast.error("워크스페이스를 선택해 주세요.");
+      return;
+    }
+
+    if (isSyncPending) return;
+
+    const item = platformConnections.find((p) => p.provider === provider);
+    if (item?.status !== "connected") return;
+
+    if (provider === "NAVER") {
+      setIsNaverSyncModalOpen(true);
+      return;
+    }
+
+    setSyncingProvider(provider);
+
+    if (provider === "META") {
+      metaSyncMutation.mutate(orgId);
+      return;
+    }
+
+    if (provider === "GOOGLE") {
+      googleSyncMutation.mutate(undefined);
+    }
+  };
+
+  const handleNaverSyncSubmit = (values: TNaverSyncFormValues) => {
+    if (orgId == null || naverSyncMutation.isPending) return;
+
+    setSyncingProvider("NAVER");
+    naverSyncMutation.mutate({ requestOrgId: orgId, body: values });
+  };
+
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
       {isLoading ? (
@@ -209,10 +322,14 @@ export default function PlatformIntegrationsPage() {
                     onConnect={() => handleConnect(item.provider)}
                     onReconnect={() => handleConnect(item.provider)}
                     onDisconnect={() => handleDisconnect(item)}
+                    onSync={() => handleSync(item.provider)}
                     isConnectLoading={
                       reconnectMutation.isPending &&
                       reconnectMutation.variables?.accountId ===
                         item.platformAccountId
+                    }
+                    isSyncLoading={
+                      syncingProvider === item.provider && isSyncPending
                     }
                   />
                 </li>
@@ -244,6 +361,17 @@ export default function PlatformIntegrationsPage() {
           orgId={orgId}
           mode={naverModalMode}
           initialCustomerId={naverCustomerId}
+        />
+      ) : null}
+      {orgId != null ? (
+        <NaverSyncModal
+          isOpen={isNaverSyncModalOpen}
+          onClose={() => {
+            if (naverSyncMutation.isPending) return;
+            setIsNaverSyncModalOpen(false);
+          }}
+          onSubmit={handleNaverSyncSubmit}
+          isLoading={naverSyncMutation.isPending}
         />
       ) : null}
       <PlatformDisconnectModal

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -134,12 +134,11 @@ export default function PlatformIntegrationsPage() {
     },
   );
 
-  const googleSyncMutation = useCoreMutation<IGoogleSyncData, void>(
+  const googleSyncMutation = useCoreMutation<IGoogleSyncData, number>(
     () => syncGoogleAdData(),
     {
-      userOnSuccess: async (data) => {
-        if (orgId == null) return;
-        await invalidateConnections(orgId);
+      userOnSuccess: async (data, requestOrgId) => {
+        await invalidateConnections(requestOrgId);
         const { type, message } = getPlatformSyncToast("GOOGLE", data);
         if (type === "success") toast.success(message);
         else toast.warning(message);
@@ -282,7 +281,7 @@ export default function PlatformIntegrationsPage() {
     }
 
     if (provider === "GOOGLE") {
-      googleSyncMutation.mutate(undefined);
+      googleSyncMutation.mutate(orgId);
     }
   };
 

--- a/src/types/integration/platformSync.ts
+++ b/src/types/integration/platformSync.ts
@@ -1,0 +1,24 @@
+/** Meta / Naver sync 공통 count 응답 */
+export interface IPlatformSyncCountData {
+  adCampaignCount: number;
+  adGroupCount: number;
+  adContentCount: number;
+  metricCount: number;
+}
+
+export interface IMetaSyncData extends IPlatformSyncCountData {
+  failedAccountIds: string[];
+}
+
+export interface INaverSyncRequest {
+  startDate: string; // "yyyy-MM-dd"
+  endDate: string;
+}
+
+export interface INaverSyncData extends IPlatformSyncCountData {
+  failedConnectionIds: number[];
+}
+
+export interface IGoogleSyncData {
+  message: string;
+}

--- a/src/utils/integration/naverSyncSchema.ts
+++ b/src/utils/integration/naverSyncSchema.ts
@@ -1,6 +1,10 @@
 import z from "zod";
 
-const dateFieldSchema = z.string().trim().min(1, "날짜를 선택해 주세요");
+const dateFieldSchema = z
+  .string()
+  .trim()
+  .min(1, { error: "날짜를 선택해 주세요" })
+  .pipe(z.iso.date({ error: "유효한 날짜를 입력해 주세요" }));
 
 export const naverSyncSchema = z
   .object({

--- a/src/utils/integration/naverSyncSchema.ts
+++ b/src/utils/integration/naverSyncSchema.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+
+const dateFieldSchema = z.string().trim().min(1, "날짜를 선택해 주세요");
+
+export const naverSyncSchema = z
+  .object({
+    startDate: dateFieldSchema,
+    endDate: dateFieldSchema,
+  })
+  .refine((data) => data.startDate <= data.endDate, {
+    path: ["endDate"],
+    message: "종료일은 시작일 이전일 수 없습니다",
+  });
+
+export type TNaverSyncFormValues = z.infer<typeof naverSyncSchema>;

--- a/src/utils/integration/platformSync.ts
+++ b/src/utils/integration/platformSync.ts
@@ -6,9 +6,12 @@ import type {
   INaverSyncData,
 } from "@/types/integration/platformSync";
 
-/** 오늘 기준 yyyy-MM-dd */
+/** 로컬 기준 yyyy-MM-dd */
 function toDateString(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 /** Naver sync 모달 기본값: 최근 30일 */

--- a/src/utils/integration/platformSync.ts
+++ b/src/utils/integration/platformSync.ts
@@ -1,0 +1,69 @@
+import { PLATFORM_MAP } from "@/types/dashboard/provider";
+import type { TIntegrationProvider } from "@/types/integration/platformConnection";
+import type {
+  IGoogleSyncData,
+  IMetaSyncData,
+  INaverSyncData,
+} from "@/types/integration/platformSync";
+
+/** 오늘 기준 yyyy-MM-dd */
+function toDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Naver sync 모달 기본값: 최근 30일 */
+export function getDefaultNaverSyncDateRange(): {
+  startDate: string;
+  endDate: string;
+} {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(end.getDate() - 29);
+
+  return {
+    startDate: toDateString(start),
+    endDate: toDateString(end),
+  };
+}
+
+type TSyncResult = IMetaSyncData | INaverSyncData;
+
+function hasPartialFailure(data: TSyncResult): boolean {
+  if ("failedAccountIds" in data) {
+    return data.failedAccountIds.length > 0;
+  }
+  return data.failedConnectionIds.length > 0;
+}
+
+function getFailedCount(data: TSyncResult): number {
+  if ("failedAccountIds" in data) {
+    return data.failedAccountIds.length;
+  }
+  return data.failedConnectionIds.length;
+}
+
+export function getPlatformSyncToast(
+  provider: TIntegrationProvider,
+  data: TSyncResult | IGoogleSyncData,
+): { type: "success" | "warning"; message: string } {
+  const label = PLATFORM_MAP[provider] ?? provider;
+
+  if ("message" in data) {
+    return {
+      type: "success",
+      message: data.message || `${label} 데이터를 동기화했습니다.`,
+    };
+  }
+
+  if (hasPartialFailure(data)) {
+    return {
+      type: "warning",
+      message: `${label} 동기화는 완료됐지만 일부 계정에서 실패했습니다. (${getFailedCount(data)}건)`,
+    };
+  }
+
+  return {
+    type: "success",
+    message: `${label} 데이터를 동기화했습니다.`,
+  };
+}


### PR DESCRIPTION
## 🚨 관련 이슈
close #398 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [X] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
자동 동기화 주기 이전에 데이터 변동이 있을 때, 플랫폼 연동 페이지에서 필요할 때 직접 동기화할 수 있도록 했습니다. 
(최초 연동 시 자동 sync와는 별개의 on-demand 기능)

### 사용자 흐름
```
플랫폼 연동 페이지 (/integrations)
  └─ 카드 상태가 「연동됨」일 때만
       └─ 「마지막 동기화」 옆 [↻ 동기화] 클릭
            ├─ Meta / Google → 즉시 sync API 호출
            └─ Naver → 날짜 선택 모달 → 기간 확인 후 sync
  └─ 「연동 오류」/「미연동」 → 동기화 UI 없음 (재연동 유도)
```

### 동기화 API
- Meta — POST /api/meta/{orgId}/refresh (7일 고정, 60초 rate limit)
- Google — POST /api/google/ad-infos
- Naver — POST /api/naver/{orgId}/sync + 날짜 body (기본 30일)

<img width="1620" height="974" alt="스크린샷 2026-08-06 오전 3 26 20" src="https://github.com/user-attachments/assets/daa653ab-61bd-493a-8707-289c690f7fd6" />

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
- 다음 이슈 - 연동 직후 자동 sync

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Meta, Google, Naver 광고 데이터를 플랫폼별로 동기화할 수 있습니다.
  * Naver 동기화 기간을 입력하는 모달과 최근 30일 기본 기간을 제공합니다.
  * 동기화 진행 상태, 애니메이션, 결과 안내를 연결된 플랫폼 카드에서 확인할 수 있습니다.
* **개선**
  * 동기화 성공, 부분 실패, 전체 실패 상황에 맞는 알림을 제공합니다.
  * 동기화 중에는 재연동·연동 해제 및 모달 조작이 제한됩니다.
  * 날짜 입력값과 시작일·종료일 순서를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->