### PR TITLE
[Bugfix/#410] 타임라인 월(MONTH) 보기 초기 스크롤을 월 초로 수정

### DIFF
--- a/src/pages/dashboard/timeline/Timeline.tsx
+++ b/src/pages/dashboard/timeline/Timeline.tsx
@@ -179,7 +179,7 @@ export default function Timeline() {
     if (hasNoTimelines) return;
     const el = scrollRef.current;
     if (!el) return;
-    el.scrollLeft = el.scrollWidth - el.clientWidth;
+    el.scrollLeft = viewUnit === "MONTH" ? 0 : el.scrollWidth - el.clientWidth;
   }, [columns, hasNoTimelines, viewUnit]);
 
   useEffect(() => {


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #410 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 월(`MONTH`) 보기 진입 시 가로 스크롤이 월 말로 가던 문제를 수정해서 월 초부터 보이도록 수정진행했습니다.
- 일/주 보기는 기존 유지

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 월 보기로 전환할 때 타임라인 스크롤 위치가 왼쪽 끝으로 초기화되도록 개선했습니다.
  * 주·일 보기에서는 기존처럼 타임라인이 오른쪽 끝으로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->