### PR TITLE
[Design/#402] 워크스페이스 목록 카드 시각 계층/사용자 눈에 띄도록 개선

### DIFF
--- a/src/components/workspace/WorkspaceCard.tsx
+++ b/src/components/workspace/WorkspaceCard.tsx
@@ -6,6 +6,7 @@ import { ROLE_LABEL_MAP } from "@/constants/workspaceRole";
 
 import Badge from "@/components/common/badge/Badge";
 
+import ChevronRightIcon from "@/assets/icon/chevron/chevron-right.svg?react";
 import { getImageUrl } from "@/lib/getImageUrl";
 
 type TProps = {
@@ -30,11 +31,11 @@ function WorkspaceCard({ workspace: w, isSelected = false, onClick }: TProps) {
       <button
         type="button"
         className={twMerge(
-          "relative flex h-full min-h-52 w-full flex-col rounded-2xl border-[1.5px] bg-surface-100 p-6 text-left shadow-Soft",
+          "group relative flex h-full min-h-52 w-full flex-col rounded-2xl border-[1.5px] bg-surface-100 p-6 text-left shadow-Soft",
           "focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none",
           "tablet:min-h-48 tablet:p-5",
           onClick &&
-            "cursor-pointer transition-all duration-300 ease-out hover:-translate-y-1 hover:border-primary-300 hover:bg-primary-100/35 active:scale-[0.98]",
+            "cursor-pointer transition-all duration-300 ease-out hover:-translate-y-1 hover:border-primary-400/30 hover:bg-primary-100/35 active:scale-[0.98]",
           isSelected
             ? "border-primary-400 bg-primary-100/55 ring-2 ring-primary-400/30"
             : "border-surface-400",
@@ -71,27 +72,29 @@ function WorkspaceCard({ workspace: w, isSelected = false, onClick }: TProps) {
           )}
         </div>
 
-        <div className="flex min-w-0 flex-1 flex-col pr-12">
-          <div
-            className={twMerge(
-              "truncate font-heading4",
-              isSelected ? "text-surface-500" : "text-text-title",
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="pr-12">
+            <div
+              className={twMerge(
+                "truncate font-heading4",
+                isSelected ? "text-surface-500" : "text-text-title",
+              )}
+            >
+              {w.name}
+            </div>
+
+            {w.description ? (
+              <p className="mt-1.5 line-clamp-2 font-body2 text-text-muted">
+                {w.description}
+              </p>
+            ) : (
+              <p className="mt-1.5 font-body2 text-text-placeholder">
+                설명이 없습니다
+              </p>
             )}
-          >
-            {w.name}
           </div>
 
-          {w.description ? (
-            <p className="mt-1.5 line-clamp-2 font-body2 text-text-muted">
-              {w.description}
-            </p>
-          ) : (
-            <p className="mt-1.5 font-body2 text-text-placeholder">
-              설명이 없습니다
-            </p>
-          )}
-
-          <div className="mt-auto pt-5">
+          <div className="mt-auto flex items-center pt-5 pr-8">
             <Badge
               variant={w.myRole === "ADMIN" ? "infoBlue" : "surface"}
               className="h-6 px-2"
@@ -100,6 +103,16 @@ function WorkspaceCard({ workspace: w, isSelected = false, onClick }: TProps) {
             </Badge>
           </div>
         </div>
+
+        <ChevronRightIcon
+          aria-hidden
+          className={twMerge(
+            "pointer-events-none absolute right-5 bottom-6 h-5 w-5 transition-all duration-300 ease-out tablet:bottom-5 tablet:right-4",
+            isSelected
+              ? "text-primary-500"
+              : "text-text-muted group-hover:text-primary-500",
+          )}
+        />
       </button>
     </li>
   );

--- a/src/components/workspace/WorkspaceCard.tsx
+++ b/src/components/workspace/WorkspaceCard.tsx
@@ -4,7 +4,8 @@ import { twMerge } from "tailwind-merge";
 import type { TWorkspace } from "@/types/workspace/workspace";
 import { ROLE_LABEL_MAP } from "@/constants/workspaceRole";
 
-import BuildingIcon from "@/assets/icon/common/building.svg?react";
+import Badge from "@/components/common/badge/Badge";
+
 import { getImageUrl } from "@/lib/getImageUrl";
 
 type TProps = {
@@ -22,60 +23,81 @@ function WorkspaceCard({ workspace: w, isSelected = false, onClick }: TProps) {
 
   const imageSrc = w.logoUrl ? getImageUrl(w.logoUrl) : null;
   const showPlaceholder = !imageSrc || imageError;
+  const initial = (w.name.trim()[0] ?? "?").toUpperCase();
 
   return (
-    <li className="block w-full">
+    <li className="block h-full">
       <button
         type="button"
         className={twMerge(
-          "flex w-full items-center justify-between rounded-2xl border bg-surface-100 px-6 py-5 text-left shadow-Soft tablet:px-4 tablet:py-4 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none",
+          "relative flex h-full min-h-52 w-full flex-col rounded-2xl border-[1.5px] bg-surface-100 p-6 text-left shadow-Soft",
+          "focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none",
+          "tablet:min-h-48 tablet:p-5",
           onClick &&
-            "cursor-pointer transition-all duration-300 ease-out hover:-translate-y-1 hover:border-primary-400/30 hover:bg-primary-100/50 active:scale-[0.98]",
+            "cursor-pointer transition-all duration-300 ease-out hover:-translate-y-1 hover:border-primary-300 hover:bg-primary-100/35 active:scale-[0.98]",
           isSelected
-            ? "border-primary-500/40 bg-primary-100/50"
-            : "border-surface-400 focus-within:border-primary-400/50",
+            ? "border-primary-400 bg-primary-100/55 ring-2 ring-primary-400/30"
+            : "border-surface-400",
         )}
         onClick={onClick}
       >
-        <div className="flex items-center gap-5 min-w-0 tablet:gap-3">
-          <div className="h-24 w-24 shrink-0 rounded-lg bg-surface-200 tablet:h-16 tablet:w-16">
-            {showPlaceholder ? (
-              <div className="w-full h-full flex items-center justify-center">
-                <BuildingIcon className="w-8 h-8 text-text-placeholder" />
-              </div>
-            ) : (
-              <img
-                src={imageSrc}
-                alt={`${w.name} 로고`}
-                className="w-full h-full object-cover rounded-lg pointer-events-none"
-                onError={() => {
-                  setImageError(true);
-                }}
-              />
+        {isSelected && (
+          <span
+            role="status"
+            className="absolute top-5 right-5 shrink-0 rounded-full bg-primary-500/85 px-2.5 py-1 font-caption text-surface-100"
+          >
+            현재 기준
+          </span>
+        )}
+
+        <div
+          className={twMerge(
+            "mb-5 flex h-18 w-18 items-center justify-center overflow-hidden rounded-2xl",
+            "tablet:mb-4 tablet:h-14 tablet:w-14",
+            showPlaceholder
+              ? "bg-primary-100 text-primary-500"
+              : "bg-surface-200",
+          )}
+        >
+          {showPlaceholder ? (
+            <span className="font-heading3">{initial}</span>
+          ) : (
+            <img
+              src={imageSrc}
+              alt={`${w.name} 로고`}
+              className="h-full w-full object-cover pointer-events-none"
+              onError={() => setImageError(true)}
+            />
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col pr-12">
+          <div
+            className={twMerge(
+              "truncate font-heading4",
+              isSelected ? "text-surface-500" : "text-text-title",
             )}
+          >
+            {w.name}
           </div>
 
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <div className="truncate font-heading4 text-text-title">
-                {w.name}
-              </div>
-              {isSelected && (
-                <span
-                  role="status"
-                  className="shrink-0 rounded-full bg-primary-500/12 px-2 py-1 font-caption text-primary-500"
-                >
-                  현재 대시보드 기준
-                </span>
-              )}
-            </div>
+          {w.description ? (
+            <p className="mt-1.5 line-clamp-2 font-body2 text-text-muted">
+              {w.description}
+            </p>
+          ) : (
+            <p className="mt-1.5 font-body2 text-text-placeholder">
+              설명이 없습니다
+            </p>
+          )}
 
-            <div className="mt-1 truncate font-body2 text-text-title">
-              {w.description ?? ""}
-            </div>
-            <div className="mt-2 font-body1 text-text-muted">
+          <div className="mt-auto pt-5">
+            <Badge
+              variant={w.myRole === "ADMIN" ? "infoBlue" : "surface"}
+              className="h-6 px-2"
+            >
               {ROLE_LABEL_MAP[w.myRole]}
-            </div>
+            </Badge>
           </div>
         </div>
       </button>

--- a/src/components/workspace/WorkspaceListLoading.tsx
+++ b/src/components/workspace/WorkspaceListLoading.tsx
@@ -2,19 +2,50 @@ import { Skeleton } from "@/components/common/skeleton/Skeleton";
 
 function WorkspaceCardSkeleton() {
   return (
-    <li className="flex h-full min-h-52 flex-col rounded-2xl border border-surface-400 bg-surface-100 p-6 shadow-Soft tablet:min-h-48 tablet:p-5">
-      <Skeleton className="mb-5 h-16 w-16 rounded-2xl tablet:mb-4 tablet:h-14 tablet:w-14" />
-      <Skeleton className="h-5 w-36" />
-      <Skeleton className="mt-2 h-4 w-full" />
-      <Skeleton className="mt-1.5 h-4 w-4/5" />
-      <div className="mt-auto pt-5">
-        <Skeleton className="h-6 w-14 rounded-full" />
+    <li className="relative flex h-full min-h-52 flex-col rounded-2xl border-[1.5px] border-surface-400 bg-surface-100 p-6 shadow-Soft tablet:min-h-48 tablet:p-5">
+      <Skeleton className="mb-5 h-18 w-18 shrink-0 rounded-2xl tablet:mb-4 tablet:h-14 tablet:w-14" />
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="pr-12">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="mt-1.5 h-4 w-full" />
+          <Skeleton className="mt-1 h-4 w-4/5" />
+        </div>
+
+        <div className="mt-auto flex items-center pt-5 pr-8">
+          <Skeleton className="h-6 w-14 rounded-full" />
+        </div>
       </div>
+
+      <Skeleton className="absolute right-5 bottom-6 h-5 w-5 rounded-md tablet:bottom-5 tablet:right-4" />
     </li>
   );
 }
 
-export default function WorkspaceListLoading() {
+function WorkspaceCardListSkeleton() {
+  return (
+    <ul className="grid grid-cols-2 gap-5 tablet:grid-cols-1">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <WorkspaceCardSkeleton key={i} />
+      ))}
+    </ul>
+  );
+}
+
+type TProps = {
+  /** 페이지 내부 로딩: 카드 그리드만. 라우트 Suspense: 전체 스켈레톤 */
+  listOnly?: boolean;
+};
+
+export default function WorkspaceListLoading({ listOnly = false }: TProps) {
+  if (listOnly) {
+    return (
+      <div role="status" aria-label="워크스페이스 목록 불러오는 중">
+        <WorkspaceCardListSkeleton />
+      </div>
+    );
+  }
+
   return (
     <section
       role="status"
@@ -25,11 +56,7 @@ export default function WorkspaceListLoading() {
         <Skeleton className="h-15 w-full rounded-2xl" />
         <Skeleton className="h-15 w-56 rounded-2xl tablet:w-full" />
       </div>
-      <ul className="grid grid-cols-2 gap-5 tablet:grid-cols-1">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <WorkspaceCardSkeleton key={i} />
-        ))}
-      </ul>
+      <WorkspaceCardListSkeleton />
     </section>
   );
 }

--- a/src/components/workspace/WorkspaceListLoading.tsx
+++ b/src/components/workspace/WorkspaceListLoading.tsx
@@ -2,18 +2,15 @@ import { Skeleton } from "@/components/common/skeleton/Skeleton";
 
 function WorkspaceCardSkeleton() {
   return (
-    <>
-      <li className="flex items-center justify-between rounded-2xl border border-surface-400 bg-surface-100 px-6 py-5 shadow-Soft tablet:px-4 tablet:py-4">
-        <div className="flex items-center gap-5 min-w-0 tablet:gap-3">
-          <Skeleton className="w-24 h-24 shrink-0 rounded-lg tablet:h-18 tablet:w-18" />
-          <div className="flex flex-col gap-2 min-w-0">
-            <Skeleton className="h-5 w-40" />
-            <Skeleton className="h-4 w-64" />
-            <Skeleton className="h-4 w-16" />
-          </div>
-        </div>
-      </li>
-    </>
+    <li className="flex h-full min-h-52 flex-col rounded-2xl border border-surface-400 bg-surface-100 p-6 shadow-Soft tablet:min-h-48 tablet:p-5">
+      <Skeleton className="mb-5 h-16 w-16 rounded-2xl tablet:mb-4 tablet:h-14 tablet:w-14" />
+      <Skeleton className="h-5 w-36" />
+      <Skeleton className="mt-2 h-4 w-full" />
+      <Skeleton className="mt-1.5 h-4 w-4/5" />
+      <div className="mt-auto pt-5">
+        <Skeleton className="h-6 w-14 rounded-full" />
+      </div>
+    </li>
   );
 }
 
@@ -24,16 +21,12 @@ export default function WorkspaceListLoading() {
       aria-label="워크스페이스 목록 불러오는 중"
       className="w-full flex flex-col gap-8"
     >
-      <div className="space-y-3">
-        <Skeleton className="h-8 w-50" />
-        <Skeleton className="h-5 w-60 tablet:w-56" />
-      </div>
       <div className="flex items-center justify-between gap-4 tablet:flex-col tablet:items-stretch">
         <Skeleton className="h-15 w-full rounded-2xl" />
         <Skeleton className="h-15 w-56 rounded-2xl tablet:w-full" />
       </div>
-      <ul className="space-y-5">
-        {Array.from({ length: 7 }).map((_, i) => (
+      <ul className="grid grid-cols-2 gap-5 tablet:grid-cols-1">
+        {Array.from({ length: 6 }).map((_, i) => (
           <WorkspaceCardSkeleton key={i} />
         ))}
       </ul>

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -168,13 +168,13 @@ export default function WorkspacePage() {
     }
     if (sortedWorkspaces.length === 0) {
       return (
-        <ul className="space-y-5">
+        <ul className="grid grid-cols-2 gap-5 rounded-2xl bg-surface-200/80 p-4 tablet:grid-cols-1">
           <WorkspaceEmptyState message="워크스페이스가 없습니다" />
         </ul>
       );
     }
     return (
-      <ul className="space-y-5">
+      <ul className="grid grid-cols-2 gap-5 tablet:grid-cols-1">
         {sortedWorkspaces.map((w) => (
           <WorkspaceCard
             key={String(w.orgId)}

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -156,7 +156,7 @@ export default function WorkspacePage() {
 
   const renderWorkspaceContent = () => {
     if (isListLoading) {
-      return <WorkspaceListLoading />;
+      return <WorkspaceListLoading listOnly />;
     }
     if (listErrorMsg) {
       return (

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -169,7 +169,9 @@ export default function WorkspacePage() {
     if (sortedWorkspaces.length === 0) {
       return (
         <ul className="grid grid-cols-2 gap-5 rounded-2xl bg-surface-200/80 p-4 tablet:grid-cols-1">
-          <WorkspaceEmptyState message="워크스페이스가 없습니다" />
+          <li className="col-span-full">
+            <WorkspaceEmptyState message="워크스페이스가 없습니다" />
+          </li>
         </ul>
       );
     }


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #402 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

워크스페이스 목록 카드가 존재감이 약하고 눈에 잘 띄지않고, 사용자가 바로 사용하고 싶다는 생각이 들지 않는다는 피드백을 반영하여, 2열 그리드 카드로 재구성하고, 선택/호버 계층을 강화하고, 세부적인 디테일을 수정했습니다.
(기능/클릭 동작은 기존과 동일합니다.)

### 워크스페이스 목록 페이지
- 워크스페이스 목록
  - 기존: 1열 그리드
  - 변경: 2열 그리드로 변경 (태블릿/모바일은 1열)
- 워크스페이스 없을때도 같은 그리드 톤 유지, 배경 깔아서 덜 허전해 보이도록 조정
- 목록 불러오는 중일때는 카드 영역만 로딩 표시

### 워크스페이스 카드
- 아이템 배치:
  - 기존: 가로형 리스트 아이템
  - 변경: 세로형 카드로 변경하여 이름/설명이 하나의 카드에서 읽히도록 구성
- 로고 없을때:
  - 기존: BuildingIcon
  - 변경: 워크스페이스 이름 첫글자(이니셜) 표시
- 역할 표시:
  - 기존: 텍스트로 표시
  - 변경: 뱃지로 변경
- 현재 선택된 워크스페이스는 테두리/배경 강조 + 우상단 `현재기준 뱃지` 표시. 이름 색도 더 진하게 표시
- 우하단에 `>` 아이콘 추가하여 카드 선택하면 상세설정 가는 느낌 추가 (평소에는 회색, hover/선택시에는 brandColor로 변경)
- 카드 hover시 위로 떠오르는 인터렉션 유지

### 워크스페이스 로딩 스켈레톤
- 바뀐 카드 레이아웃에 맞춰서 스켈레톤 형태 동기화
- 페이지에서 목록만 로딩할때/라우트 전체 로딩일때 구분하여 검색창 두번나오지않도록 정리


## 💻 작업 화면

### 기존화면
<img width="1724" height="880" alt="image" src="https://github.com/user-attachments/assets/3093c4db-06b8-4226-851e-c2137284d346" />
<img width="1724" height="885" alt="image" src="https://github.com/user-attachments/assets/1b5258c6-71e7-4ded-b949-abc74be9adb3" />


### 변경화면
<img width="1880" height="887" alt="image" src="https://github.com/user-attachments/assets/40037ece-0502-4201-81be-ad66ab05663c" />
<img width="1865" height="882" alt="image" src="https://github.com/user-attachments/assets/613f9075-4899-4de3-a0ca-147a85888973" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- 밋밋한 디자인에서 사용자가 사용하고 싶어하는 느낌이 들도록 생동감과 레이아웃 배치 및 세부적인 디테일을 수정하였습니다. 혹시 추가 디자인 수정사항 있으시면 코멘트로 제안주시면 좋을것같아요! 피드백 환영합니다! 

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
