### PR TITLE
[Feature/#405] 모바일·태블릿 반응형 처리

### DIFF
--- a/src/assets/icon/sidebar/menu.svg
+++ b/src/assets/icon/sidebar/menu.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 5H20M4 12H20M4 19H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ads/AdDetailContent.tsx
+++ b/src/components/ads/AdDetailContent.tsx
@@ -60,7 +60,7 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
   return (
     <div className="animate-fade-in">
       <div className="border-t border-surface-400/60">
-        <div className="flex flex-col gap-4 px-4 pb-2 pt-4 tablet:px-5 mobile:gap-3 mobile:px-3 mobile:pt-3">
+        <div className="flex flex-col gap-4 px-4 pb-2 pt-4 tablet:px-5 mobile:gap-3 mobile:px-4 mobile:pt-3">
           <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3 mobile:px-3 mobile:py-2.5">
             <h3 className="mb-2 font-caption text-text-placeholder">
               광고 소재
@@ -116,7 +116,7 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
           </section>
         </div>
 
-        <div className="mx-4 mb-4 mt-1 overflow-hidden rounded-lg border border-surface-400/40 bg-surface-100 tablet:mx-5 mobile:mx-3 mobile:mb-3">
+        <div className="mx-4 mb-4 mt-1 overflow-hidden rounded-lg border border-surface-400/40 bg-surface-100 tablet:mx-5 mobile:mx-4 mobile:mb-3">
           <div className="flex flex-wrap items-start justify-between gap-3 gap-y-3 px-4 py-4 mobile:px-3 mobile:py-3">
             <div className="min-w-0 flex-1">
               <p className="font-caption text-text-placeholder">트래킹</p>

--- a/src/components/ads/AdDetailContent.tsx
+++ b/src/components/ads/AdDetailContent.tsx
@@ -60,8 +60,8 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
   return (
     <div className="animate-fade-in">
       <div className="border-t border-surface-400/60">
-        <div className="flex flex-col gap-4 px-4 pb-2 pt-4 tablet:px-5">
-          <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3">
+        <div className="flex flex-col gap-4 px-4 pb-2 pt-4 tablet:px-5 mobile:gap-3 mobile:px-3 mobile:pt-3">
+          <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3 mobile:px-3 mobile:py-2.5">
             <h3 className="mb-2 font-caption text-text-placeholder">
               광고 소재
             </h3>
@@ -70,7 +70,7 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
             </p>
           </section>
 
-          <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3">
+          <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3 mobile:px-3 mobile:py-2.5">
             <h3 className="mb-2 font-caption text-text-placeholder">타겟</h3>
             <div className="flex flex-wrap gap-2">
               {tags.length > 0 ? (
@@ -91,7 +91,7 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
             </div>
           </section>
 
-          <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3">
+          <section className="rounded-lg border border-surface-400/40 bg-surface-100 px-4 py-3 mobile:px-3 mobile:py-2.5">
             <h3 className="mb-2 font-caption text-text-placeholder">
               랜딩 URL
             </h3>
@@ -116,8 +116,8 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
           </section>
         </div>
 
-        <div className="mx-4 mb-4 mt-1 overflow-hidden rounded-lg border border-surface-400/40 bg-surface-100 tablet:mx-5">
-          <div className="flex flex-wrap items-start justify-between gap-3 gap-y-3 px-4 py-4">
+        <div className="mx-4 mb-4 mt-1 overflow-hidden rounded-lg border border-surface-400/40 bg-surface-100 tablet:mx-5 mobile:mx-3 mobile:mb-3">
+          <div className="flex flex-wrap items-start justify-between gap-3 gap-y-3 px-4 py-4 mobile:px-3 mobile:py-3">
             <div className="min-w-0 flex-1">
               <p className="font-caption text-text-placeholder">트래킹</p>
               <p className="mt-1 font-body1 text-text-title">

--- a/src/components/ads/AdRow.tsx
+++ b/src/components/ads/AdRow.tsx
@@ -18,8 +18,8 @@ const adListTableGridColsWithoutPlatform =
   "grid w-full min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_5.5rem_2.5rem] items-center gap-x-3 mobile:grid-cols-[2rem_minmax(0,1fr)_auto_1.75rem] mobile:gap-x-1.5";
 
 const adListTableGridPadding = {
-  header: "px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:px-3 mobile:py-3",
-  row: "px-6 py-5 tablet:px-5 tablet:py-4 mobile:px-3 mobile:py-3",
+  header: "px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:px-4 mobile:py-3",
+  row: "px-6 py-5 tablet:px-5 tablet:py-4 mobile:px-4 mobile:py-3",
 } as const;
 
 export function getAdListTableStatusCellClass() {

--- a/src/components/ads/AdRow.tsx
+++ b/src/components/ads/AdRow.tsx
@@ -12,18 +12,18 @@ import NaverLogo from "@/assets/logo/social-logo/circle/naver-circle.svg?react";
 
 /** 체크박스 | 광고 명 | 상태 | (플랫폼) | 펼침 — AdListTable과 동일 그리드 */
 const adListTableGridColsWithPlatform =
-  "grid w-full min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_5.5rem_2.75rem_2.5rem] items-center gap-x-3";
+  "grid w-full min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_5.5rem_2.75rem_2.5rem] items-center gap-x-3 mobile:grid-cols-[2rem_minmax(0,1fr)_auto_2rem_1.75rem] mobile:gap-x-1.5";
 
 const adListTableGridColsWithoutPlatform =
-  "grid w-full min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_5.5rem_2.5rem] items-center gap-x-3";
+  "grid w-full min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_5.5rem_2.5rem] items-center gap-x-3 mobile:grid-cols-[2rem_minmax(0,1fr)_auto_1.75rem] mobile:gap-x-1.5";
 
 const adListTableGridPadding = {
-  header: "px-6 py-4 tablet:px-5 tablet:py-3.5",
-  row: "px-6 py-5 tablet:px-5 tablet:py-4",
+  header: "px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:px-3 mobile:py-3",
+  row: "px-6 py-5 tablet:px-5 tablet:py-4 mobile:px-3 mobile:py-3",
 } as const;
 
 export function getAdListTableStatusCellClass() {
-  return "flex min-w-0 items-center justify-center justify-self-center self-center";
+  return "flex min-w-0 items-center justify-center justify-self-center self-center mobile:justify-self-end";
 }
 
 export function getAdListTableHeaderGridClass(hidePlatformColumn = false) {
@@ -117,7 +117,7 @@ export default function AdRow({
           onClick={onToggle}
           aria-expanded={isOpen}
           className={twMerge(
-            "min-w-0 cursor-pointer truncate text-left font-body1 outline-none transition-colors hover:text-primary-500",
+            "min-w-0 cursor-pointer truncate text-left font-body1-rsp outline-none transition-colors hover:text-primary-500",
             isPaused ? "text-text-muted" : "text-text-title",
             isOpen && "text-primary-500",
           )}
@@ -126,13 +126,16 @@ export default function AdRow({
         </button>
 
         <div className={getAdListTableStatusCellClass()}>
-          <Badge variant={runStatus === "running" ? "infoBlue" : "surface"}>
+          <Badge
+            variant={runStatus === "running" ? "infoBlue" : "surface"}
+            className="mobile:h-6 mobile:px-2"
+          >
             {runStatusText}
           </Badge>
         </div>
 
         {!hidePlatformColumn ? (
-          <div className="flex min-w-11 items-center justify-start justify-self-start">
+          <div className="flex min-w-11 items-center justify-start justify-self-start mobile:min-w-0">
             <span className="flex shrink-0" title={platform}>
               {LogoMap[platform] ?? (
                 <span className="font-caption text-text-muted">?</span>
@@ -146,7 +149,7 @@ export default function AdRow({
             type="button"
             onClick={onToggle}
             aria-label={isOpen ? `${name} 상세 접기` : `${name} 상세 펼치기`}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-auth-sub transition-colors hover:bg-surface-200/80 hover:text-text-title"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-auth-sub transition-colors hover:bg-surface-200/80 hover:text-text-title mobile:h-8 mobile:w-8"
           >
             <ChevronIcon
               className={twMerge(

--- a/src/components/ads/CampaignPlatformSection.tsx
+++ b/src/components/ads/CampaignPlatformSection.tsx
@@ -92,8 +92,13 @@ export default function CampaignPlatformSection({
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {PLATFORM_LOGO[platform]}
             <div className="flex min-w-0 flex-col gap-1">
-              <h2 className="font-heading3 text-text-title">
-                {PLATFORM_LABEL[platform]}
+              <h2 className="text-text-title">
+                <span className="font-heading3 mobile:hidden">
+                  {PLATFORM_LABEL[platform]}
+                </span>
+                <span className="hidden font-heading4 mobile:inline">
+                  {PLATFORM_LABEL[platform]}
+                </span>
               </h2>
               {platformBudget?.adCampaignName ? (
                 <p className="truncate font-body2 text-text-muted">

--- a/src/components/ads/CampaignRow.tsx
+++ b/src/components/ads/CampaignRow.tsx
@@ -20,6 +20,14 @@ interface ICampaignRowProps {
   onClick?: () => void;
 }
 
+/** 헤더·행·스켈레톤 플랫폼 열 — 모바일에서 로고 최대 3개 폭 예약 */
+export const CAMPAIGN_PLATFORM_COL_CLASS =
+  "mr-24 w-28 shrink-0 tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-16";
+
+/** 헤더·행·스켈레톤 예산 열 */
+export const CAMPAIGN_BUDGET_COL_CLASS =
+  "w-[28%] shrink-0 tablet:w-[26%] mobile:w-[30%] mobile:max-w-28";
+
 const LogoMap: Record<TPlatform, ReactNode> = {
   meta: (
     <MetaLogo className="h-7 w-7 shrink-0 text-text-title tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
@@ -88,7 +96,12 @@ export default function CampaignRow({
         </div>
       </div>
 
-      <div className="mr-24 flex w-28 shrink-0 items-center justify-start tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-auto">
+      <div
+        className={twMerge(
+          CAMPAIGN_PLATFORM_COL_CLASS,
+          "flex items-center justify-start",
+        )}
+      >
         {providers && providers.length > 0 ? (
           <div className="flex items-center justify-start gap-1 mobile:gap-0.5">
             {providers.map((p, idx) => (
@@ -105,10 +118,7 @@ export default function CampaignRow({
       </div>
 
       <div
-        className={twMerge(
-          "w-[28%] shrink-0 tablet:w-[26%] mobile:w-[30%] mobile:max-w-28",
-          isPaused && "opacity-80",
-        )}
+        className={twMerge(CAMPAIGN_BUDGET_COL_CLASS, isPaused && "opacity-80")}
       >
         <ProgressBar value={budgetUsageRate} />
       </div>

--- a/src/components/ads/CampaignRow.tsx
+++ b/src/components/ads/CampaignRow.tsx
@@ -22,10 +22,14 @@ interface ICampaignRowProps {
 
 const LogoMap: Record<TPlatform, ReactNode> = {
   meta: (
-    <MetaLogo className="h-7 w-7 shrink-0 text-text-title tablet:h-6 tablet:w-6" />
+    <MetaLogo className="h-7 w-7 shrink-0 text-text-title tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
   ),
-  google: <GoogleLogo className="h-7 w-7 shrink-0 tablet:h-6 tablet:w-6" />,
-  naver: <NaverLogo className="h-7 w-7 shrink-0 tablet:h-6 tablet:w-6" />,
+  google: (
+    <GoogleLogo className="h-7 w-7 shrink-0 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
+  ),
+  naver: (
+    <NaverLogo className="h-7 w-7 shrink-0 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
+  ),
 };
 
 export default function CampaignRow({
@@ -42,7 +46,7 @@ export default function CampaignRow({
   return (
     <li
       className={twMerge(
-        "flex list-none cursor-pointer items-center border-b border-surface-400/50 px-6 py-5 transition-colors last:border-b-0 tablet:px-5 tablet:py-4",
+        "flex list-none cursor-pointer items-center border-b border-surface-400/50 px-6 py-5 transition-colors last:border-b-0 tablet:px-5 tablet:py-4 mobile:px-3 mobile:py-3",
         isSelected
           ? "bg-primary-100/35 hover:bg-primary-100/45"
           : "bg-surface-100 hover:bg-surface-200/50",
@@ -59,7 +63,7 @@ export default function CampaignRow({
       }}
     >
       <div
-        className="flex w-11 shrink-0 items-center justify-center tablet:w-10"
+        className="flex w-11 shrink-0 items-center justify-center tablet:w-10 mobile:w-8"
         role="presentation"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
@@ -73,10 +77,10 @@ export default function CampaignRow({
         />
       </div>
 
-      <div className="min-w-0 flex-1 pr-5 tablet:pr-4">
+      <div className="min-w-0 flex-1 pr-5 tablet:pr-4 mobile:pr-2">
         <div
           className={twMerge(
-            "truncate font-body1",
+            "truncate font-body1-rsp",
             isPaused ? "text-text-muted" : "text-text-title",
           )}
         >
@@ -84,9 +88,9 @@ export default function CampaignRow({
         </div>
       </div>
 
-      <div className="mr-24 flex w-28 shrink-0 items-center justify-start tablet:mr-20 tablet:w-24">
+      <div className="mr-24 flex w-28 shrink-0 items-center justify-start tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-auto">
         {providers && providers.length > 0 ? (
-          <div className="flex items-center justify-start gap-1">
+          <div className="flex items-center justify-start gap-1 mobile:gap-0.5">
             {providers.map((p, idx) => (
               <span key={idx} className="flex shrink-0">
                 {LogoMap[p.toLowerCase() as TPlatform] ?? (
@@ -102,7 +106,7 @@ export default function CampaignRow({
 
       <div
         className={twMerge(
-          "w-[28%] shrink-0 tablet:w-[26%]",
+          "w-[28%] shrink-0 tablet:w-[26%] mobile:w-[30%] mobile:max-w-28",
           isPaused && "opacity-80",
         )}
       >

--- a/src/components/ads/CampaignTable.tsx
+++ b/src/components/ads/CampaignTable.tsx
@@ -3,7 +3,10 @@ import { twMerge } from "tailwind-merge";
 
 import type { ICampaign } from "@/types/ads/campaign";
 
-import CampaignRow from "./CampaignRow";
+import CampaignRow, {
+  CAMPAIGN_BUDGET_COL_CLASS,
+  CAMPAIGN_PLATFORM_COL_CLASS,
+} from "./CampaignRow";
 
 interface ICampaignTableProps {
   campaigns: ICampaign[];
@@ -71,10 +74,20 @@ export default function CampaignTable({
         <div className="min-w-0 flex-1 font-label text-text-muted">
           캠페인 명
         </div>
-        <div className="mr-24 w-28 shrink-0 whitespace-nowrap text-left font-label text-text-muted tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-auto">
+        <div
+          className={twMerge(
+            CAMPAIGN_PLATFORM_COL_CLASS,
+            "whitespace-nowrap text-left font-label text-text-muted",
+          )}
+        >
           <span className="mobile:hidden">플랫폼</span>
         </div>
-        <div className="w-[28%] shrink-0 text-left font-label text-text-muted tablet:w-[26%] mobile:w-[30%] mobile:max-w-28">
+        <div
+          className={twMerge(
+            CAMPAIGN_BUDGET_COL_CLASS,
+            "text-left font-label text-text-muted",
+          )}
+        >
           <span className="tablet:hidden">예산 소진 현황</span>
           <span className="hidden tablet:inline">예산</span>
         </div>

--- a/src/components/ads/CampaignTable.tsx
+++ b/src/components/ads/CampaignTable.tsx
@@ -53,9 +53,9 @@ export default function CampaignTable({
           : "rounded-xl border border-surface-400/40",
       )}
     >
-      <div className="flex shrink-0 items-center border-b border-surface-400/50 bg-surface-200/60 px-6 py-4 tablet:px-5 tablet:py-3.5">
+      <div className="flex shrink-0 items-center border-b border-surface-400/50 bg-surface-200/60 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:px-3 mobile:py-3">
         <div
-          className="flex w-11 shrink-0 items-center justify-center tablet:w-10"
+          className="flex w-11 shrink-0 items-center justify-center tablet:w-10 mobile:w-8"
           role="presentation"
           onClick={(e) => e.stopPropagation()}
         >
@@ -71,10 +71,10 @@ export default function CampaignTable({
         <div className="min-w-0 flex-1 font-label text-text-muted">
           캠페인 명
         </div>
-        <div className="w-28 shrink-0 text-left font-label text-text-muted whitespace-nowrap mr-24 tablet:w-24 tablet:mr-20">
-          플랫폼
+        <div className="mr-24 w-28 shrink-0 whitespace-nowrap text-left font-label text-text-muted tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-auto">
+          <span className="mobile:hidden">플랫폼</span>
         </div>
-        <div className="w-[28%] shrink-0 text-left font-label text-text-muted tablet:w-[26%]">
+        <div className="w-[28%] shrink-0 text-left font-label text-text-muted tablet:w-[26%] mobile:w-[30%] mobile:max-w-28">
           <span className="tablet:hidden">예산 소진 현황</span>
           <span className="hidden tablet:inline">예산</span>
         </div>

--- a/src/components/ads/skeleton/AdsSkeleton.tsx
+++ b/src/components/ads/skeleton/AdsSkeleton.tsx
@@ -205,7 +205,7 @@ export function AdListTableSkeleton({
 export function CampaignDetailAdsSectionSkeleton() {
   return (
     <Card className="flex flex-col overflow-hidden p-0">
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-3">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-4">
         <div className="flex min-w-0 flex-1 flex-col gap-2 mobile:flex-none">
           <Skeleton className="h-3 w-20" />
           <Skeleton className="h-6 w-28" />
@@ -216,7 +216,7 @@ export function CampaignDetailAdsSectionSkeleton() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5 mobile:gap-4 mobile:px-3 mobile:py-4">
+      <div className="flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5 mobile:gap-4 mobile:px-4 mobile:py-4">
         <div className="flex items-stretch gap-3">
           <span
             className="w-1 shrink-0 self-stretch rounded-r-md bg-surface-400"

--- a/src/components/ads/skeleton/AdsSkeleton.tsx
+++ b/src/components/ads/skeleton/AdsSkeleton.tsx
@@ -70,17 +70,17 @@ export function AdsListPageSkeleton() {
       aria-label="캠페인 목록 로딩 중"
     >
       <Card className="flex flex-col overflow-hidden p-0">
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:flex-col tablet:items-stretch tablet:px-5 tablet:py-3.5 mobile:px-3">
-          <div className="flex min-w-0 flex-1 flex-col gap-2 tablet:flex-none">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-3">
+          <div className="flex min-w-0 flex-1 flex-col gap-2 mobile:flex-none">
             <Skeleton className="h-3 w-8" />
             <Skeleton className="h-6 w-28" />
           </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 tablet:w-full tablet:flex-col tablet:items-stretch">
-            <div className="flex items-center gap-2 tablet:w-full">
-              <Skeleton className="h-9 w-14 rounded-xl tablet:min-w-0 tablet:flex-1" />
-              <Skeleton className="h-9 w-14 rounded-xl tablet:min-w-0 tablet:flex-1" />
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 mobile:w-full mobile:flex-col mobile:items-stretch">
+            <div className="flex items-center gap-2 mobile:w-full">
+              <Skeleton className="h-9 w-14 rounded-xl mobile:min-w-0 mobile:flex-1" />
+              <Skeleton className="h-9 w-14 rounded-xl mobile:min-w-0 mobile:flex-1" />
             </div>
-            <Skeleton className="h-9 w-32 rounded-xl tablet:w-full" />
+            <Skeleton className="h-9 w-32 rounded-xl mobile:w-full" />
           </div>
         </div>
 
@@ -94,8 +94,11 @@ export function AdsListPageSkeleton() {
 
 export function CampaignDetailHeaderSkeleton() {
   return (
-    <Card className="px-6 py-8 tablet:px-5 tablet:py-7" aria-hidden>
-      <header className="flex w-full flex-col gap-6">
+    <Card
+      className="px-6 py-8 tablet:px-5 tablet:py-7 mobile:px-4 mobile:py-6"
+      aria-hidden
+    >
+      <header className="flex w-full flex-col gap-6 mobile:gap-7">
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
           <div className="flex min-w-0 flex-wrap items-center gap-3">
             <Skeleton className="h-8 w-48 max-w-full" />
@@ -190,18 +193,18 @@ export function AdListTableSkeleton({
 export function CampaignDetailAdsSectionSkeleton() {
   return (
     <Card className="flex flex-col overflow-hidden p-0">
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5">
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-2 mobile:flex-none">
           <Skeleton className="h-3 w-20" />
           <Skeleton className="h-6 w-28" />
         </div>
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          <Skeleton className="h-9 w-14 rounded-xl" />
-          <Skeleton className="h-9 w-14 rounded-xl" />
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 mobile:w-full">
+          <Skeleton className="h-9 w-14 rounded-xl mobile:min-w-0 mobile:flex-1" />
+          <Skeleton className="h-9 w-14 rounded-xl mobile:min-w-0 mobile:flex-1" />
         </div>
       </div>
 
-      <div className="flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5">
+      <div className="flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5 mobile:gap-4 mobile:px-3 mobile:py-4">
         <div className="flex items-stretch gap-3">
           <span
             className="w-1 shrink-0 self-stretch rounded-r-md bg-surface-400"

--- a/src/components/ads/skeleton/AdsSkeleton.tsx
+++ b/src/components/ads/skeleton/AdsSkeleton.tsx
@@ -17,20 +17,20 @@ const PLATFORM_DROPDOWN_COUNT = 3;
 function CampaignTableRowSkeleton() {
   return (
     <li
-      className="flex list-none items-center border-b border-surface-400/50 px-6 py-5 last:border-b-0 tablet:px-5 tablet:py-4"
+      className="flex list-none items-center border-b border-surface-400/50 px-6 py-5 last:border-b-0 tablet:px-5 tablet:py-4 mobile:px-3 mobile:py-3"
       aria-hidden
     >
-      <div className="flex w-11 shrink-0 items-center justify-center tablet:w-10">
+      <div className="flex w-11 shrink-0 items-center justify-center tablet:w-10 mobile:w-8">
         <Skeleton className="h-4 w-4 rounded" />
       </div>
-      <div className="min-w-0 flex-1 pr-5 tablet:pr-4">
+      <div className="min-w-0 flex-1 pr-5 tablet:pr-4 mobile:pr-2">
         <Skeleton className="h-4 w-full max-w-48" />
       </div>
-      <div className="mr-24 flex w-28 shrink-0 items-center gap-1 tablet:mr-20 tablet:w-24">
-        <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6" />
-        <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6" />
+      <div className="mr-24 flex w-28 shrink-0 items-center gap-1 tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-auto mobile:gap-0.5">
+        <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
+        <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
       </div>
-      <div className="w-[28%] shrink-0 tablet:w-[26%]">
+      <div className="w-[28%] shrink-0 tablet:w-[26%] mobile:w-[30%] mobile:max-w-28">
         <Skeleton className="h-2 w-full rounded-full" />
       </div>
     </li>
@@ -43,14 +43,14 @@ export function CampaignTableSkeleton() {
       className="flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-surface-100"
       aria-hidden
     >
-      <div className="flex shrink-0 items-center border-b border-surface-400/50 bg-surface-200/60 px-6 py-4 tablet:px-5 tablet:py-3.5">
-        <div className="flex w-11 shrink-0 items-center justify-center tablet:w-10">
+      <div className="flex shrink-0 items-center border-b border-surface-400/50 bg-surface-200/60 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:px-3 mobile:py-3">
+        <div className="flex w-11 shrink-0 items-center justify-center tablet:w-10 mobile:w-8">
           <Skeleton className="h-4 w-4 rounded" />
         </div>
         <Skeleton className="h-4 w-16" />
         <div className="flex-1" aria-hidden />
-        <Skeleton className="mr-24 h-4 w-12 tablet:mr-20" />
-        <Skeleton className="h-4 w-24" />
+        <Skeleton className="mr-24 h-4 w-12 tablet:mr-20 mobile:mr-2 mobile:hidden" />
+        <Skeleton className="h-4 w-24 mobile:w-16" />
       </div>
 
       <ul className="m-0 list-none p-0">
@@ -70,15 +70,17 @@ export function AdsListPageSkeleton() {
       aria-label="캠페인 목록 로딩 중"
     >
       <Card className="flex flex-col overflow-hidden p-0">
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5">
-          <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:flex-col tablet:items-stretch tablet:px-5 tablet:py-3.5 mobile:px-3">
+          <div className="flex min-w-0 flex-1 flex-col gap-2 tablet:flex-none">
             <Skeleton className="h-3 w-8" />
             <Skeleton className="h-6 w-28" />
           </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-            <Skeleton className="h-9 w-14 rounded-xl" />
-            <Skeleton className="h-9 w-14 rounded-xl" />
-            <Skeleton className="h-9 w-32 rounded-xl" />
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 tablet:w-full tablet:flex-col tablet:items-stretch">
+            <div className="flex items-center gap-2 tablet:w-full">
+              <Skeleton className="h-9 w-14 rounded-xl tablet:min-w-0 tablet:flex-1" />
+              <Skeleton className="h-9 w-14 rounded-xl tablet:min-w-0 tablet:flex-1" />
+            </div>
+            <Skeleton className="h-9 w-32 rounded-xl tablet:w-full" />
           </div>
         </div>
 

--- a/src/components/ads/skeleton/AdsSkeleton.tsx
+++ b/src/components/ads/skeleton/AdsSkeleton.tsx
@@ -4,6 +4,10 @@ import {
   getAdListTableHeaderGridClass,
   getAdListTableRowGridClass,
 } from "@/components/ads/AdRow";
+import {
+  CAMPAIGN_BUDGET_COL_CLASS,
+  CAMPAIGN_PLATFORM_COL_CLASS,
+} from "@/components/ads/CampaignRow";
 import Card from "@/components/common/card/Card";
 import {
   Skeleton,
@@ -26,11 +30,16 @@ function CampaignTableRowSkeleton() {
       <div className="min-w-0 flex-1 pr-5 tablet:pr-4 mobile:pr-2">
         <Skeleton className="h-4 w-full max-w-48" />
       </div>
-      <div className="mr-24 flex w-28 shrink-0 items-center gap-1 tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-auto mobile:gap-0.5">
+      <div
+        className={twMerge(
+          CAMPAIGN_PLATFORM_COL_CLASS,
+          "flex items-center gap-1 mobile:gap-0.5",
+        )}
+      >
         <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
         <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
       </div>
-      <div className="w-[28%] shrink-0 tablet:w-[26%] mobile:w-[30%] mobile:max-w-28">
+      <div className={CAMPAIGN_BUDGET_COL_CLASS}>
         <Skeleton className="h-2 w-full rounded-full" />
       </div>
     </li>
@@ -47,10 +56,13 @@ export function CampaignTableSkeleton() {
         <div className="flex w-11 shrink-0 items-center justify-center tablet:w-10 mobile:w-8">
           <Skeleton className="h-4 w-4 rounded" />
         </div>
-        <Skeleton className="h-4 w-16" />
-        <div className="flex-1" aria-hidden />
-        <Skeleton className="mr-24 h-4 w-12 tablet:mr-20 mobile:mr-2 mobile:hidden" />
-        <Skeleton className="h-4 w-24 mobile:w-16" />
+        <div className="min-w-0 flex-1">
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <div className={CAMPAIGN_PLATFORM_COL_CLASS} aria-hidden />
+        <div className={CAMPAIGN_BUDGET_COL_CLASS}>
+          <Skeleton className="h-4 w-24 mobile:w-16" />
+        </div>
       </div>
 
       <ul className="m-0 list-none p-0">

--- a/src/components/common/card/StatCard.tsx
+++ b/src/components/common/card/StatCard.tsx
@@ -16,6 +16,8 @@ export interface IStatCardProps extends HTMLAttributes<HTMLDivElement> {
   trend?: ITrend;
   /** 수치·트렌드 배지를 기본보다 한 단계 작게 (제목은 동일) */
   compact?: boolean;
+  /** 수치 타이포 오버라이드 (중첩 카드 등) */
+  valueClassName?: string;
 }
 
 const trendClasses: Record<ITrend["direction"], string> = {
@@ -61,6 +63,7 @@ const StatCard = memo(function StatCard({
   trend,
   className,
   compact = false,
+  valueClassName,
   ...rest
 }: IStatCardProps) {
   return (
@@ -76,6 +79,7 @@ const StatCard = memo(function StatCard({
         className={twMerge(
           "text-text-title tracking-tight",
           compact ? "font-heading2" : "font-heading1",
+          valueClassName,
         )}
       >
         {value}

--- a/src/components/common/card/StatCard.tsx
+++ b/src/components/common/card/StatCard.tsx
@@ -69,15 +69,16 @@ const StatCard = memo(function StatCard({
   return (
     <div
       className={twMerge(
-        "bg-surface-100/80 backdrop-blur-sm rounded-3xl shadow-Soft p-7 flex flex-col gap-4 border border-surface-100/40",
+        "flex flex-col gap-4 rounded-3xl border border-surface-100/40 bg-surface-100/80 p-7 shadow-Soft backdrop-blur-sm",
         className,
       )}
       {...rest}
     >
       <p className="font-body2 text-text-muted">{title}</p>
       <p
+        title={String(value)}
         className={twMerge(
-          "text-text-title tracking-tight",
+          "tracking-tight text-text-title",
           compact ? "font-heading2" : "font-heading1",
           valueClassName,
         )}

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -192,9 +192,11 @@ function Modal({
             <motion.div
               ref={modalRef}
               className={twMerge(
-                "relative w-full max-h-[90vh] overflow-auto rounded-2xl bg-surface-100 shadow-Soft",
+                "relative mx-4 w-full max-h-[90vh] overflow-auto rounded-2xl bg-surface-100 shadow-Soft",
                 sizeClasses[size],
                 paddingClasses[padding],
+                // absolute 닫기 버튼(top-4 right-4)과 본문 겹침 방지
+                !hideCloseButton && "pr-12",
                 className,
               )}
               initial={{ opacity: 0, scale: reduceMotion ? 1 : 0.95 }}

--- a/src/components/common/progressbar/ProgressBar.tsx
+++ b/src/components/common/progressbar/ProgressBar.tsx
@@ -26,7 +26,7 @@ export default function ProgressBar({
         />
       </div>
       {/* 퍼센트 텍스트 */}
-      <span className="min-w-8 w-11 shrink-0 text-right font-body1 text-text-muted">
+      <span className="min-w-8 w-11 shrink-0 text-right font-body1-rsp text-text-muted">
         {progress}%
       </span>
     </div>

--- a/src/components/dashboard/charts/BudgetGaugeChart.tsx
+++ b/src/components/dashboard/charts/BudgetGaugeChart.tsx
@@ -122,7 +122,7 @@ const BudgetGaugeChart = memo(function BudgetGaugeChart({
           </div>
         )}
         <div className={twMerge("flex items-baseline gap-2", remainingRowGap)}>
-          <span className="font-heading1 text-text-title tabular-nums leading-none">
+          <span className="font-heading2 text-text-title tabular-nums leading-none">
             {remainingPct}%
           </span>
           <span className="font-body2 text-text-body tabular-nums">남음</span>

--- a/src/components/dashboard/charts/PerformanceEfficiencyChart.tsx
+++ b/src/components/dashboard/charts/PerformanceEfficiencyChart.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, Suspense, useMemo } from "react";
+import { lazy, memo, Suspense, useMemo, useSyncExternalStore } from "react";
 
 import type { IPlatformPerformance } from "@/types/dashboard/platform";
 import { PLATFORM_MAP } from "@/types/dashboard/provider";
@@ -9,15 +9,37 @@ import { getMixedChartOptions } from "./performanceEfficiencyChart.config";
 
 const Chart = lazy(() => import("react-apexcharts"));
 
+const MOBILE_MQ = "(max-width: 639px)";
+
+function subscribeMobile(onStoreChange: () => void) {
+  const mq = window.matchMedia(MOBILE_MQ);
+  mq.addEventListener("change", onStoreChange);
+  return () => mq.removeEventListener("change", onStoreChange);
+}
+
+function getMobileSnapshot() {
+  return window.matchMedia(MOBILE_MQ).matches;
+}
+
+function getServerMobileSnapshot() {
+  return false;
+}
+
 export const PerformanceEfficiencyChart = memo(
   ({ data }: { data: IPlatformPerformance[] }) => {
+    const isMobile = useSyncExternalStore(
+      subscribeMobile,
+      getMobileSnapshot,
+      getServerMobileSnapshot,
+    );
+
     const categories = useMemo(
       () => data.map((d) => PLATFORM_MAP[d.provider] || d.provider),
       [data],
     );
     const options = useMemo(
-      () => getMixedChartOptions(categories),
-      [categories],
+      () => getMixedChartOptions(categories, { compact: isMobile }),
+      [categories, isMobile],
     );
 
     const series = [
@@ -40,9 +62,11 @@ export const PerformanceEfficiencyChart = memo(
       },
     ];
 
+    const chartHeight = isMobile ? 175 : 150;
+
     return (
-      <Suspense fallback={<div className="h-40" />}>
-        <Chart options={options} series={series} height={150} />
+      <Suspense fallback={<div className={isMobile ? "h-44" : "h-40"} />}>
+        <Chart options={options} series={series} height={chartHeight} />
       </Suspense>
     );
   },

--- a/src/components/dashboard/charts/performanceEfficiencyChart.config.ts
+++ b/src/components/dashboard/charts/performanceEfficiencyChart.config.ts
@@ -2,7 +2,10 @@ import type { ApexOptions } from "apexcharts";
 
 import { METRIC_REGISTRY as M } from "@/utils/dashboard/metricRegistry";
 
-export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
+export const getMixedChartOptions = (
+  categories: string[],
+  { compact = false }: { compact?: boolean } = {},
+): ApexOptions => ({
   chart: {
     type: "line",
     toolbar: { show: false },
@@ -35,6 +38,7 @@ export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
   xaxis: {
     categories: categories,
     labels: {
+      hideOverlappingLabels: !compact,
       style: {
         fontSize: "14px",
         fontWeight: 500,
@@ -47,6 +51,7 @@ export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
   yaxis: [
     {
       seriesName: M.ctr.label,
+      show: !compact,
       labels: {
         formatter: (val) => M.ctr.format(val),
         style: {
@@ -62,6 +67,7 @@ export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
     {
       opposite: true,
       seriesName: M.impressions.label,
+      show: !compact,
       labels: {
         offsetX: -10,
         formatter: (val) => M.impressions.format(val),
@@ -90,10 +96,9 @@ export const getMixedChartOptions = (categories: string[]): ApexOptions => ({
   grid: {
     borderColor: "var(--color-surface-200)",
     yaxis: { lines: { show: true } },
-    padding: {
-      bottom: -15,
-      top: -15,
-    },
+    padding: compact
+      ? { bottom: 4, top: 0, left: 4, right: 4 }
+      : { bottom: -15, top: -15 },
   },
   legend: { show: false },
 });

--- a/src/components/dashboard/platform/PlatformDetailCard.tsx
+++ b/src/components/dashboard/platform/PlatformDetailCard.tsx
@@ -24,10 +24,10 @@ export const PlatformDetailCard = memo(
     const kpis = useMemo(() => metricsToKpis(data), [data]);
 
     const innerCardClass =
-      "shadow-none! hover:shadow-none! !rounded-2xl p-2! gap-2!";
+      "min-w-0 shadow-none! hover:shadow-none! !rounded-2xl p-2! gap-2!";
 
     return (
-      <Card className="flex-1 p-7">
+      <Card className="min-w-0 flex-1 p-7">
         <div className="mb-8 flex items-center gap-2">
           <div className="shrink-0">{PLATFORM_LOGOS[provider]}</div>
           <h3 className="truncate font-heading4 text-text-title">
@@ -35,7 +35,7 @@ export const PlatformDetailCard = memo(
           </h3>
         </div>
 
-        <div className="grid grid-cols-2 gap-2">
+        <div className="grid min-w-0 grid-cols-2 gap-2">
           {kpis.map((kpi) => (
             <StatCard
               key={kpi.title}
@@ -43,7 +43,7 @@ export const PlatformDetailCard = memo(
               value={kpi.value}
               trend={kpi.trend}
               className={innerCardClass}
-              valueClassName="font-heading2"
+              valueClassName="min-w-0 truncate font-heading2-rsp tabular-nums"
             />
           ))}
         </div>

--- a/src/components/dashboard/platform/PlatformDetailCard.tsx
+++ b/src/components/dashboard/platform/PlatformDetailCard.tsx
@@ -43,6 +43,8 @@ export const PlatformDetailCard = memo(
               value={kpi.value}
               trend={kpi.trend}
               className={innerCardClass}
+              compact
+              valueClassName="font-heading3"
             />
           ))}
         </div>

--- a/src/components/dashboard/platform/PlatformDetailCard.tsx
+++ b/src/components/dashboard/platform/PlatformDetailCard.tsx
@@ -43,8 +43,7 @@ export const PlatformDetailCard = memo(
               value={kpi.value}
               trend={kpi.trend}
               className={innerCardClass}
-              compact
-              valueClassName="font-heading3"
+              valueClassName="font-heading2"
             />
           ))}
         </div>

--- a/src/components/dashboard/platform/PlatformViewSwitcher.tsx
+++ b/src/components/dashboard/platform/PlatformViewSwitcher.tsx
@@ -44,7 +44,7 @@ export default function PlatformViewSwitcher({
         variant={isAllView ? "primary" : "custom"}
         onClick={onSelectAll}
         className={twMerge(
-          "rounded-2xl py-5 font-body1",
+          "h-12 rounded-2xl font-body1",
           isMobileLayout ? "w-full min-w-0" : "w-28 shrink-0",
           !isAllView &&
             "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",
@@ -62,7 +62,7 @@ export default function PlatformViewSwitcher({
               size="small"
               variant={!isAllView ? "primary" : "custom"}
               className={twMerge(
-                "flex items-center rounded-2xl py-5",
+                "flex h-12 items-center rounded-2xl",
                 isMobileLayout ? "w-full min-w-0" : "w-34 shrink-0",
                 isAllView &&
                   "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",

--- a/src/components/dashboard/platform/PlatformViewSwitcher.tsx
+++ b/src/components/dashboard/platform/PlatformViewSwitcher.tsx
@@ -1,0 +1,94 @@
+import { twMerge } from "tailwind-merge";
+
+import Button from "@/components/common/button/Button";
+import { DropdownMenu } from "@/components/common/dropdownmenu/DropdownMenu";
+
+import ChevronDownIcon from "@/assets/icon/chevron/chevron-up.svg?react";
+
+type TPlatformViewSwitcherItem = {
+  label: string;
+  onClick: () => void;
+};
+
+interface IPlatformViewSwitcherProps {
+  isAllView: boolean;
+  selectedPlatformLabel: string;
+  platformItems: TPlatformViewSwitcherItem[];
+  onSelectAll: () => void;
+  layout?: "header" | "mobile";
+  className?: string;
+}
+
+export default function PlatformViewSwitcher({
+  isAllView,
+  selectedPlatformLabel,
+  platformItems,
+  onSelectAll,
+  layout = "header",
+  className,
+}: IPlatformViewSwitcherProps) {
+  const isMobileLayout = layout === "mobile";
+
+  return (
+    <div
+      className={twMerge(
+        isMobileLayout
+          ? "hidden w-full min-w-0 grid-cols-2 gap-2 mobile:grid"
+          : "flex items-center gap-2",
+        className,
+      )}
+    >
+      <Button
+        type="button"
+        size="small"
+        variant={isAllView ? "primary" : "custom"}
+        onClick={onSelectAll}
+        className={twMerge(
+          "rounded-2xl py-5 font-body1",
+          isMobileLayout ? "w-full min-w-0" : "w-28 shrink-0",
+          !isAllView &&
+            "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",
+        )}
+      >
+        전체보기
+      </Button>
+      <div className={isMobileLayout ? "min-w-0" : undefined}>
+        <DropdownMenu
+          fullWidth={isMobileLayout}
+          menuClassName={twMerge("w-34", isMobileLayout && "w-full")}
+          trigger={
+            <Button
+              type="button"
+              size="small"
+              variant={!isAllView ? "primary" : "custom"}
+              className={twMerge(
+                "flex items-center rounded-2xl py-5",
+                isMobileLayout
+                  ? "w-full min-w-0 justify-between"
+                  : "w-34 shrink-0",
+                isAllView &&
+                  "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",
+              )}
+            >
+              <span
+                className={twMerge(
+                  "truncate font-body1",
+                  isAllView ? "text-text-muted" : "text-surface-100",
+                )}
+              >
+                {selectedPlatformLabel}
+              </span>
+              <ChevronDownIcon
+                className={twMerge(
+                  "ml-2 h-3 w-3 shrink-0 rotate-180 transition-transform",
+                  isAllView ? "text-text-muted" : "text-surface-100",
+                )}
+              />
+            </Button>
+          }
+          items={platformItems}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/platform/PlatformViewSwitcher.tsx
+++ b/src/components/dashboard/platform/PlatformViewSwitcher.tsx
@@ -63,9 +63,7 @@ export default function PlatformViewSwitcher({
               variant={!isAllView ? "primary" : "custom"}
               className={twMerge(
                 "flex items-center rounded-2xl py-5",
-                isMobileLayout
-                  ? "w-full min-w-0 justify-between"
-                  : "w-34 shrink-0",
+                isMobileLayout ? "w-full min-w-0" : "w-34 shrink-0",
                 isAllView &&
                   "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",
               )}

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -110,7 +110,7 @@ export default function SinglePlatformView({
         FallbackComponent={MetricErrorFallback}
         resetKeys={[platformData]}
       >
-        <div className="grid grid-cols-4 tablet:grid-cols-2 gap-4">
+        <div className="grid grid-cols-4 gap-4 tablet:grid-cols-2 grid-mobile-1">
           {isMetricsLoading ? (
             Array.from({ length: 4 }).map((_, i) => (
               <div

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -115,11 +115,11 @@ export default function SinglePlatformView({
             Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="rounded-3xl border border-surface-100/40 bg-surface-100/80 p-7 shadow-Soft backdrop-blur-sm flex flex-col gap-4"
+                className="flex flex-col gap-3 rounded-3xl border border-surface-100/40 bg-surface-100/80 px-7 py-5 shadow-Soft backdrop-blur-sm"
               >
                 <Skeleton className="h-4 w-16" />
-                <Skeleton className="h-8 w-24" />
-                <Skeleton className="h-6 w-14 rounded-full" />
+                <Skeleton className="h-7 w-24" />
+                <Skeleton className="h-5 w-14 rounded-full" />
               </div>
             ))
           ) : isMetricsError ? (
@@ -137,6 +137,8 @@ export default function SinglePlatformView({
                 title={kpi.title}
                 value={kpi.value}
                 trend={kpi.trend}
+                className="gap-3 py-5"
+                compact
               />
             ))
           )}

--- a/src/components/dashboard/platform/SinglePlatformView.tsx
+++ b/src/components/dashboard/platform/SinglePlatformView.tsx
@@ -92,8 +92,8 @@ export default function SinglePlatformView({
 
   return (
     <div className="flex flex-col gap-8">
-      {/* platform header */}
-      <div className="flex items-center justify-between">
+      {/* platform header — mobile에서는 dropdown으로 플랫폼명 표시 */}
+      <div className="flex items-center justify-between mobile:hidden">
         <div className="h-10 flex items-center">
           {logoInfo ? (
             <logoInfo.component

--- a/src/components/dashboard/platform/TopPerformanceList.tsx
+++ b/src/components/dashboard/platform/TopPerformanceList.tsx
@@ -35,9 +35,9 @@ export const TopPerformanceList = memo(function TopPerformanceList({
                 {item.rank}
               </span>
               <div className="shrink-0" aria-hidden="true">
-                {Logo && <Logo className="w-8 h-8" />}
+                {Logo && <Logo className="h-8 w-8" />}
               </div>
-              <span className="font-body1 text-text-title truncate">
+              <span className="truncate font-body1 text-text-title mobile:sr-only">
                 {name}
               </span>
             </div>

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -13,7 +13,7 @@ export function TopPerformanceListSkeleton() {
         <div key={i} className="flex items-center gap-4 w-full">
           <Skeleton className="h-4 w-4 shrink-0" /> {/* 순위 숫자 */}
           <SkeletonCircle className="h-8 w-8 shrink-0" /> {/* 로고 */}
-          <Skeleton className="h-4 flex-1" /> {/* 이름 */}
+          <Skeleton className="h-4 flex-1 mobile:hidden" /> {/* 이름 */}
           <Skeleton className="h-6 w-20" /> {/* 수치 */}
         </div>
       ))}

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -33,10 +33,11 @@ export function PlatformDetailCardSkeleton() {
         {[1, 2, 3, 4].map((i) => (
           <div
             key={i}
-            className="flex flex-col gap-3 rounded-2xl bg-surface-100/40 p-5"
+            className="flex flex-col gap-2 rounded-2xl bg-surface-100/40 p-2"
           >
             <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-15 w-30" />
+            <Skeleton className="h-6 w-24" />
+            <Skeleton className="h-5 w-14 rounded-full" />
           </div>
         ))}
       </div>

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -36,7 +36,7 @@ export function PlatformDetailCardSkeleton() {
             className="flex flex-col gap-2 rounded-2xl bg-surface-100/40 p-2"
           >
             <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-6 w-24" />
+            <Skeleton className="h-7 w-24" />
             <Skeleton className="h-5 w-14 rounded-full" />
           </div>
         ))}

--- a/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
+++ b/src/components/dashboard/platform/skeleton/PlatformSkeleton.tsx
@@ -56,8 +56,8 @@ export function AdStatusChartSkeleton() {
 //플랫폼별 성과 효율
 export function PerformanceEfficiencyChartSkeleton() {
   return (
-    <div className="flex-1 flex items-center justify-center w-full px-5">
-      <Skeleton className="w-full h-35 rounded-2xl mb-2" />
+    <div className="flex w-full flex-1 items-center justify-center px-5">
+      <Skeleton className="mb-2 h-35 w-full rounded-2xl" />
     </div>
   );
 }

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -250,7 +250,7 @@ function PlatformIntegrationCard({
       : STATUS_LABEL[status];
 
   return (
-    <div className="flex h-full min-h-70 w-full flex-col gap-5 rounded-3xl bg-surface-100 p-8 shadow-Soft">
+    <div className="flex h-full min-h-70 w-full flex-col gap-5 rounded-3xl bg-surface-100 p-8 shadow-Soft mobile:p-6">
       <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-3">
           <div className="shrink-0">{PLATFORM_LOGOS[provider]}</div>

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -284,9 +284,9 @@ function PlatformIntegrationCard({
 
       <div className="flex-1" aria-hidden />
 
-      <div className="mt-auto flex w-full flex-col gap-4">
+      <div className="mt-auto flex w-full flex-col gap-4 mobile:gap-3">
         {status === "disconnected" ? (
-          <p className="font-body2 text-text-muted/80">
+          <p className="font-body2 leading-relaxed text-text-muted/80 mobile:leading-snug">
             {platformAccountId != null ? (
               <>
                 기존 계정을 다시 연동하면 대시보드와 캠페인에서 데이터를 확인할

--- a/src/components/integration/UpcomingPlatformCard.tsx
+++ b/src/components/integration/UpcomingPlatformCard.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/common/button/Button";
 import KakaoLogo from "@/assets/logo/social-logo/circle/kakao-circle.svg?react";
 
 const UPCOMING_CARD_SHELL_CLASS =
-  "flex h-full min-h-70 w-full rounded-3xl bg-surface-100 p-8 shadow-Soft tablet:p-8";
+  "flex h-full min-h-70 w-full rounded-3xl bg-surface-100 p-8 shadow-Soft mobile:p-6";
 const UPCOMING_CARD_DISABLED_CLASS =
   "pointer-events-none select-none opacity-70 grayscale";
 

--- a/src/components/integration/skeleton/PlatformIntegrationsSkeleton.tsx
+++ b/src/components/integration/skeleton/PlatformIntegrationsSkeleton.tsx
@@ -8,7 +8,7 @@ const SKELETON_COUNT = 3;
 export function PlatformIntegrationCardSkeleton() {
   return (
     <div
-      className="flex h-full min-h-70 w-full flex-col gap-5 rounded-3xl bg-surface-100 p-8 shadow-Soft"
+      className="flex h-full min-h-70 w-full flex-col gap-5 rounded-3xl bg-surface-100 p-8 shadow-Soft mobile:p-6"
       aria-hidden
     >
       <div className="flex min-w-0 items-center justify-between gap-3">

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -87,12 +87,15 @@ function collapsedSubmenuInteractionProps(
 export default function Sidebar() {
   const {
     isCollapsed,
+    isCollapsedStore,
+    isMobileOpen,
     openId,
     setOpenId,
     handleItemClick,
     pathname,
     toggleSidebar,
     toggleOpenId,
+    closeMobileDrawer,
   } = useSidebar();
 
   const { showComingSoon } = useComingSoon();
@@ -201,7 +204,7 @@ export default function Sidebar() {
                 key={item.id}
                 className="relative flex flex-col"
                 {...collapsedSubmenuInteractionProps(
-                  isCollapsed && !!item.children?.length,
+                  isCollapsedStore && !isMobileOpen && !!item.children?.length,
                   item.id,
                   setOpenId,
                 )}
@@ -216,6 +219,7 @@ export default function Sidebar() {
                     isOpen={isOpen}
                     className="flex-1 h-full"
                     onClick={handleItemClick}
+                    onNavigate={closeMobileDrawer}
                   />
                   {showChevron && (
                     <button
@@ -248,8 +252,9 @@ export default function Sidebar() {
                     <SubMenu
                       key={item.id}
                       items={item.children}
-                      isCollapsed={isCollapsed}
+                      isCollapsed={isCollapsedStore && !isMobileOpen}
                       parentLabel={item.label}
+                      onNavigate={closeMobileDrawer}
                     />
                   ) : null}
                 </AnimatePresence>
@@ -276,6 +281,7 @@ export default function Sidebar() {
                   isCollapsed={isCollapsed}
                   className="w-full h-full"
                   onClick={handleFooterItemClick}
+                  onNavigate={closeMobileDrawer}
                   trailing={
                     item.id === "integrations" &&
                     showIntegrationsAttention &&
@@ -288,7 +294,7 @@ export default function Sidebar() {
             );
           })}
 
-          <div className="mt-2 pt-2 border-t border-surface-300">
+          <div className="mt-2 border-t border-surface-300 pt-2 tablet:hidden">
             <button
               type="button"
               aria-label={isCollapsed ? "사이드바 펼치기" : "사이드바 접기"}

--- a/src/components/sidebar/SidebarItem.tsx
+++ b/src/components/sidebar/SidebarItem.tsx
@@ -10,6 +10,7 @@ interface ISidebarItemProps {
   isOpen?: boolean;
   className: string;
   onClick: (id: string, hasChildren: boolean) => void;
+  onNavigate?: () => void;
   trailing?: ReactNode;
 }
 
@@ -19,6 +20,7 @@ export const SidebarItem = memo(function SidebarItem({
   isOpen,
   className,
   onClick,
+  onNavigate,
   trailing,
 }: ISidebarItemProps) {
   const hasChildren = !!item.children?.length;
@@ -52,6 +54,7 @@ export const SidebarItem = memo(function SidebarItem({
         onClick={(e) => {
           if (e.defaultPrevented) return;
           onClick(item.id, hasChildren);
+          onNavigate?.();
         }}
       >
         {content}

--- a/src/components/sidebar/SubMenu.tsx
+++ b/src/components/sidebar/SubMenu.tsx
@@ -8,9 +8,15 @@ interface ISubMenuProps {
   items: INavItem[];
   isCollapsed: boolean;
   parentLabel?: string;
+  onNavigate?: () => void;
 }
 
-export function SubMenu({ items, isCollapsed, parentLabel }: ISubMenuProps) {
+export function SubMenu({
+  items,
+  isCollapsed,
+  parentLabel,
+  onNavigate,
+}: ISubMenuProps) {
   const getSubItemClass = (isActive: boolean) =>
     twMerge(
       "flex items-center rounded-xl px-3 font-body2 transition-all duration-200 whitespace-nowrap",
@@ -60,6 +66,7 @@ export function SubMenu({ items, isCollapsed, parentLabel }: ISubMenuProps) {
           to={child.path ?? "#"}
           end
           className={({ isActive }) => getSubItemClass(isActive)}
+          onClick={() => onNavigate?.()}
         >
           {isCollapsed && parentLabel ? (
             <div className="flex min-w-0 flex-col items-start">

--- a/src/hooks/sidebar/useSidebar.ts
+++ b/src/hooks/sidebar/useSidebar.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useLocation } from "react-router-dom";
 
 import { mainNavSidebar } from "@/utils/navigation/mainNavSidebar";
@@ -9,13 +15,29 @@ import useSidebarStore from "@/store/useSidebarStore";
 export const useSidebar = () => {
   const location = useLocation();
   const [openId, setOpenId] = useState<string | null>(null);
-  const isCollapsed = useSidebarStore((s) => s.isCollapsed);
+  const isCollapsedStore = useSidebarStore((s) => s.isCollapsed);
+  const isMobileOpen = useSidebarStore((s) => s.isMobileOpen);
+  const closeMobileFromStore = useSidebarStore((s) => s.closeMobile);
   const setIsCollapsed = useSidebarStore((s) => s.setIsCollapsed);
+  /** tablet drawer 열림 시 항상 expanded */
+  const isCollapsed = isMobileOpen ? false : isCollapsedStore;
 
   const lastPathRef = useRef("");
   const pathname = normalizePathname(location.pathname);
 
   const { childIdToParentId } = mainNavSidebar;
+
+  /** drawer 닫힘 시 flyout submenu(openId) 잔류 방지 */
+  useLayoutEffect(() => {
+    if (!isMobileOpen) {
+      setOpenId(null);
+    }
+  }, [isMobileOpen]);
+
+  const closeMobileDrawer = useCallback(() => {
+    setOpenId(null);
+    closeMobileFromStore();
+  }, [closeMobileFromStore]);
 
   useEffect(() => {
     if (isCollapsed) return;
@@ -28,8 +50,8 @@ export const useSidebar = () => {
   }, [pathname, isCollapsed]);
 
   const toggleSidebar = () => {
-    setIsCollapsed(!isCollapsed);
-    if (!isCollapsed) lastPathRef.current = "";
+    setIsCollapsed(!isCollapsedStore);
+    if (!isCollapsedStore) lastPathRef.current = "";
     setOpenId(null);
   };
 
@@ -51,11 +73,14 @@ export const useSidebar = () => {
 
   return {
     isCollapsed,
+    isCollapsedStore,
+    isMobileOpen,
     openId,
     setOpenId,
     pathname,
     toggleSidebar,
     handleItemClick,
     toggleOpenId,
+    closeMobileDrawer,
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @custom-variant tablet (@media (max-width: 1280px));
+@custom-variant mobile (@media (max-width: 639px));
 
 @import "./styles/tokens.css";
 @import "./styles/base.css";

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
+import { twMerge } from "tailwind-merge";
 
 import { footerNav, mainNav } from "@/constants/sidebarNav";
 
@@ -23,7 +24,9 @@ import Sidebar from "@/components/sidebar/Sidebar";
 
 import { getMyInfo } from "@/api/auth/auth";
 import { getMyWorkspaces, getSavedWorkspace } from "@/api/workspace/org";
+import MenuIcon from "@/assets/icon/sidebar/menu.svg?react";
 import { QUERY_KEYS } from "@/lib/queryKeys";
+import useSidebarStore from "@/store/useSidebarStore";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export type TMainLayoutOutletContext = {
@@ -53,6 +56,9 @@ export default function MainLayout() {
     getMyWorkspaces,
   );
   const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
+  const isMobileOpen = useSidebarStore((s) => s.isMobileOpen);
+  const setIsMobileOpen = useSidebarStore((s) => s.setIsMobileOpen);
+  const closeMobile = useSidebarStore((s) => s.closeMobile);
 
   const navForHeader = useMemo(
     () => [...applyWorkspacePathsToNav(mainNav, selectedOrgId), ...footerNav],
@@ -110,6 +116,27 @@ export default function MainLayout() {
     }
   }, [isAdsCampaignDetailPath]);
 
+  useEffect(() => {
+    closeMobile();
+  }, [location.pathname, closeMobile]);
+
+  useEffect(() => {
+    if (!isMobileOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeMobile();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isMobileOpen, closeMobile]);
+
+  useEffect(() => {
+    if (!isMobileOpen) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isMobileOpen]);
+
   const { parentLabel, currentLabel, parentTo, currentTo } = useMemo(() => {
     const path = pathname;
     if (/^\/ads\/[^/]+\/[^/]+$/.test(path)) {
@@ -164,13 +191,37 @@ export default function MainLayout() {
           autoStart={!localStorage.getItem("hasSeenOnboarding")}
         />
       )}
-      <div className="flex h-full shrink-0">
+      <div
+        className={twMerge(
+          "flex h-full shrink-0",
+          "tablet:fixed tablet:inset-y-0 tablet:left-0 tablet:z-50",
+          "tablet:transition-transform tablet:duration-300 tablet:ease-out",
+          isMobileOpen ? "tablet:translate-x-0" : "tablet:-translate-x-full",
+        )}
+      >
         <Sidebar />
       </div>
+      {isMobileOpen ? (
+        <button
+          type="button"
+          aria-label="메뉴 닫기"
+          className="fixed inset-0 z-40 hidden bg-text-title/40 tablet:block"
+          onClick={closeMobile}
+        />
+      ) : null}
       <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-y-auto scroll-pt-14">
         <header className="sticky top-0 z-30 shrink-0 border-b border-surface-300 bg-surface-100">
-          <div className="flex h-14 items-center justify-between px-6 tablet:px-4">
+          <div className="flex h-14 items-center justify-between gap-2 px-6 tablet:px-4">
             <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+              <button
+                type="button"
+                aria-label="메뉴 열기"
+                aria-expanded={isMobileOpen}
+                className="hidden shrink-0 rounded-xl p-2 text-text-body hover:bg-surface-200 tablet:flex"
+                onClick={() => setIsMobileOpen(true)}
+              >
+                <MenuIcon className="h-6 w-6" />
+              </button>
               {isAdsCampaignDetailPath ? (
                 <>
                   <Link to="/ads" className={`shrink-0 ${crumbLinkBody}`}>
@@ -223,7 +274,9 @@ export default function MainLayout() {
               )}
             </div>
 
-            <div className="flex items-center gap-2">{headerRight}</div>
+            <div className="flex shrink-0 items-center gap-2">
+              {headerRight}
+            </div>
           </div>
         </header>
         <div className="w-full min-w-0 px-8 py-6 tablet:px-6">

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -147,8 +147,8 @@ export default function AdsListPage() {
   return (
     <section className="flex w-full flex-col">
       <Card className="flex flex-col overflow-hidden p-0">
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:flex-col tablet:items-stretch tablet:px-5 tablet:py-3.5 mobile:px-3">
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5 tablet:flex-none">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-3">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5 mobile:flex-none">
             <p className="font-caption text-text-placeholder">광고</p>
             <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
               <h2 className="font-heading3 text-text-title">캠페인 목록</h2>
@@ -168,13 +168,13 @@ export default function AdsListPage() {
               ) : null}
             </div>
           </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 tablet:w-full tablet:flex-col tablet:items-stretch">
-            <div className="flex items-center gap-2 tablet:w-full">
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 mobile:w-full mobile:flex-col mobile:items-stretch">
+            <div className="flex items-center gap-2 mobile:w-full">
               <Button
                 type="button"
                 size="small"
                 variant="dangerSoft"
-                className="tablet:min-w-0 tablet:flex-1"
+                className="mobile:min-w-0 mobile:flex-1"
                 onClick={openPauseModal}
                 disabled={!canPause || bulkStop.isLoading}
               >
@@ -184,7 +184,7 @@ export default function AdsListPage() {
                 type="button"
                 size="small"
                 variant="outline"
-                className="border-info-blue text-info-blue hover:bg-info-blue/5 tablet:min-w-0 tablet:flex-1"
+                className="border-info-blue text-info-blue hover:bg-info-blue/5 mobile:min-w-0 mobile:flex-1"
                 onClick={openResumeModal}
                 disabled={!canResume || bulkResume.isLoading}
               >
@@ -195,7 +195,7 @@ export default function AdsListPage() {
               type="button"
               size="small"
               variant="gradient"
-              className="tablet:w-full"
+              className="mobile:w-full"
               onClick={handleCampaignGroupClick}
             >
               통합 캠페인 등록

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -147,8 +147,8 @@ export default function AdsListPage() {
   return (
     <section className="flex w-full flex-col">
       <Card className="flex flex-col overflow-hidden p-0">
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5">
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/45 bg-surface-100 px-6 py-4 tablet:flex-col tablet:items-stretch tablet:px-5 tablet:py-3.5 mobile:px-3">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5 tablet:flex-none">
             <p className="font-caption text-text-placeholder">광고</p>
             <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
               <h2 className="font-heading3 text-text-title">캠페인 목록</h2>
@@ -168,30 +168,34 @@ export default function AdsListPage() {
               ) : null}
             </div>
           </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-            <Button
-              type="button"
-              size="small"
-              variant="dangerSoft"
-              onClick={openPauseModal}
-              disabled={!canPause || bulkStop.isLoading}
-            >
-              중단
-            </Button>
-            <Button
-              type="button"
-              size="small"
-              variant="outline"
-              className="border-info-blue text-info-blue hover:bg-info-blue/5"
-              onClick={openResumeModal}
-              disabled={!canResume || bulkResume.isLoading}
-            >
-              재개
-            </Button>
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 tablet:w-full tablet:flex-col tablet:items-stretch">
+            <div className="flex items-center gap-2 tablet:w-full">
+              <Button
+                type="button"
+                size="small"
+                variant="dangerSoft"
+                className="tablet:min-w-0 tablet:flex-1"
+                onClick={openPauseModal}
+                disabled={!canPause || bulkStop.isLoading}
+              >
+                중단
+              </Button>
+              <Button
+                type="button"
+                size="small"
+                variant="outline"
+                className="border-info-blue text-info-blue hover:bg-info-blue/5 tablet:min-w-0 tablet:flex-1"
+                onClick={openResumeModal}
+                disabled={!canResume || bulkResume.isLoading}
+              >
+                재개
+              </Button>
+            </div>
             <Button
               type="button"
               size="small"
               variant="gradient"
+              className="tablet:w-full"
               onClick={handleCampaignGroupClick}
             >
               통합 캠페인 등록

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -39,7 +39,7 @@ const PLATFORM_WORDMARK: Record<TPlatform, string> = {
 };
 
 const platformSectionBlockClass =
-  "flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-6";
+  "flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5 mobile:gap-4 mobile:px-3 mobile:py-4";
 
 const platformSectionDividerClass = "border-t border-surface-400/75";
 
@@ -249,11 +249,11 @@ export default function CampaignDetail() {
 
   return (
     <section className="flex w-full flex-col gap-8">
-      <Card className="px-6 py-8 tablet:px-5 tablet:py-7">
-        <header className="flex w-full flex-col gap-6">
+      <Card className="px-6 py-8 tablet:px-5 tablet:py-7 mobile:px-4 mobile:py-6">
+        <header className="flex w-full flex-col gap-6 mobile:gap-7">
           <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
             <div className="flex min-w-0 flex-wrap items-center gap-3">
-              <h1 className="min-w-0 wrap-break-word font-heading2 text-text-title">
+              <h1 className="min-w-0 wrap-break-word font-heading2-rsp text-text-title">
                 {data.name}
               </h1>
               <Badge
@@ -307,8 +307,8 @@ export default function CampaignDetail() {
         <CampaignDetailAdsSectionSkeleton />
       ) : (
         <Card className="flex flex-col overflow-hidden p-0">
-          <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5">
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5 mobile:flex-none">
               <p className="font-caption text-text-placeholder">광고</p>
               <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
                 <h2 className="font-heading3 text-text-title">광고 모아보기</h2>
@@ -328,11 +328,12 @@ export default function CampaignDetail() {
                 ) : null}
               </div>
             </div>
-            <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 mobile:w-full">
               <Button
                 type="button"
                 size="small"
                 variant="dangerSoft"
+                className="mobile:min-w-0 mobile:flex-1"
                 onClick={openAdPauseModal}
                 disabled={!canPauseAds || bulkAdPause.isLoading}
               >
@@ -342,7 +343,7 @@ export default function CampaignDetail() {
                 type="button"
                 size="small"
                 variant="outline"
-                className="border-info-blue text-info-blue hover:bg-info-blue/5"
+                className="border-info-blue text-info-blue hover:bg-info-blue/5 mobile:min-w-0 mobile:flex-1"
                 onClick={openAdResumeModal}
                 disabled={!canResumeAds || bulkAdResume.isLoading}
               >

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -39,7 +39,7 @@ const PLATFORM_WORDMARK: Record<TPlatform, string> = {
 };
 
 const platformSectionBlockClass =
-  "flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5 mobile:gap-4 mobile:px-3 mobile:py-4";
+  "flex flex-col gap-6 px-6 py-6 tablet:px-5 tablet:py-5 mobile:gap-4 mobile:px-4 mobile:py-4";
 
 const platformSectionDividerClass = "border-t border-surface-400/75";
 
@@ -307,7 +307,7 @@ export default function CampaignDetail() {
         <CampaignDetailAdsSectionSkeleton />
       ) : (
         <Card className="flex flex-col overflow-hidden p-0">
-          <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-3">
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-surface-400/75 bg-surface-100 px-6 py-4 tablet:px-5 tablet:py-3.5 mobile:flex-col mobile:items-stretch mobile:px-4">
             <div className="flex min-w-0 flex-1 flex-col gap-0.5 mobile:flex-none">
               <p className="font-caption text-text-placeholder">광고</p>
               <div className="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
@@ -397,7 +397,7 @@ export default function CampaignDetail() {
               ))}
             </div>
           ) : (
-            <p className="px-6 py-16 text-center font-body1 text-text-placeholder tablet:px-5">
+            <p className="px-6 py-16 text-center font-body1 text-text-placeholder tablet:px-5 mobile:px-4">
               연결된 광고 소재가 없습니다.
             </p>
           )}

--- a/src/pages/ads/new/CampaignGroup.tsx
+++ b/src/pages/ads/new/CampaignGroup.tsx
@@ -40,16 +40,16 @@ export default function CampaignGroup() {
   } = useCampaignGroup();
 
   return (
-    <section className="flex w-full flex-col gap-8 pb-20">
+    <section className="flex w-full flex-col gap-8 pb-20 mobile:gap-6 mobile:pb-12">
       {/* 캠페인 기본 정보 */}
-      <Card className="flex flex-col gap-8 p-8 tablet:p-10">
+      <Card className="flex flex-col gap-8 p-8 mobile:gap-6 mobile:p-5">
         <div className="flex flex-col gap-2">
           <h3 className="font-heading3 text-text-title">캠페인 기본 정보</h3>
           <p className="font-body1 leading-relaxed text-text-muted">
             워크스페이스에서 묶어 관리할 통합 캠페인 그룹의 기본 정보입니다.
           </p>
         </div>
-        <div className="flex w-full flex-col gap-10">
+        <div className="flex w-full flex-col gap-10 mobile:gap-6">
           {/* 캠페인명 */}
           <div className="flex flex-col gap-2">
             <label
@@ -87,7 +87,7 @@ export default function CampaignGroup() {
       </Card>
 
       {/* 플랫폼별 캠페인 연결 */}
-      <Card className="flex flex-col gap-8 p-8 tablet:p-10">
+      <Card className="flex flex-col gap-8 p-8 mobile:gap-6 mobile:p-5">
         <div className="flex flex-col gap-2">
           <h3 className="font-heading3 text-text-title">
             플랫폼별 캠페인 연결
@@ -104,7 +104,7 @@ export default function CampaignGroup() {
           {isPlatformCampaignsLoading ? (
             <CampaignGroupDropdownSkeleton />
           ) : (
-            <div className="flex flex-col gap-10">
+            <div className="flex flex-col gap-10 mobile:gap-6">
               {/* Google */}
               <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-2 px-1">

--- a/src/pages/ads/new/CampaignGroup.tsx
+++ b/src/pages/ads/new/CampaignGroup.tsx
@@ -45,7 +45,7 @@ export default function CampaignGroup() {
       <Card className="flex flex-col gap-8 p-8 mobile:gap-6 mobile:p-5">
         <div className="flex flex-col gap-2">
           <h3 className="font-heading3 text-text-title">캠페인 기본 정보</h3>
-          <p className="font-body1 leading-relaxed text-text-muted">
+          <p className="font-body1-rsp leading-relaxed text-text-muted">
             워크스페이스에서 묶어 관리할 통합 캠페인 그룹의 기본 정보입니다.
           </p>
         </div>
@@ -92,7 +92,7 @@ export default function CampaignGroup() {
           <h3 className="font-heading3 text-text-title">
             플랫폼별 캠페인 연결
           </h3>
-          <p className="font-body1 leading-relaxed text-text-muted">
+          <p className="font-body1-rsp leading-relaxed text-text-muted">
             매체별 운영 중인 캠페인을 선택해 통합 그룹에 연결합니다. 최소 1개
             매체에서 캠페인을 선택해야 합니다.
           </p>

--- a/src/pages/dashboard/platform/PlatformDashboard.tsx
+++ b/src/pages/dashboard/platform/PlatformDashboard.tsx
@@ -1,16 +1,12 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useOutletContext } from "react-router-dom";
-import { twMerge } from "tailwind-merge";
 
 import type { TProviderType } from "@/types/dashboard/overview";
 import { PLATFORM_MAP, PROVIDER_TYPES } from "@/types/dashboard/provider";
 
-import Button from "@/components/common/button/Button";
-import { DropdownMenu } from "@/components/common/dropdownmenu/DropdownMenu";
 import AllPlatformView from "@/components/dashboard/platform/AllPlatformView";
+import PlatformViewSwitcher from "@/components/dashboard/platform/PlatformViewSwitcher";
 import SinglePlatformView from "@/components/dashboard/platform/SinglePlatformView";
-
-import ChevronDownIcon from "@/assets/icon/chevron/chevron-up.svg?react";
 
 type TPlatformView = "전체" | TProviderType;
 
@@ -43,52 +39,13 @@ export default function PlatformDashboard() {
     if (!setHeaderRight) return;
 
     setHeaderRight(
-      <div className="flex items-center gap-3">
-        <Button
-          type="button"
-          size="small"
-          variant={isAllView ? "primary" : "custom"}
-          onClick={() => setSelectedPlatform("전체")}
-          className={twMerge(
-            "w-28 py-5 font-body1 rounded-2xl",
-            !isAllView &&
-              "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",
-          )}
-        >
-          전체보기
-        </Button>
-        <DropdownMenu
-          menuClassName="w-34"
-          trigger={
-            <Button
-              type="button"
-              size="small"
-              variant={!isAllView ? "primary" : "custom"}
-              className={twMerge(
-                "flex items-center w-34 py-5 rounded-2xl",
-                isAllView &&
-                  "border border-surface-400 bg-surface-100 text-text-muted hover:bg-surface-200",
-              )}
-            >
-              <span
-                className={twMerge(
-                  "font-body1",
-                  isAllView ? "text-text-muted" : "text-surface-100",
-                )}
-              >
-                {selectedPlatformLabel}
-              </span>
-              <ChevronDownIcon
-                className={twMerge(
-                  "w-3 h-3 rotate-180 ml-2 transition-transform",
-                  isAllView ? "text-text-muted" : "text-surface-100",
-                )}
-              />
-            </Button>
-          }
-          items={platformItems}
-        />
-      </div>,
+      <PlatformViewSwitcher
+        isAllView={isAllView}
+        selectedPlatformLabel={selectedPlatformLabel}
+        platformItems={platformItems}
+        onSelectAll={() => setSelectedPlatform("전체")}
+        className="mobile:hidden"
+      />,
     );
 
     return () => setHeaderRight(null);
@@ -96,6 +53,13 @@ export default function PlatformDashboard() {
 
   return (
     <section className="flex w-full min-w-0 flex-col gap-8">
+      <PlatformViewSwitcher
+        isAllView={isAllView}
+        selectedPlatformLabel={selectedPlatformLabel}
+        platformItems={platformItems}
+        onSelectAll={() => setSelectedPlatform("전체")}
+        layout="mobile"
+      />
       {isAllView ? (
         <AllPlatformView />
       ) : (

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -280,8 +280,8 @@ export default function PlatformIntegrationsPage() {
             </ul>
           </ErrorBoundary>
 
-          <div className="flex w-full min-w-0 flex-col items-center gap-8 pt-15">
-            <p className="w-full text-center font-body1 text-text-muted/70">
+          <div className="flex w-full min-w-0 flex-col items-center gap-8 pt-15 mobile:gap-6 mobile:pt-10">
+            <p className="w-full text-center font-body1-rsp text-text-muted/70">
               더 많은 플랫폼 연동을 준비하고 있어요. 지원 범위는 변경될 수
               있습니다.
             </p>

--- a/src/store/useSidebarStore.ts
+++ b/src/store/useSidebarStore.ts
@@ -4,12 +4,19 @@ interface ISidebarState {
   isCollapsed: boolean;
   setIsCollapsed: (next: boolean) => void;
   toggleSidebar: () => void;
+  /** tablet 이하 off-canvas 열림 */
+  isMobileOpen: boolean;
+  setIsMobileOpen: (next: boolean) => void;
+  closeMobile: () => void;
 }
 
 const useSidebarStore = create<ISidebarState>((set) => ({
   isCollapsed: true,
   setIsCollapsed: (next) => set({ isCollapsed: next }),
   toggleSidebar: () => set((prev) => ({ isCollapsed: !prev.isCollapsed })),
+  isMobileOpen: false,
+  setIsMobileOpen: (next) => set({ isMobileOpen: next }),
+  closeMobile: () => set({ isMobileOpen: false }),
 }));
 
 export default useSidebarStore;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -115,6 +115,19 @@
     }
   }
 
+  .font-body1-rsp {
+    font-size: var(--type-body1-size);
+    font-weight: var(--type-body1-weight);
+    line-height: var(--type-body1-leading);
+  }
+  @media (max-width: 639px) {
+    .font-body1-rsp {
+      font-size: var(--type-body2-size);
+      font-weight: var(--type-body2-weight);
+      line-height: var(--type-body2-leading);
+    }
+  }
+
   /* 모바일(< 640px)에서 그리드를 1열로 강제 — tablet: 커스텀 변형 우선순위 우회 */
   .grid-mobile-1 {}
   @media (max-width: 639px) {


### PR DESCRIPTION
## 🚨 관련 이슈
close #405 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [X] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 사이드바 / 레이아웃
- 모바일·태블릿 off-canvas 사이드바 및 햄버거 메뉴 추가
- drawer UX 개선, 서브메뉴 잔류 버그 수정

### 플랫폼 대시보드
- 모바일에서 플랫폼 전환 버튼을 페이지 상단으로 이동
- KPI 모바일 1열, 통합 뷰와 밀도 맞춤
- 성과 우수 플랫폼: 모바일 로고만 표시
- 성과 효율 차트: 모바일 Y축 숨김·라벨 여백 조정
- 예산 게이지 남은 %, 상세 카드 KPI 타이포 조정

### 캠페인 / 광고
- 캠페인 목록: 행·타이포 밀도, 모바일 CTA 레이아웃 조정
- 캠페인 상세: 헤더·섹션·광고 테이블 모바일·태블릿 대응
- 통합 캠페인 등록: 카드 패딩 정리, 모바일 설명 문구(`body1-rsp`) 축소
- 광고 상세: 모바일 패딩 축소

### 플랫폼 연동
- 연동/Coming soon 카드 모바일 패딩 축소
- Coming soon·미연동 안내 문구·간격 조정

### 공통
- 모달: 화면 좌우 `mx-4`, 닫기 버튼 영역 `pr-12`로 본문 겹침 완화
- `mobile:`(≤639) / `tablet:`(≤1280) 브레이크포인트 활용

---

> ### 모바일

https://github.com/user-attachments/assets/d38e1723-b030-4252-8ed7-778251c0f393

> ### 태블릿

https://github.com/user-attachments/assets/5332e51f-22e1-4a05-8a52-94948b042476

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 화면에서 플랫폼 전체보기 및 플랫폼 선택 UI를 제공합니다.
  * 모바일 사이드바를 메뉴 선택, 오버레이 또는 Escape 키로 닫을 수 있습니다.

* **개선 사항**
  * 광고·캠페인·대시보드·연동 화면의 모바일 레이아웃, 간격, 버튼 배치를 개선했습니다.
  * 모바일 차트가 더 간결하게 표시되도록 크기와 라벨을 조정했습니다.
  * 모달, 카드, 통계, 타이포그래피가 작은 화면에 맞게 최적화되었습니다.
  * 모바일 메뉴 탐색 후 사이드바가 자동으로 닫힙니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->