### PR TITLE
[Refactor/#436] XSS 방어를 위해 downloadAiSummaryPdf에 DOMPurify sanitize 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "apexcharts": "^5.7.0",
     "axios": "^1.13.4",
     "crypto-js": "^4.2.0",
+    "dompurify": "^3.4.13",
     "framer-motion": "^12.38.0",
     "react": "^19.2.0",
     "react-apexcharts": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
+      dompurify:
+        specifier: ^3.4.13
+        version: 3.4.13
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1357,6 +1360,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2093,6 +2099,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -5884,6 +5893,9 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -6670,6 +6682,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-case@3.0.4:
     dependencies:

--- a/src/components/dashboard/ai-report/print/downloadAiSummaryPdf.ts
+++ b/src/components/dashboard/ai-report/print/downloadAiSummaryPdf.ts
@@ -1,5 +1,6 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import DOMPurify from "dompurify";
 
 import AiSummaryPrintReport from "./AiSummaryPrintReport";
 import { buildPrintThemeStyleBlock } from "./printAssets";
@@ -47,7 +48,7 @@ export function downloadAiSummaryPdf(document: TAiReportPrintDocument) {
 <title></title>
 <style>${FONT_FACE_STYLE}${tokenStyles}${printThemeStyles}${printStyles}</style>
 </head>
-<body>${reportMarkup}</body>
+<body>${DOMPurify.sanitize(reportMarkup)}</body>
 </html>`);
   printDoc.close();
 


### PR DESCRIPTION
## 🚨 관련 이슈

Closes #436 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `dompurify` 패키지 추가 (v3.4.13)
- `downloadAiSummaryPdf.ts`에서 `printDoc.write()`에 삽입되는 `reportMarkup`을 `DOMPurify.sanitize()`로 정제

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항

`AiSummaryPrintReport`에서 AI 응답 데이터를 렌더링할 때 `{line}`, `{paragraph}` 처럼 JSX 중괄호로 출력합니다. React는 이 방식으로 렌더링할 때 <, > 같은 문자를 자동으로 &lt;, &gt;로 변환합니다. 그래서 AI 서버가 <script>alert(1)</script>를 응답해도 그냥 텍스트로 출력될 뿐 실행되지 않습니다. 따라서 XSS위험은 낮습니다.
다만 향후 서버에서 받은 마크다운이나 HTML을 렌더링하려고 dangerouslySetInnerHTML을 쓰면, 그 내용이 reportMarkup에 그대로 포함되고 printDoc.write()까지 그냥 흘러가서 XSS가 됩니다.
따라서 방어적으로 sanitize를 적용했습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
