### PR TITLE
[Feature/#427] 사이드바 접힘 시 연동 필요 표시

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -269,6 +269,8 @@ export default function Sidebar() {
           {footerNavByRole.map((item) => {
             const isActive =
               item.path != null ? isPathMatch(pathname, item.path) : false;
+            const isIntegrationsAttention =
+              item.id === "integrations" && showIntegrationsAttention;
 
             return (
               <div
@@ -282,10 +284,9 @@ export default function Sidebar() {
                   className="w-full h-full"
                   onClick={handleFooterItemClick}
                   onNavigate={closeMobileDrawer}
+                  showAttention={isIntegrationsAttention}
                   trailing={
-                    item.id === "integrations" &&
-                    showIntegrationsAttention &&
-                    !isCollapsed ? (
+                    isIntegrationsAttention && !isCollapsed ? (
                       <Badge variant="infoRed">연동 필요</Badge>
                     ) : undefined
                   }

--- a/src/components/sidebar/SidebarItem.tsx
+++ b/src/components/sidebar/SidebarItem.tsx
@@ -12,6 +12,8 @@ interface ISidebarItemProps {
   onClick: (id: string, hasChildren: boolean) => void;
   onNavigate?: () => void;
   trailing?: ReactNode;
+  /** 연동 주의 상태 — 접힘 시 아이콘 `!` */
+  showAttention?: boolean;
 }
 
 export const SidebarItem = memo(function SidebarItem({
@@ -22,10 +24,14 @@ export const SidebarItem = memo(function SidebarItem({
   onClick,
   onNavigate,
   trailing,
+  showAttention = false,
 }: ISidebarItemProps) {
   const hasChildren = !!item.children?.length;
   const Icon = item.icon;
 
+  const accessibilityLabel = showAttention
+    ? `${item.label}, 연동 필요`
+    : item.label;
   const itemClassName = twMerge(
     className,
     "flex items-center",
@@ -34,7 +40,17 @@ export const SidebarItem = memo(function SidebarItem({
 
   const content = isCollapsed ? (
     Icon ? (
-      <Icon className="h-6 w-6 shrink-0" aria-hidden />
+      <span className="relative inline-flex">
+        <Icon className="h-6 w-6 shrink-0" aria-hidden />
+        {showAttention ? (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -right-1 -top-1.5 font-body2 font-bold leading-none text-info-red"
+          >
+            !
+          </span>
+        ) : null}
+      </span>
     ) : null
   ) : (
     <div className="flex min-w-0 w-full items-center gap-2">
@@ -51,6 +67,10 @@ export const SidebarItem = memo(function SidebarItem({
       <NavLink
         to={item.path}
         className={itemClassName}
+        // 접힘: 보이는 텍스트 없음 → 항상 label. attention이면 "연동 필요" 포함
+        aria-label={
+          isCollapsed || showAttention ? accessibilityLabel : undefined
+        }
         onClick={(e) => {
           if (e.defaultPrevented) return;
           onClick(item.id, hasChildren);
@@ -65,7 +85,7 @@ export const SidebarItem = memo(function SidebarItem({
   return (
     <button
       type="button"
-      aria-label={item.label}
+      aria-label={accessibilityLabel}
       aria-haspopup={hasChildren ? "menu" : undefined}
       aria-expanded={hasChildren ? isOpen : undefined}
       className={twMerge(itemClassName, "text-left")}


### PR DESCRIPTION
## 🚨 관련 이슈
close #427 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- 재연동 필요 시 사이드바 접힘 상태에서 플랫폼 연동 아이콘에 빨간 `!` 표시
- 펼침 상태의 기존 `연동 필요` Badge는 유지
- 연동 정상일 때는 접힘·펼침 모두 주의 표시 없음
- 접근성: attention 시 `aria-label`에 「연동 필요」 포함, 접힘 시에도 라벨 제공

<img width="600" alt="스크린샷 2026-08-10 오전 3 12 26" src="https://github.com/user-attachments/assets/c51a722e-49ed-446c-9bd6-2d8d5edd0167" />

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 연동이 필요한 통합 메뉴에 주의 표시를 추가했습니다.
  * 사이드바가 펼쳐진 상태에서는 `연동 필요` 배지가 표시됩니다.
  * 사이드바가 접힌 상태에서는 메뉴 아이콘에 `!` 표시가 나타납니다.
  * 해당 상태가 접근성 라벨에도 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->