### PR TITLE
[Feature/#448] 멤버 관리 권한 설정을 역할별 고정 안내표로 변경

### DIFF
--- a/src/assets/icon/common/close.svg
+++ b/src/assets/icon/common/close.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M20 4L4 20M20 20L4 4" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M20 4L4 20M20 20L4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/components/workspace/PermissionTable.tsx
+++ b/src/components/workspace/PermissionTable.tsx
@@ -8,14 +8,14 @@ import CloseIcon from "@/assets/icon/common/close.svg?react";
 const permissionRows: TPermissionRow[] = [
   {
     key: "campaignView",
-    label: "광고/캠페인 조회",
+    label: "광고•캠페인 조회",
     description: "광고 및 캠페인을 조회할 수 있습니다",
     memberAllowed: true,
   },
   {
     key: "timelineManage",
-    label: "타임라인 조회/관리",
-    description: "성과 타임라인을 조회하고 생성•수정•삭제할 수 있습니다",
+    label: "타임라인 조회•관리",
+    description: "성과 타임라인을 조회하고 생성/수정/삭제할 수 있습니다",
     memberAllowed: true,
   },
   {
@@ -46,7 +46,7 @@ const permissionRows: TPermissionRow[] = [
   {
     key: "workspaceEdit",
     label: "워크스페이스 설정 수정",
-    description: "워크스페이스 이름•로고 등 기본 정보를 수정합니다",
+    description: "워크스페이스 이름/로고 등 기본 정보를 수정합니다",
     memberAllowed: false,
   },
   {

--- a/src/components/workspace/PermissionTable.tsx
+++ b/src/components/workspace/PermissionTable.tsx
@@ -14,44 +14,44 @@ const permissionRows: TPermissionRow[] = [
     key: "campaignView",
     label: "광고/캠페인 조회",
     description: "광고 및 캠페인을 조회할 수 있습니다",
-    defaultMemberEnabled: true,
+    memberAllowed: true,
   },
   {
     key: "billingManage",
     label: "결제 관리",
     description: "구독 플랜 변경 및 결제 수단을 관리합니다",
-    defaultMemberEnabled: false,
+    memberAllowed: false,
   },
   {
     key: "workspaceView",
     label: "워크스페이스 조회",
     description: "워크스페이스에 대한 정보를 조회할 수 있습니다",
-    defaultMemberEnabled: true,
+    memberAllowed: true,
   },
   {
     key: "memberInvite",
     label: "멤버 초대",
     description: "새로운 팀원을 워크스페이스에 초대할 수 있습니다",
-    defaultMemberEnabled: true,
+    memberAllowed: true,
   },
   {
     key: "memberRoleEdit",
     label: "멤버 역할 변경",
     description:
       "워크스페이스에 소속되어있는 멤버들의 역할을 변경할 수 있습니다",
-    defaultMemberEnabled: false,
+    memberAllowed: false,
   },
   {
     key: "workspaceEdit",
     label: "워크스페이스 설정 수정",
     description: "워크스페이스 이름, 로고 등 기본 정보를 수정합니다",
-    defaultMemberEnabled: false,
+    memberAllowed: false,
   },
   {
     key: "projectDelete",
     label: "프로젝트 삭제",
     description: "생성된 프로젝트를 영구적으로 삭제합니다",
-    defaultMemberEnabled: false,
+    memberAllowed: false,
   },
 ];
 
@@ -59,7 +59,7 @@ type TMemberPermissionState = Record<TPermissionRow["key"], boolean>;
 
 const initialMemberPermissionState: TMemberPermissionState =
   permissionRows.reduce((acc, row) => {
-    acc[row.key] = row.defaultMemberEnabled;
+    acc[row.key] = row.memberAllowed;
     return acc;
   }, {} as TMemberPermissionState);
 

--- a/src/components/workspace/PermissionTable.tsx
+++ b/src/components/workspace/PermissionTable.tsx
@@ -1,11 +1,6 @@
-import { useMemo, useState } from "react";
-import { toast } from "sonner";
-
 import type { TPermissionRow } from "@/types/workspace/workspace";
 
-import Button from "../common/button/Button";
 import Card from "../common/card/Card";
-import Toggle from "../common/toggle/Toggle";
 
 import CheckIcon from "@/assets/icon/common/check.svg?react";
 import CloseIcon from "@/assets/icon/common/close.svg?react";

--- a/src/components/workspace/PermissionTable.tsx
+++ b/src/components/workspace/PermissionTable.tsx
@@ -8,6 +8,7 @@ import Card from "../common/card/Card";
 import Toggle from "../common/toggle/Toggle";
 
 import CheckIcon from "@/assets/icon/common/check.svg?react";
+import CloseIcon from "@/assets/icon/common/close.svg?react";
 
 const permissionRows: TPermissionRow[] = [
   {
@@ -32,7 +33,7 @@ const permissionRows: TPermissionRow[] = [
     key: "memberInvite",
     label: "멤버 초대",
     description: "새로운 팀원을 워크스페이스에 초대할 수 있습니다",
-    memberAllowed: true,
+    memberAllowed: false,
   },
   {
     key: "memberRoleEdit",
@@ -55,66 +56,40 @@ const permissionRows: TPermissionRow[] = [
   },
 ];
 
-type TMemberPermissionState = Record<TPermissionRow["key"], boolean>;
-
-const initialMemberPermissionState: TMemberPermissionState =
-  permissionRows.reduce((acc, row) => {
-    acc[row.key] = row.memberAllowed;
-    return acc;
-  }, {} as TMemberPermissionState);
-
-function AdminCheckBadge() {
+function PermissionAllowedBadge() {
   return (
-    <div className="inline-flex h-8 w-8 items-center justify-center rounded-3xl bg-primary-100/80">
-      <CheckIcon className="h-5 w-5 stroke-2 text-primary-500" />
-      <span className="sr-only">가능</span>
+    <div
+      className="inline-flex h-8 w-8 items-center justify-center rounded-3xl bg-primary-100/80"
+      aria-label="가능"
+    >
+      <CheckIcon
+        className="h-5 w-5 stroke-2 text-primary-500"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+function PermissionDeniedBadge() {
+  return (
+    <div
+      className="inline-flex h-8 w-8 items-center justify-center rounded-3xl bg-surface-300/80"
+      aria-label="불가능"
+    >
+      <CloseIcon
+        className="h-4.5 w-4.5 [&_path]:stroke-[2.5] text-info-red"
+        aria-hidden="true"
+      />
     </div>
   );
 }
 
 export default function PermissionTable() {
-  const [savedPermissionState, setSavedPermissionState] = useState(
-    initialMemberPermissionState,
-  );
-  const [draftPermissionState, setDraftPermissionState] = useState(
-    initialMemberPermissionState,
-  );
-  const [isSaving, setIsSaving] = useState(false);
-  const hasChanges = useMemo(() => {
-    return permissionRows.some(
-      (row) => savedPermissionState[row.key] !== draftPermissionState[row.key],
-    );
-  }, [savedPermissionState, draftPermissionState]);
-  const handleToggleMemberPermission = (key: TPermissionRow["key"]) => {
-    setDraftPermissionState((prev) => ({
-      ...prev,
-      [key]: !prev[key],
-    }));
-  };
-  const handleResetChange = () => {
-    setDraftPermissionState(savedPermissionState);
-  };
-  const handleSaveChanges = async () => {
-    if (!hasChanges || isSaving) return;
-    setIsSaving(true);
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      setSavedPermissionState(draftPermissionState);
-      toast.success("권한 설정이 저장되었습니다");
-    } catch (error) {
-      toast.error("권한 설정 저장에 실패했습니다. 다시 시도해주세요");
-      console.error("권한 설정 저장 실패", error);
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
   return (
     <Card className="p-8 tablet:p-6">
       <header className="mb-7">
         <h2 className="font-heading4 text-text-title">권한 설정</h2>
         <p className="mt-2 font-body2 text-text-muted break-keep">
-          역할별 권한을 확인하고 설정할 수 있습니다
+          역할(관리자/멤버)에 따른 권한을 확인할 수 있습니다
         </p>
       </header>
 
@@ -151,16 +126,16 @@ export default function PermissionTable() {
                 </td>
                 <td className="px-6 py-5 text-center tablet:px-2">
                   <div className="flex justify-center">
-                    <AdminCheckBadge />
+                    <PermissionAllowedBadge />
                   </div>
                 </td>
                 <td className="px-6 py-5 text-center tablet:px-2">
                   <div className="flex justify-center">
-                    <Toggle
-                      checked={draftPermissionState[row.key]}
-                      onToggle={() => handleToggleMemberPermission(row.key)}
-                      ariaLabel={`${row.label} 권한 토글`}
-                    />
+                    {row.memberAllowed ? (
+                      <PermissionAllowedBadge />
+                    ) : (
+                      <PermissionDeniedBadge />
+                    )}
                   </div>
                 </td>
               </tr>
@@ -170,44 +145,10 @@ export default function PermissionTable() {
       </div>
 
       <div className="mt-8 rounded-2xl bg-surface-200/60 px-5 py-5 tablet:px-4 tablet:py-4">
-        {hasChanges ? (
-          <p
-            role="status"
-            className="mb-4 rounded-xl bg-primary-100/50 px-4 py-3 font-body2 text-text-title break-keep text-pretty"
-          >
-            <span className="font-label text-primary-500">저장 필요</span>
-            <span className="text-text-muted"> · </span>
-            멤버 권한이 변경되었습니다. 반영하려면 저장을 눌러주세요. 취소하면
-            이전 설정으로 돌아갑니다.
-          </p>
-        ) : (
-          <p className="mb-4 font-body2 text-text-muted break-keep text-pretty">
-            멤버 열의 토글을 바꾼 뒤, 아래에서 저장하거나 변경을 취소할 수
-            있습니다.
-          </p>
-        )}
-        <div className="flex flex-wrap items-center justify-end gap-3 tablet:flex-col tablet:items-stretch">
-          <Button
-            type="button"
-            variant="outline"
-            size="big"
-            onClick={handleResetChange}
-            disabled={!hasChanges || isSaving}
-            className="rounded-2xl tablet:w-full"
-          >
-            변경 취소
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            size="big"
-            onClick={handleSaveChanges}
-            disabled={!hasChanges || isSaving}
-            className="rounded-2xl tablet:w-full"
-          >
-            {isSaving ? "저장 중..." : "변경사항 저장하기"}
-          </Button>
-        </div>
+        <p className="font-body2 text-text-muted break-keep text-pretty">
+          권한은 역할에 따라 고정됩니다. 멤버의 접근 범위를 바꾸려면 위 멤버
+          목록에서 역할을 변경하세요.
+        </p>
       </div>
     </Card>
   );

--- a/src/components/workspace/PermissionTable.tsx
+++ b/src/components/workspace/PermissionTable.tsx
@@ -13,6 +13,12 @@ const permissionRows: TPermissionRow[] = [
     memberAllowed: true,
   },
   {
+    key: "timelineManage",
+    label: "타임라인 조회/관리",
+    description: "성과 타임라인을 조회하고 생성•수정•삭제할 수 있습니다",
+    memberAllowed: true,
+  },
+  {
     key: "billingManage",
     label: "결제 관리",
     description: "구독 플랜 변경 및 결제 수단을 관리합니다",
@@ -40,7 +46,7 @@ const permissionRows: TPermissionRow[] = [
   {
     key: "workspaceEdit",
     label: "워크스페이스 설정 수정",
-    description: "워크스페이스 이름, 로고 등 기본 정보를 수정합니다",
+    description: "워크스페이스 이름•로고 등 기본 정보를 수정합니다",
     memberAllowed: false,
   },
   {
@@ -84,7 +90,7 @@ export default function PermissionTable() {
       <header className="mb-7">
         <h2 className="font-heading4 text-text-title">권한 설정</h2>
         <p className="mt-2 font-body2 text-text-muted break-keep">
-          역할(관리자/멤버)에 따른 권한을 확인할 수 있습니다
+          역할(관리자•멤버)에 따른 권한을 확인할 수 있습니다
         </p>
       </header>
 

--- a/src/components/workspace/PermissionTable.tsx
+++ b/src/components/workspace/PermissionTable.tsx
@@ -59,7 +59,8 @@ const permissionRows: TPermissionRow[] = [
 
 function PermissionAllowedBadge() {
   return (
-    <div
+    <span
+      role="img"
       className="inline-flex h-8 w-8 items-center justify-center rounded-3xl bg-primary-100/80"
       aria-label="가능"
     >
@@ -67,12 +68,13 @@ function PermissionAllowedBadge() {
         className="h-5 w-5 stroke-2 text-primary-500"
         aria-hidden="true"
       />
-    </div>
+    </span>
   );
 }
 function PermissionDeniedBadge() {
   return (
-    <div
+    <span
+      role="img"
       className="inline-flex h-8 w-8 items-center justify-center rounded-3xl bg-surface-300/80"
       aria-label="불가능"
     >
@@ -80,7 +82,7 @@ function PermissionDeniedBadge() {
         className="h-4.5 w-4.5 [&_path]:stroke-[2.5] text-info-red"
         aria-hidden="true"
       />
-    </div>
+    </span>
   );
 }
 

--- a/src/types/workspace/workspace.ts
+++ b/src/types/workspace/workspace.ts
@@ -79,6 +79,7 @@ export type TDeleteWorkspaceMemberResponse = string;
 
 export type TPermissionKey =
   | "campaignView"
+  | "timelineManage"
   | "billingManage"
   | "workspaceView"
   | "memberInvite"

--- a/src/types/workspace/workspace.ts
+++ b/src/types/workspace/workspace.ts
@@ -90,7 +90,7 @@ export type TPermissionRow = {
   key: TPermissionKey;
   label: string;
   description: string;
-  defaultMemberEnabled: boolean;
+  memberAllowed: boolean;
 };
 
 export type TInviteMemberRequest = {


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #448 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 멤버 관리 권한 설정을 토글/저장 UI를 역할별 고정 안내표로 변경
- 기존 설정해둔 RBAC 기준으로 멤버 가능/불가능 정리
- `defaultMemberEnabled` → `memberAllowed`, 안내 문구 수정 

## 💻 작업 화면
<img width="1406" height="788" alt="image" src="https://github.com/user-attachments/assets/0b2cdb63-1db1-4a5a-b387-b0f8a7d8374f" />

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

권한 변경은 역할 변경으로 처리합니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 권한 표가 관리자와 멤버별 권한을 ‘가능’ 또는 ‘불가능’ 뱃지로 표시하도록 변경되었습니다.
  * 권한을 직접 토글하거나 저장·취소하는 기능이 제거되었습니다.
  * 권한 안내 문구가 역할에 따라 권한이 고정되며, 역할 변경은 멤버 목록에서 진행한다는 내용으로 업데이트되었습니다.
  * 타임라인 관리 권한 항목이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->