### PR TITLE
[Bugfix/#460] org 저장시 alert draft 값 반영

### DIFF
--- a/src/hooks/setting/useSettingNotifications.ts
+++ b/src/hooks/setting/useSettingNotifications.ts
@@ -86,6 +86,7 @@ export default function useSettingNotifications() {
     (isNotificationLoading || isNotificationRefetching);
 
   const buildOrgBody = (
+    alerts: { alertClicks: boolean; alertReport: boolean },
     overrides: Partial<IUpdateOrgNotificationSettingsRequest> = {},
   ): IUpdateOrgNotificationSettingsRequest => ({
     isSlackEnabled: savedOrgNotif.slackEnabled,
@@ -94,8 +95,8 @@ export default function useSettingNotifications() {
     isDiscordEnabled: savedOrgNotif.discordEnabled,
     discordWebhookUrl: "",
     disconnectDiscord: false,
-    alertClicks: savedWorkspaceNotif.clickAlarm ?? false,
-    alertReport: savedWorkspaceNotif.weeklyReport ?? false,
+    alertClicks: alerts.alertClicks,
+    alertReport: alerts.alertReport,
     ...overrides,
   });
 
@@ -121,11 +122,17 @@ export default function useSettingNotifications() {
     setPendingOrgAction("slack");
     try {
       await updateOrg.mutateAsync(
-        buildOrgBody({
-          isSlackEnabled: true,
-          slackWebhookUrl: url,
-          disconnectSlack: false,
-        }),
+        buildOrgBody(
+          {
+            alertClicks: draftWorkspaceNotif.clickAlarm,
+            alertReport: draftWorkspaceNotif.weeklyReport,
+          },
+          {
+            isSlackEnabled: true,
+            slackWebhookUrl: url,
+            disconnectSlack: false,
+          },
+        ),
       );
       toast.success("슬랙이 연동되었습니다");
       setSlackWebhookUrl("");
@@ -142,11 +149,17 @@ export default function useSettingNotifications() {
     setPendingOrgAction("slack");
     try {
       await updateOrg.mutateAsync(
-        buildOrgBody({
-          isSlackEnabled: false,
-          slackWebhookUrl: "",
-          disconnectSlack: true,
-        }),
+        buildOrgBody(
+          {
+            alertClicks: draftWorkspaceNotif.clickAlarm,
+            alertReport: draftWorkspaceNotif.weeklyReport,
+          },
+          {
+            isSlackEnabled: false,
+            slackWebhookUrl: "",
+            disconnectSlack: true,
+          },
+        ),
       );
       toast.success("슬랙 연동이 해제되었습니다");
     } catch (e) {
@@ -171,11 +184,17 @@ export default function useSettingNotifications() {
     setPendingOrgAction("discord");
     try {
       await updateOrg.mutateAsync(
-        buildOrgBody({
-          isDiscordEnabled: true,
-          discordWebhookUrl: url,
-          disconnectDiscord: false,
-        }),
+        buildOrgBody(
+          {
+            alertClicks: draftWorkspaceNotif.clickAlarm,
+            alertReport: draftWorkspaceNotif.weeklyReport,
+          },
+          {
+            isDiscordEnabled: true,
+            discordWebhookUrl: url,
+            disconnectDiscord: false,
+          },
+        ),
       );
       toast.success("디스코드가 연동되었습니다");
       setDiscordWebhookUrl("");
@@ -192,11 +211,17 @@ export default function useSettingNotifications() {
     setPendingOrgAction("discord");
     try {
       await updateOrg.mutateAsync(
-        buildOrgBody({
-          isDiscordEnabled: false,
-          discordWebhookUrl: "",
-          disconnectDiscord: true,
-        }),
+        buildOrgBody(
+          {
+            alertClicks: draftWorkspaceNotif.clickAlarm,
+            alertReport: draftWorkspaceNotif.weeklyReport,
+          },
+          {
+            isDiscordEnabled: false,
+            discordWebhookUrl: "",
+            disconnectDiscord: true,
+          },
+        ),
       );
       toast.success("디스코드 연동이 해제되었습니다");
     } catch (e) {

--- a/src/hooks/setting/useSettingSave.ts
+++ b/src/hooks/setting/useSettingSave.ts
@@ -131,14 +131,20 @@ export default function useSettingSave({
           }
           if (shouldSaveOrg) {
             await notifications.updateOrg.mutateAsync(
-              notifications.buildOrgBody({
-                isSlackEnabled: notifications.draftOrgNotif.slackEnabled,
-                slackWebhookUrl: "",
-                disconnectSlack: false,
-                isDiscordEnabled: notifications.draftOrgNotif.discordEnabled,
-                discordWebhookUrl: "",
-                disconnectDiscord: false,
-              }),
+              notifications.buildOrgBody(
+                {
+                  alertClicks: notifications.draftWorkspaceNotif.clickAlarm,
+                  alertReport: notifications.draftWorkspaceNotif.weeklyReport,
+                },
+                {
+                  isSlackEnabled: notifications.draftOrgNotif.slackEnabled,
+                  slackWebhookUrl: "",
+                  disconnectSlack: false,
+                  isDiscordEnabled: notifications.draftOrgNotif.discordEnabled,
+                  discordWebhookUrl: "",
+                  disconnectDiscord: false,
+                },
+              ),
             );
             notifications.setSavedOrgNotif((prev) => ({
               ...prev,


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #460 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- develop 에서 main으로 배포과정 중에 org 알림 저장할때 alertClick과 alertReport가 최신값인 draft 값이 아니라 이전 saved 값이 실릴 수도 있다는 점을 확인했습니다.
- 그래서 `buildOrgBody`가 `savedWorkspaceNotif`를 암묵적으로 참조할 수 없도록, alert 값을 인자로 받도록 변경했습니다.
- 저장/슬랙/디스코드 연동 에서도 draft 값 받도록 수정했습니다.

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
