### PR TITLE
[Bugfix#419] 랜딩페이지 날짜 균등분배로 변경하여 빈공간 제거

### DIFF
--- a/src/components/landing/GuideTimeline.tsx
+++ b/src/components/landing/GuideTimeline.tsx
@@ -29,7 +29,7 @@ export default function GuideTimeline() {
   const rowCount = Math.max(...LANDING_TIMELINE_BARS.map((bar) => bar.row), 1);
 
   return (
-    <div className="landing-guide-timeline flex h-75 w-full flex-col overflow-hidden rounded-2xl border border-surface-400/70 bg-surface-100 md:h-85">
+    <div className="landing-guide-timeline flex h-75 w-full flex-col rounded-2xl bg-surface-100 md:h-85">
       <style>
         {`
         .landing-guide-timeline .custom-scrollbar::-webkit-scrollbar {

--- a/src/components/landing/GuideTimeline.tsx
+++ b/src/components/landing/GuideTimeline.tsx
@@ -1,8 +1,12 @@
+import { useRef } from "react";
+
 import {
   LANDING_TIMELINE_BARS,
   LANDING_TIMELINE_COLUMNS,
 } from "@/constants/landing/timeline";
 import { TIMELINE_COL_WIDTH } from "@/constants/timeline/layout";
+
+import { useContainerWidth } from "@/hooks/timeline/useContainerWidth";
 
 import TimelineAxis from "@/components/timeline/TimelineAxis";
 import TimelineBar from "@/components/timeline/TimelineBar";
@@ -13,7 +17,14 @@ import SortIcon from "@/assets/icon/timeline/sort.svg?react";
 
 export default function GuideTimeline() {
   //랜딩 가이드 column 폭이 좁아서 실제 타임라인보다는 작게
-  const colWidth = Math.min(TIMELINE_COL_WIDTH, 72);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const containerWidth = useContainerWidth(scrollRef);
+
+  const columnCount = LANDING_TIMELINE_COLUMNS.length;
+  const colWidth =
+    columnCount > 0 && containerWidth > 0
+      ? Math.max(TIMELINE_COL_WIDTH, containerWidth / columnCount)
+      : TIMELINE_COL_WIDTH;
   const totalWidth = LANDING_TIMELINE_COLUMNS.length * colWidth;
   const rowCount = Math.max(...LANDING_TIMELINE_BARS.map((bar) => bar.row), 1);
 
@@ -64,7 +75,10 @@ export default function GuideTimeline() {
         </div>
       </div>
 
-      <div className="custom-scrollbar relative flex-1 overflow-x-auto overflow-y-hidden bg-surface-100">
+      <div
+        ref={scrollRef}
+        className="custom-scrollbar relative flex-1 overflow-x-auto overflow-y-hidden bg-surface-100"
+      >
         <div className="flex h-full flex-col" style={{ width: totalWidth }}>
           <TimelineAxis
             columns={LANDING_TIMELINE_COLUMNS}


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #419 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 랜딩 `GuideTimeline`에서 날짜 칸 너비를 컨테이너 너비 기준으로 균등분배 되도록 수정
- 대시보드 타임라인과 동일하게 `useContainerWidth`로 컨테이너 너비 측정해서 `colWidth` 계산 
- 주 단위를 유지하면서 오른쪽 빈공간 제거


## 💻 작업 화면
### 변경 전
<img width="1251" height="399" alt="image" src="https://github.com/user-attachments/assets/a53a73a9-c1b8-46da-9813-f9104cd4e109" />


### 변경 후
<img width="1315" height="422" alt="image" src="https://github.com/user-attachments/assets/1ec9fa5d-20ad-4a21-9062-90cac2e25181" />


## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항



> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 화면 너비에 따라 가이드 타임라인의 열 너비가 자동으로 조정됩니다.
  * 열 너비가 최소 기준보다 작아지지 않아 다양한 화면 크기에서 가독성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->