### PR TITLE
[Bugfix/#461] Discord webhook URL 검증 추가

### DIFF
--- a/src/hooks/setting/useSettingNotifications.ts
+++ b/src/hooks/setting/useSettingNotifications.ts
@@ -163,11 +163,21 @@ export default function useSettingNotifications() {
       setDiscordWebhookError("Webhook URL을 입력해주세요");
       return;
     }
-    if (!url.startsWith("https://")) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
       setDiscordWebhookError("올바른 URL 형식으로 입력해주세요");
       return;
     }
-
+    const DISCORD_HOSTS = ["discord.com", "discordapp.com"];
+    if (
+      parsed.protocol !== "https:" ||
+      !DISCORD_HOSTS.includes(parsed.hostname)
+    ) {
+      setDiscordWebhookError("디스코드 Webhook URL을 입력해주세요");
+      return;
+    }
     setPendingOrgAction("discord");
     try {
       await updateOrg.mutateAsync(


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #461 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- develop에서 main으로 배포 과정에서 discord webhook url 검증이 slack 채널보다 느슨하다는 점을 확인했습니다.
- 따라서, discord도 slack과 동일하게  protocol/hostname을 검증하는 단계를 추가하였습니다.

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
