### PR TITLE
[Refactor/#453] 예산 API 스펙 매핑 및 캠페인 목록 예산 열 제거

### DIFF
--- a/src/components/ads/CampaignPlatformSection.tsx
+++ b/src/components/ads/CampaignPlatformSection.tsx
@@ -3,10 +3,7 @@ import { twMerge } from "tailwind-merge";
 
 import type { IPlatformBudgetSummary, TPlatform } from "@/types/ads/campaign";
 
-import {
-  BUDGET_EDIT_BLOCK_MESSAGES,
-  canSubmitPlatformBudgetEdit,
-} from "@/utils/ads/budgetEdit";
+import { canSubmitPlatformBudgetEdit } from "@/utils/ads/budgetEdit";
 import {
   mapPlatformBudgetSummariesToGauges,
   pickEditablePlatformBudget,
@@ -47,49 +44,28 @@ export default function CampaignPlatformSection({
 
   const editCheck = canSubmitPlatformBudgetEdit(editTarget ?? undefined);
   const isBudgetEditDisabled = !onEditBudget || !editTarget || !editCheck.ok;
-  const budgetEditDisabledReason = !onEditBudget
-    ? undefined
-    : !editTarget
-      ? BUDGET_EDIT_BLOCK_MESSAGES.MISSING_PLATFORM_BUDGET
-      : editCheck.ok
-        ? undefined
-        : BUDGET_EDIT_BLOCK_MESSAGES[editCheck.reason];
-  const budgetEditHintId = `budget-edit-hint-${platform}`;
 
   const campaignName = platformBudgets.find(
     (row) => row.adCampaignName,
   )?.adCampaignName;
 
   const budgetEditAction = (
-    <div className="flex flex-col items-end gap-1">
-      <Button
-        type="button"
-        size="small"
-        variant="outline"
-        className={twMerge(
-          "h-9 shrink-0 px-3.5",
-          isBudgetEditDisabled && "opacity-60",
-        )}
-        onClick={() => {
-          if (!editTarget || !onEditBudget) return;
-          onEditBudget(editTarget);
-        }}
-        disabled={isBudgetEditDisabled}
-        aria-describedby={
-          budgetEditDisabledReason ? budgetEditHintId : undefined
-        }
-      >
-        예산 수정
-      </Button>
-      {budgetEditDisabledReason ? (
-        <p
-          id={budgetEditHintId}
-          className="max-w-48 text-right font-caption text-text-muted"
-        >
-          {budgetEditDisabledReason}
-        </p>
-      ) : null}
-    </div>
+    <Button
+      type="button"
+      size="small"
+      variant="outline"
+      className={twMerge(
+        "h-9 shrink-0 px-3.5",
+        isBudgetEditDisabled && "opacity-60",
+      )}
+      onClick={() => {
+        if (!editTarget || !onEditBudget) return;
+        onEditBudget(editTarget);
+      }}
+      disabled={isBudgetEditDisabled}
+    >
+      예산 수정
+    </Button>
   );
 
   return (

--- a/src/components/ads/CampaignPlatformSection.tsx
+++ b/src/components/ads/CampaignPlatformSection.tsx
@@ -1,13 +1,16 @@
 import type { ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 
-import type { IPlatformProjectBudget, TPlatform } from "@/types/ads/campaign";
+import type { IPlatformBudgetSummary, TPlatform } from "@/types/ads/campaign";
 
 import {
   BUDGET_EDIT_BLOCK_MESSAGES,
   canSubmitPlatformBudgetEdit,
 } from "@/utils/ads/budgetEdit";
-import { mapPlatformProjectBudgetToGauges } from "@/utils/ads/projectBudget";
+import {
+  mapPlatformBudgetSummariesToGauges,
+  pickEditablePlatformBudget,
+} from "@/utils/ads/projectBudget";
 
 import PlatformBudgetItem from "@/components/ads/PlatformBudgetItem";
 import Button from "@/components/common/button/Button";
@@ -30,27 +33,32 @@ const PLATFORM_LABEL: Record<TPlatform, string> = {
 
 interface ICampaignPlatformSectionProps {
   platform: TPlatform;
-  platformBudget?: IPlatformProjectBudget;
-  onEditBudget?: () => void;
+  platformBudgets?: IPlatformBudgetSummary[];
+  onEditBudget?: (budget: IPlatformBudgetSummary) => void;
 }
 
 export default function CampaignPlatformSection({
   platform,
-  platformBudget,
+  platformBudgets = [],
   onEditBudget,
 }: ICampaignPlatformSectionProps) {
-  const gauges = platformBudget
-    ? mapPlatformProjectBudgetToGauges(platformBudget)
-    : [];
+  const gauges = mapPlatformBudgetSummariesToGauges(platformBudgets);
+  const editTarget = pickEditablePlatformBudget(platformBudgets);
 
-  const editCheck = canSubmitPlatformBudgetEdit(platformBudget);
-  const isBudgetEditDisabled = !onEditBudget || !editCheck.ok;
+  const editCheck = canSubmitPlatformBudgetEdit(editTarget ?? undefined);
+  const isBudgetEditDisabled = !onEditBudget || !editTarget || !editCheck.ok;
   const budgetEditDisabledReason = !onEditBudget
     ? undefined
-    : editCheck.ok
-      ? undefined
-      : BUDGET_EDIT_BLOCK_MESSAGES[editCheck.reason];
+    : !editTarget
+      ? BUDGET_EDIT_BLOCK_MESSAGES.MISSING_PLATFORM_BUDGET
+      : editCheck.ok
+        ? undefined
+        : BUDGET_EDIT_BLOCK_MESSAGES[editCheck.reason];
   const budgetEditHintId = `budget-edit-hint-${platform}`;
+
+  const campaignName = platformBudgets.find(
+    (row) => row.adCampaignName,
+  )?.adCampaignName;
 
   const budgetEditAction = (
     <div className="flex flex-col items-end gap-1">
@@ -62,7 +70,10 @@ export default function CampaignPlatformSection({
           "h-9 shrink-0 px-3.5",
           isBudgetEditDisabled && "opacity-60",
         )}
-        onClick={onEditBudget}
+        onClick={() => {
+          if (!editTarget || !onEditBudget) return;
+          onEditBudget(editTarget);
+        }}
         disabled={isBudgetEditDisabled}
         aria-describedby={
           budgetEditDisabledReason ? budgetEditHintId : undefined
@@ -100,9 +111,9 @@ export default function CampaignPlatformSection({
                   {PLATFORM_LABEL[platform]}
                 </span>
               </h2>
-              {platformBudget?.adCampaignName ? (
+              {campaignName ? (
                 <p className="truncate font-body2 text-text-muted">
-                  {platformBudget.adCampaignName}
+                  {campaignName}
                 </p>
               ) : null}
             </div>
@@ -115,12 +126,12 @@ export default function CampaignPlatformSection({
           예산 정보가 없습니다.
         </p>
       ) : (
-        <div className="w-full min-w-0">
-          {gauges.map((gauge) => (
+        <div className="flex w-full min-w-0 flex-col gap-5">
+          {gauges.map((gauge, index) => (
             <PlatformBudgetItem
               key={`${platform}-${gauge.label}`}
               {...gauge}
-              headerAction={budgetEditAction}
+              headerAction={index === 0 ? budgetEditAction : undefined}
             />
           ))}
         </div>

--- a/src/components/ads/CampaignRow.tsx
+++ b/src/components/ads/CampaignRow.tsx
@@ -3,8 +3,6 @@ import { twMerge } from "tailwind-merge";
 
 import type { TPlatform, TStatus } from "@/types/ads/campaign";
 
-import ProgressBar from "../common/progressbar/ProgressBar";
-
 import GoogleLogo from "@/assets/logo/social-logo/circle/google-circle.svg?react";
 import MetaLogo from "@/assets/logo/social-logo/circle/meta-circle.svg?react";
 import NaverLogo from "@/assets/logo/social-logo/circle/naver-circle.svg?react";
@@ -14,7 +12,6 @@ interface ICampaignRowProps {
   name: string;
   providers: TPlatform[];
   status: TStatus;
-  budgetUsageRate: number;
   isSelected: boolean;
   onToggleSelect: () => void;
   onClick?: () => void;
@@ -22,11 +19,7 @@ interface ICampaignRowProps {
 
 /** 헤더·행·스켈레톤 플랫폼 열 — 모바일에서 로고 최대 3개 폭 예약 */
 export const CAMPAIGN_PLATFORM_COL_CLASS =
-  "mr-24 w-28 shrink-0 tablet:mr-20 tablet:w-24 mobile:mr-2 mobile:w-16";
-
-/** 헤더·행·스켈레톤 예산 열 */
-export const CAMPAIGN_BUDGET_COL_CLASS =
-  "w-[28%] shrink-0 tablet:w-[26%] mobile:w-[30%] mobile:max-w-28";
+  "w-28 shrink-0 tablet:w-24 mobile:w-16";
 
 const LogoMap: Record<TPlatform, ReactNode> = {
   meta: (
@@ -44,7 +37,6 @@ export default function CampaignRow({
   name,
   providers,
   status,
-  budgetUsageRate,
   isSelected,
   onToggleSelect,
   onClick,
@@ -99,11 +91,12 @@ export default function CampaignRow({
       <div
         className={twMerge(
           CAMPAIGN_PLATFORM_COL_CLASS,
-          "flex items-center justify-start",
+          "flex items-center justify-end",
+          isPaused && "opacity-80",
         )}
       >
         {providers && providers.length > 0 ? (
-          <div className="flex items-center justify-start gap-1 mobile:gap-0.5">
+          <div className="flex items-center justify-end gap-2 mobile:gap-1.5">
             {providers.map((p, idx) => (
               <span key={idx} className="flex shrink-0">
                 {LogoMap[p.toLowerCase() as TPlatform] ?? (
@@ -115,12 +108,6 @@ export default function CampaignRow({
         ) : (
           <div className="font-caption text-text-placeholder">미연결</div>
         )}
-      </div>
-
-      <div
-        className={twMerge(CAMPAIGN_BUDGET_COL_CLASS, isPaused && "opacity-80")}
-      >
-        <ProgressBar value={budgetUsageRate} />
       </div>
     </li>
   );

--- a/src/components/ads/CampaignTable.tsx
+++ b/src/components/ads/CampaignTable.tsx
@@ -3,10 +3,7 @@ import { twMerge } from "tailwind-merge";
 
 import type { ICampaign } from "@/types/ads/campaign";
 
-import CampaignRow, {
-  CAMPAIGN_BUDGET_COL_CLASS,
-  CAMPAIGN_PLATFORM_COL_CLASS,
-} from "./CampaignRow";
+import CampaignRow, { CAMPAIGN_PLATFORM_COL_CLASS } from "./CampaignRow";
 
 interface ICampaignTableProps {
   campaigns: ICampaign[];
@@ -77,19 +74,10 @@ export default function CampaignTable({
         <div
           className={twMerge(
             CAMPAIGN_PLATFORM_COL_CLASS,
-            "whitespace-nowrap text-left font-label text-text-muted",
+            "whitespace-nowrap text-right font-label text-text-muted",
           )}
         >
           <span className="mobile:hidden">플랫폼</span>
-        </div>
-        <div
-          className={twMerge(
-            CAMPAIGN_BUDGET_COL_CLASS,
-            "text-left font-label text-text-muted",
-          )}
-        >
-          <span className="tablet:hidden">예산 소진 현황</span>
-          <span className="hidden tablet:inline">예산</span>
         </div>
       </div>
 

--- a/src/components/ads/EditPlatformBudgetModal.tsx
+++ b/src/components/ads/EditPlatformBudgetModal.tsx
@@ -8,7 +8,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 
-import type { IPlatformProjectBudget } from "@/types/ads/campaign";
+import type { IPlatformBudgetSummary } from "@/types/ads/campaign";
 
 import {
   buildUpdatePlatformBudgetVariables,
@@ -89,7 +89,7 @@ const BudgetAmountInput = forwardRef<HTMLInputElement, IBudgetAmountInputProps>(
   },
 );
 
-const PROVIDER_LABEL: Record<IPlatformProjectBudget["providerType"], string> = {
+const PROVIDER_LABEL: Record<IPlatformBudgetSummary["provider"], string> = {
   META: "Meta",
   GOOGLE: "Google",
   NAVER: "NAVER",
@@ -99,7 +99,7 @@ interface IEditPlatformBudgetModalProps {
   isOpen: boolean;
   onClose: () => void;
   onClosed?: () => void;
-  budget: IPlatformProjectBudget | null;
+  budget: IPlatformBudgetSummary | null;
   orgId: number;
   projectId: number;
 }
@@ -112,7 +112,7 @@ export default function EditPlatformBudgetModal({
   orgId,
   projectId,
 }: IEditPlatformBudgetModalProps) {
-  const budgetRef = useRef<IPlatformProjectBudget | null>(null);
+  const budgetRef = useRef<IPlatformBudgetSummary | null>(null);
   if (budget) budgetRef.current = budget;
 
   const activeBudget = budget ?? budgetRef.current;
@@ -184,12 +184,12 @@ export default function EditPlatformBudgetModal({
       onExitComplete={onClosed}
       size="md"
       padding="lg"
-      title={`${PROVIDER_LABEL[activeBudget.providerType]} 예산 수정`}
+      title={`${PROVIDER_LABEL[activeBudget.provider]} 예산 수정`}
       disableOverlayClick={isPending}
     >
       <div className="flex w-full flex-col items-start">
         <p aria-hidden className="mb-2 font-heading3 text-text-title">
-          {PROVIDER_LABEL[activeBudget.providerType]} 예산 수정
+          {PROVIDER_LABEL[activeBudget.provider]} 예산 수정
         </p>
         {activeBudget.adCampaignName ? (
           <p className="mb-1 max-w-full truncate font-body2 text-text-muted">
@@ -201,7 +201,7 @@ export default function EditPlatformBudgetModal({
         </p>
 
         <form
-          key={`${activeBudget.providerType}-${effectiveBudget?.activeBudgetType ?? "daily"}`}
+          key={`${activeBudget.provider}-${effectiveBudget?.activeBudgetType ?? "daily"}`}
           onSubmit={handleSubmit(onSubmit)}
           className="flex w-full flex-col gap-8"
           noValidate

--- a/src/components/ads/skeleton/AdsSkeleton.tsx
+++ b/src/components/ads/skeleton/AdsSkeleton.tsx
@@ -4,10 +4,7 @@ import {
   getAdListTableHeaderGridClass,
   getAdListTableRowGridClass,
 } from "@/components/ads/AdRow";
-import {
-  CAMPAIGN_BUDGET_COL_CLASS,
-  CAMPAIGN_PLATFORM_COL_CLASS,
-} from "@/components/ads/CampaignRow";
+import { CAMPAIGN_PLATFORM_COL_CLASS } from "@/components/ads/CampaignRow";
 import Card from "@/components/common/card/Card";
 import {
   Skeleton,
@@ -33,14 +30,11 @@ function CampaignTableRowSkeleton() {
       <div
         className={twMerge(
           CAMPAIGN_PLATFORM_COL_CLASS,
-          "flex items-center gap-1 mobile:gap-0.5",
+          "flex items-center justify-end gap-2 mobile:gap-1.5",
         )}
       >
         <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
         <SkeletonCircle className="h-7 w-7 tablet:h-6 tablet:w-6 mobile:h-5 mobile:w-5" />
-      </div>
-      <div className={CAMPAIGN_BUDGET_COL_CLASS}>
-        <Skeleton className="h-2 w-full rounded-full" />
       </div>
     </li>
   );
@@ -60,9 +54,6 @@ export function CampaignTableSkeleton() {
           <Skeleton className="h-4 w-16" />
         </div>
         <div className={CAMPAIGN_PLATFORM_COL_CLASS} aria-hidden />
-        <div className={CAMPAIGN_BUDGET_COL_CLASS}>
-          <Skeleton className="h-4 w-24 mobile:w-16" />
-        </div>
       </div>
 
       <ul className="m-0 list-none p-0">

--- a/src/hooks/ads/useUpdatePlatformBudget.ts
+++ b/src/hooks/ads/useUpdatePlatformBudget.ts
@@ -41,7 +41,7 @@ export function useUpdatePlatformBudget(orgId: number, projectId: number) {
             throw new Error("일일 예산을 입력해 주세요.");
           }
           if (
-            vars.activeBudgetType === "LIFETIME" &&
+            vars.activeBudgetType === "TOTAL" &&
             vars.lifetimeBudget === undefined
           ) {
             throw new Error("전체 예산을 입력해 주세요.");
@@ -63,7 +63,7 @@ export function useUpdatePlatformBudget(orgId: number, projectId: number) {
             throw new Error("일일 예산을 입력해 주세요.");
           }
           if (
-            vars.activeBudgetType === "LIFETIME" &&
+            vars.activeBudgetType === "TOTAL" &&
             vars.lifetimeBudget === undefined
           ) {
             throw new Error("전체 예산을 입력해 주세요.");

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
 
-import type { IPlatformProjectBudget, TPlatform } from "@/types/ads/campaign";
+import type { IPlatformBudgetSummary, TPlatform } from "@/types/ads/campaign";
 
 import { AD_PLATFORM_ORDER, groupAdsByPlatform } from "@/utils/ads/adPlatform";
 import {
+  groupPlatformBudgetsByPlatform,
   providerTypeToPlatform,
   resolvePlatformBudgets,
 } from "@/utils/ads/projectBudget";
@@ -79,7 +80,7 @@ export default function CampaignDetail() {
   const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
 
   const [budgetEditTarget, setBudgetEditTarget] =
-    useState<IPlatformProjectBudget | null>(null);
+    useState<IPlatformBudgetSummary | null>(null);
   const [isBudgetEditOpen, setIsBudgetEditOpen] = useState(false);
 
   const clearAdSelection = useCallback(() => {
@@ -193,13 +194,10 @@ export default function CampaignDetail() {
     [data?.providers, data?.platformBudgets],
   );
 
-  const budgetByPlatform = useMemo(() => {
-    const map = new Map<TPlatform, (typeof platformBudgets)[number]>();
-    for (const budget of platformBudgets) {
-      map.set(providerTypeToPlatform(budget.providerType), budget);
-    }
-    return map;
-  }, [platformBudgets]);
+  const budgetsByPlatform = useMemo(
+    () => groupPlatformBudgetsByPlatform(platformBudgets),
+    [platformBudgets],
+  );
 
   const platformSections = useMemo(() => {
     if (!data) return [];
@@ -207,9 +205,9 @@ export default function CampaignDetail() {
     const fromAds = groupAdsByPlatform(adsList, data.providers);
     const seen = new Set(fromAds.map((section) => section.platform));
 
-    // 광고 0개여도 예산 mock/API 있으면 섹션 표시
+    // 광고 0개여도 예산 API 있으면 섹션 표시
     for (const budget of platformBudgets) {
-      const platform = providerTypeToPlatform(budget.providerType);
+      const platform = providerTypeToPlatform(budget.provider);
       if (!seen.has(platform)) {
         fromAds.push({ platform, ads: [] });
         seen.add(platform);
@@ -365,13 +363,10 @@ export default function CampaignDetail() {
                 >
                   <CampaignPlatformSection
                     platform={platform}
-                    platformBudget={budgetByPlatform.get(platform)}
-                    onEditBudget={() => {
-                      const budget = budgetByPlatform.get(platform);
-                      if (budget) {
-                        setBudgetEditTarget(budget);
-                        setIsBudgetEditOpen(true);
-                      }
+                    platformBudgets={budgetsByPlatform.get(platform)}
+                    onEditBudget={(budget) => {
+                      setBudgetEditTarget(budget);
+                      setIsBudgetEditOpen(true);
                     }}
                   />
                   {platformAds.length > 0 ? (

--- a/src/types/ads/budget.ts
+++ b/src/types/ads/budget.ts
@@ -19,10 +19,10 @@ export interface INaverBudgetUpdateRequest {
   dailyBudget: number;
 }
 
-/** 일일 / 총 예산 구분 — 상세 API·수정 응답 공통 */
-export type TPlatformBudgetType = "DAILY" | "LIFETIME";
+/** 일일 / 총 예산 구분 — 상세·대시보드·수정 응답 공통 (OpenAPI: DAILY | TOTAL) */
+export type TPlatformBudgetType = "DAILY" | "TOTAL";
 
-/** Meta 상세 platformBudgets.activeBudgetType */
+/** @deprecated TPlatformBudgetType 사용 */
 export type TMetaActiveBudgetType = TPlatformBudgetType;
 
 /**

--- a/src/types/ads/campaign.ts
+++ b/src/types/ads/campaign.ts
@@ -8,6 +8,11 @@ export type TStatus = "ON_GOING" | "PAUSED" | "OVER";
  * GET /api/project/{orgId}/{projectId} — platformBudgets[] 항목
  * OpenAPI: PlatformBudgetSummary
  */
+export interface INaverBudgetTarget {
+  connectionId: number;
+  campaignId: string;
+}
+
 export interface IPlatformBudgetSummary {
   provider: TProvider;
   budgetType: TPlatformBudgetType;
@@ -15,11 +20,11 @@ export interface IPlatformBudgetSummary {
   spend: number;
   remainingBudget: number;
   remainingPercentage: number;
-  /** 예산 수정용 — 현재 OpenAPI 미포함, 내려오면 수정 활성화 */
-  adCampaignId?: number;
+  /** Meta / Google 예산 수정 path */
+  adCampaignId?: number | null;
   adCampaignName?: string;
-  naverConnectionId?: number;
-  naverCampaignId?: string;
+  /** Naver 예산 수정 path */
+  naverBudgetTarget?: INaverBudgetTarget | null;
   canEditBudget?: boolean;
 }
 

--- a/src/types/ads/campaign.ts
+++ b/src/types/ads/campaign.ts
@@ -1,26 +1,25 @@
 import type { TPlatformBudgetType } from "@/types/ads/budget";
-import type { IBudgetAmountSlice } from "@/types/dashboard/common";
 
 export type TPlatform = "meta" | "google" | "naver"; //UI
 export type TProvider = "META" | "GOOGLE" | "NAVER"; //API
 export type TStatus = "ON_GOING" | "PAUSED" | "OVER";
 
-/** project 상세 — 플랫폼(매체 캠페인) 단위 예산 */
-export interface IPlatformProjectBudget {
-  providerType: TProvider;
-  /** Meta / Google 예산 수정 path param */
+/**
+ * GET /api/project/{orgId}/{projectId} — platformBudgets[] 항목
+ * OpenAPI: PlatformBudgetSummary
+ */
+export interface IPlatformBudgetSummary {
+  provider: TProvider;
+  budgetType: TPlatformBudgetType;
+  budget: number;
+  spend: number;
+  remainingBudget: number;
+  remainingPercentage: number;
+  /** 예산 수정용 — 현재 OpenAPI 미포함, 내려오면 수정 활성화 */
   adCampaignId?: number;
   adCampaignName?: string;
-  lifetime: IBudgetAmountSlice;
-  /** Meta / Google — activeBudgetType에 따라 표시
-   *  Naver — 일일 예산 */
-  daily?: IBudgetAmountSlice | null;
-  /** Meta / Google — 기존 daily / lifetime 중 어떤 유형인지 */
-  activeBudgetType?: TPlatformBudgetType;
-  /** Naver 일일 예산 수정 — /api/naver/{connectionId}/campaigns/{campaignId}/budget */
   naverConnectionId?: number;
   naverCampaignId?: string;
-  /** 소유자 등 수정 가능 여부 */
   canEditBudget?: boolean;
 }
 
@@ -60,7 +59,7 @@ export interface ICampaignDetail extends ICampaign {
   budget: number;
   createdAt: string;
   ads: IAd[];
-  platformBudgets?: IPlatformProjectBudget[];
+  platformBudgets?: IPlatformBudgetSummary[];
 }
 
 export interface IPlatformCampaign {

--- a/src/types/dashboard/budget.ts
+++ b/src/types/dashboard/budget.ts
@@ -1,9 +1,5 @@
-/** 게이지 라벨 */
-export type TBudgetGaugeLabel =
-  | "전체 예산"
-  | "일일 예산"
-  | "Google·Meta"
-  | "NAVER";
+/** 게이지 라벨 — groups.budgetType(TOTAL/DAILY) 매핑 */
+export type TBudgetGaugeLabel = "전체 예산" | "일일 예산";
 
 /** 게이지 1개 분량 */
 export interface IBudgetSlice {

--- a/src/types/dashboard/common.ts
+++ b/src/types/dashboard/common.ts
@@ -1,3 +1,5 @@
+import type { TProviderType } from "./provider";
+
 // 공통 지표 응답 (overview/platform 공유)
 export interface IMetricsResponse {
   clicks: number;
@@ -10,25 +12,37 @@ export interface IMetricsResponse {
   ROASChangeRate: number;
 }
 
-// 예산 금액 단위 (API 분리 응답)
+// 예산 금액 단위
 export interface IBudgetAmountSlice {
   totalBudget: number;
   totalSpend: number;
 }
 
-// 예산 소진 현황
-export interface IBudgetResponse {
-  providerType: string;
-  usagePercentage: number;
-  totalBudget: number;
-  totalSpend: number;
+/** 대시보드 예산 group.budgetType */
+export type TDashboardBudgetType = "TOTAL" | "DAILY";
+
+/** 대시보드 예산 group.detail */
+export interface IBudgetGroupDetail {
+  budget: number;
+  spend: number;
   remainingBudget: number;
-  /** 통합 대시보드 — Google·Meta / Naver 분리 */
-  googleMeta?: IBudgetAmountSlice;
-  naver?: IBudgetAmountSlice;
-  /** 플랫폼 Google/Meta — 전체 / 일일 분리 */
-  lifetime?: IBudgetAmountSlice;
-  daily?: IBudgetAmountSlice;
+  /** 0~100 */
+  remainingPercentage: number;
+  estimated: boolean;
+}
+
+/** 대시보드 예산 groups[] 항목 */
+export interface IBudgetGroup {
+  budgetType: TDashboardBudgetType;
+  providers: TProviderType[];
+  detail: IBudgetGroupDetail;
+}
+
+/** GET /api/dashboard/budgets 응답 data */
+export interface IBudgetResponse {
+  /** 통합: "ALL", 플랫폼: GOOGLE | META | NAVER */
+  providerType: TProviderType | "ALL";
+  groups: IBudgetGroup[];
 }
 
 // ROAS 순위 항목

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -5,7 +5,7 @@ import type {
   TMetaGoogleBudgetUpdateRequest,
   TPlatformBudgetType,
 } from "@/types/ads/budget";
-import type { IPlatformProjectBudget } from "@/types/ads/campaign";
+import type { IPlatformBudgetSummary } from "@/types/ads/campaign";
 
 /** 예산 수정 불가 사유 — canSubmitPlatformBudgetEdit 반환값 */
 export type TBudgetEditBlockReason =
@@ -36,7 +36,7 @@ export const dailyBudgetFormSchema = z.object({
   dailyBudget: positiveBudget,
 });
 
-/** Meta / Google LIFETIME */
+/** Meta / Google TOTAL — 요청 body 필드명은 lifetimeBudget */
 export const lifetimeBudgetFormSchema = z.object({
   lifetimeBudget: positiveBudget,
 });
@@ -72,51 +72,47 @@ export interface IEffectivePlatformBudget {
 }
 
 /**
- * activeBudgetType + daily/lifetime 데이터 존재 여부로 실제 활성 예산 결정
- * — DAILY인데 daily 없으면 LIFETIME fallback
+ * PlatformBudgetSummary row → 수정/표시용 effective 예산
+ * — TOTAL 요청 body는 Meta/Google lifetimeBudget 필드 유지
  */
 export function resolveEffectivePlatformBudget(
-  budget: IPlatformProjectBudget,
+  budget: IPlatformBudgetSummary,
 ): IEffectivePlatformBudget {
-  if (budget.providerType === "NAVER") {
-    const daily = budget.daily ?? { totalBudget: 0, totalSpend: 0 };
+  if (budget.provider === "NAVER") {
     return {
-      activeBudgetType: "DAILY",
+      activeBudgetType: budget.budgetType,
       fieldName: "dailyBudget",
-      label: "일일 예산",
-      totalBudget: daily.totalBudget,
-      totalSpend: daily.totalSpend,
+      label: budget.budgetType === "TOTAL" ? "전체 예산" : "일일 예산",
+      totalBudget: budget.budget,
+      totalSpend: budget.spend,
     };
   }
 
-  const declaredType =
-    budget.activeBudgetType ?? (budget.daily ? "DAILY" : "LIFETIME");
-
-  if (declaredType === "DAILY" && budget.daily) {
+  if (budget.budgetType === "DAILY") {
     return {
       activeBudgetType: "DAILY",
       fieldName: "dailyBudget",
       label: "일일 예산",
-      totalBudget: budget.daily.totalBudget,
-      totalSpend: budget.daily.totalSpend,
+      totalBudget: budget.budget,
+      totalSpend: budget.spend,
     };
   }
 
   return {
-    activeBudgetType: "LIFETIME",
+    activeBudgetType: "TOTAL",
     fieldName: "lifetimeBudget",
     label: "전체 예산",
-    totalBudget: budget.lifetime.totalBudget,
-    totalSpend: budget.lifetime.totalSpend,
+    totalBudget: budget.budget,
+    totalSpend: budget.spend,
   };
 }
 
 /**
  * platformBudget → API 호출 가능 여부
- * BE 필드 없거나 mock이면 ok: false → 수정 버튼 disabled
+ * OpenAPI PlatformBudgetSummary에 수정용 ID가 없으면 disabled
  */
 export function canSubmitPlatformBudgetEdit(
-  budget: IPlatformProjectBudget | undefined,
+  budget: IPlatformBudgetSummary | undefined,
 ): { ok: true } | { ok: false; reason: TBudgetEditBlockReason } {
   if (!budget) {
     return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
@@ -126,15 +122,15 @@ export function canSubmitPlatformBudgetEdit(
     return { ok: false, reason: "NOT_EDITABLE" };
   }
 
-  switch (budget.providerType) {
+  switch (budget.provider) {
     case "META":
-      if (!budget.adCampaignId || !budget.activeBudgetType) {
+      if (!budget.adCampaignId) {
         return { ok: false, reason: "MISSING_META_CONTEXT" };
       }
       return { ok: true };
 
     case "GOOGLE":
-      if (!budget.adCampaignId || !budget.activeBudgetType) {
+      if (!budget.adCampaignId) {
         return { ok: false, reason: "MISSING_GOOGLE_CONTEXT" };
       }
       return { ok: true };
@@ -143,9 +139,6 @@ export function canSubmitPlatformBudgetEdit(
       if (!budget.naverConnectionId || !budget.naverCampaignId) {
         return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
       }
-      if (!budget.daily) {
-        return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
-      }
       return { ok: true };
 
     default:
@@ -153,7 +146,7 @@ export function canSubmitPlatformBudgetEdit(
   }
 }
 
-/** Meta / Google — activeBudgetType에 맞는 필드 하나만 body에 */
+/** Meta / Google — budgetType에 맞는 필드 하나만 body에 */
 export function buildMetaGoogleBudgetPayload(
   activeBudgetType: TPlatformBudgetType,
   values: { dailyBudget?: number; lifetimeBudget?: number },
@@ -179,10 +172,10 @@ export function buildNaverBudgetPayload(
 }
 
 /**
- * 모달 — provider + activeBudgetType에 맞는 zod schema
+ * 모달 — provider + budgetType에 맞는 zod schema
  */
-export function resolveBudgetEditFormSchema(budget: IPlatformProjectBudget) {
-  if (budget.providerType === "NAVER") {
+export function resolveBudgetEditFormSchema(budget: IPlatformBudgetSummary) {
+  if (budget.provider === "NAVER") {
     return naverBudgetFormSchema;
   }
 
@@ -193,7 +186,7 @@ export function resolveBudgetEditFormSchema(budget: IPlatformProjectBudget) {
 }
 
 /** 모달 input — 필드명·라벨 (게이지 라벨과 동일) */
-export function resolveBudgetEditFieldMeta(budget: IPlatformProjectBudget): {
+export function resolveBudgetEditFieldMeta(budget: IPlatformBudgetSummary): {
   fieldName: "dailyBudget" | "lifetimeBudget";
   label: string;
 } {
@@ -203,7 +196,7 @@ export function resolveBudgetEditFieldMeta(budget: IPlatformProjectBudget): {
 
 /** platformBudget → 폼 defaultValues */
 export function resolveBudgetEditDefaultValues(
-  budget: IPlatformProjectBudget,
+  budget: IPlatformBudgetSummary,
 ): TBudgetEditModalFormValues {
   const { fieldName, totalBudget } = resolveEffectivePlatformBudget(budget);
 
@@ -216,10 +209,10 @@ export function resolveBudgetEditDefaultValues(
 
 /** budget + form values → mutation variables */
 export function buildUpdatePlatformBudgetVariables(
-  budget: IPlatformProjectBudget,
+  budget: IPlatformBudgetSummary,
   values: TBudgetEditModalFormValues,
 ): {
-  providerType: IPlatformProjectBudget["providerType"];
+  providerType: IPlatformBudgetSummary["provider"];
   adCampaignId?: number;
   activeBudgetType?: TPlatformBudgetType;
   naverConnectionId?: number;
@@ -230,7 +223,7 @@ export function buildUpdatePlatformBudgetVariables(
   const { activeBudgetType } = resolveEffectivePlatformBudget(budget);
 
   const base = {
-    providerType: budget.providerType,
+    providerType: budget.provider,
     adCampaignId: budget.adCampaignId,
     activeBudgetType,
     naverConnectionId: budget.naverConnectionId,

--- a/src/utils/ads/budgetEdit.ts
+++ b/src/utils/ads/budgetEdit.ts
@@ -135,11 +135,13 @@ export function canSubmitPlatformBudgetEdit(
       }
       return { ok: true };
 
-    case "NAVER":
-      if (!budget.naverConnectionId || !budget.naverCampaignId) {
+    case "NAVER": {
+      const target = budget.naverBudgetTarget;
+      if (!target?.connectionId || !target.campaignId) {
         return { ok: false, reason: "MISSING_NAVER_CONTEXT" };
       }
       return { ok: true };
+    }
 
     default:
       return { ok: false, reason: "MISSING_PLATFORM_BUDGET" };
@@ -221,13 +223,14 @@ export function buildUpdatePlatformBudgetVariables(
   lifetimeBudget?: number;
 } {
   const { activeBudgetType } = resolveEffectivePlatformBudget(budget);
+  const naverTarget = budget.naverBudgetTarget;
 
   const base = {
     providerType: budget.provider,
-    adCampaignId: budget.adCampaignId,
+    adCampaignId: budget.adCampaignId ?? undefined,
     activeBudgetType,
-    naverConnectionId: budget.naverConnectionId,
-    naverCampaignId: budget.naverCampaignId,
+    naverConnectionId: naverTarget?.connectionId,
+    naverCampaignId: naverTarget?.campaignId,
   };
 
   if (values.lifetimeBudget !== undefined) {

--- a/src/utils/ads/projectBudget.ts
+++ b/src/utils/ads/projectBudget.ts
@@ -113,7 +113,14 @@ export function buildPlaceholderPlatformBudgets(
         totalBudget > 0
           ? Math.round(((totalBudget - totalSpend) / totalBudget) * 100)
           : 100,
-      adCampaignId: 1000 + index,
+      ...(provider === "NAVER"
+        ? {
+            naverBudgetTarget: {
+              connectionId: 1,
+              campaignId: `mock-campaign-${index}`,
+            },
+          }
+        : { adCampaignId: 1000 + index }),
       adCampaignName: `${provider} 매체 캠페인 (mock)`,
       canEditBudget: false,
     });

--- a/src/utils/ads/projectBudget.ts
+++ b/src/utils/ads/projectBudget.ts
@@ -1,15 +1,23 @@
+import type { TPlatformBudgetType } from "@/types/ads/budget";
 import type {
-  IPlatformProjectBudget,
+  IPlatformBudgetSummary,
   TPlatform,
   TProvider,
 } from "@/types/ads/campaign";
 import type { IBudgetGaugeProps } from "@/types/dashboard/budget";
 
-import { resolveEffectivePlatformBudget } from "@/utils/ads/budgetEdit";
 import {
   buildBudgetGaugesFromSlices,
   supportsDailyBudget,
 } from "@/utils/dashboard/budget";
+
+const BUDGET_TYPE_LABEL: Record<
+  TPlatformBudgetType,
+  "전체 예산" | "일일 예산"
+> = {
+  TOTAL: "전체 예산",
+  DAILY: "일일 예산",
+};
 
 export function providerTypeToPlatform(
   provider: TProvider | string,
@@ -25,67 +33,132 @@ export function platformToProviderType(platform: TPlatform): TProvider {
   return platform.toUpperCase() as TProvider;
 }
 
-/** project detail — 플랫폼별 BudgetGaugeChart props */
-export function mapPlatformProjectBudgetToGauges(
-  budget: IPlatformProjectBudget,
+/**
+ * 플랫폼별 표시할 budget rows
+ * — Naver: TOTAL 우선, TOTAL 없고 DAILY만 있으면 DAILY 표시
+ */
+export function filterPlatformBudgetSummariesForDisplay(
+  summaries: IPlatformBudgetSummary[],
+): IPlatformBudgetSummary[] {
+  const hasNaverTotal = summaries.some(
+    (row) => row.provider === "NAVER" && row.budgetType === "TOTAL",
+  );
+
+  return summaries.filter((row) => {
+    if (row.provider !== "NAVER") return true;
+    if (row.budgetType === "TOTAL") return true;
+    // TOTAL이 있을 때만 DAILY 숨김 (둘 다 오면 전체만)
+    if (row.budgetType === "DAILY") return !hasNaverTotal;
+    return true;
+  });
+}
+
+/** project detail — 플랫폼별 게이지 props */
+export function mapPlatformBudgetSummariesToGauges(
+  summaries: IPlatformBudgetSummary[],
 ): IBudgetGaugeProps[] {
-  const effective = resolveEffectivePlatformBudget(budget);
+  const visible = filterPlatformBudgetSummariesForDisplay(summaries);
 
   return buildBudgetGaugesFromSlices(
-    [
-      {
-        label: effective.label,
-        totalBudget: effective.totalBudget,
-        spent: effective.totalSpend,
-      },
-    ],
+    visible.map((row) => ({
+      label: BUDGET_TYPE_LABEL[row.budgetType],
+      totalBudget: row.budget,
+      spent: row.spend,
+    })),
     { showInsight: true },
   );
 }
 
-/** API 미준비 시 dev placeholder */
+/** 수정 모달용 — 플랫폼에서 대표 row 선택 */
+export function pickEditablePlatformBudget(
+  summaries: IPlatformBudgetSummary[],
+): IPlatformBudgetSummary | null {
+  if (summaries.length === 0) return null;
+
+  const provider = summaries[0]?.provider;
+  if (provider === "NAVER") {
+    return (
+      summaries.find((row) => row.budgetType === "TOTAL") ??
+      summaries[0] ??
+      null
+    );
+  }
+
+  return (
+    summaries.find((row) => row.budgetType === "DAILY") ??
+    summaries.find((row) => row.budgetType === "TOTAL") ??
+    summaries[0] ??
+    null
+  );
+}
+
+/** API 미준비 시(platformBudgets 필드 자체 없음) dev placeholder */
 export function buildPlaceholderPlatformBudgets(
   providers: TPlatform[],
-): IPlatformProjectBudget[] {
-  return providers.map((platform, index) => {
-    const providerType = platformToProviderType(platform);
+): IPlatformBudgetSummary[] {
+  const rows: IPlatformBudgetSummary[] = [];
+
+  providers.forEach((platform, index) => {
+    const provider = platformToProviderType(platform);
     const totalBudget = 1_000_000 + index * 200_000;
     const totalSpend = Math.round(totalBudget * (0.2 + index * 0.15));
 
-    const item: IPlatformProjectBudget = {
-      providerType,
+    rows.push({
+      provider,
+      budgetType: "TOTAL",
+      budget: totalBudget,
+      spend: totalSpend,
+      remainingBudget: Math.max(0, totalBudget - totalSpend),
+      remainingPercentage:
+        totalBudget > 0
+          ? Math.round(((totalBudget - totalSpend) / totalBudget) * 100)
+          : 100,
       adCampaignId: 1000 + index,
-      adCampaignName: `${providerType} 매체 캠페인 (mock)`,
-      lifetime: { totalBudget, totalSpend },
-    };
+      adCampaignName: `${provider} 매체 캠페인 (mock)`,
+      canEditBudget: false,
+    });
 
-    if (providerType === "NAVER") {
-      item.daily = {
-        totalBudget: 50_000,
-        totalSpend: 12_000 + index * 2_000,
-      };
-      item.naverConnectionId = 1;
-      item.naverCampaignId = `mock-campaign-${index}`;
-      item.canEditBudget = true;
-    } else if (supportsDailyBudget(providerType)) {
-      item.daily = {
-        totalBudget: 50_000,
-        totalSpend: 12_000 + index * 2_000,
-      };
-      item.activeBudgetType = index % 2 === 0 ? "DAILY" : "LIFETIME";
-      item.canEditBudget = true;
+    if (supportsDailyBudget(provider)) {
+      const dailyBudget = 50_000;
+      const dailySpend = 12_000 + index * 2_000;
+      rows.push({
+        provider,
+        budgetType: "DAILY",
+        budget: dailyBudget,
+        spend: dailySpend,
+        remainingBudget: Math.max(0, dailyBudget - dailySpend),
+        remainingPercentage: Math.round(
+          ((dailyBudget - dailySpend) / dailyBudget) * 100,
+        ),
+        adCampaignId: 1000 + index,
+        adCampaignName: `${provider} 매체 캠페인 (mock)`,
+        canEditBudget: false,
+      });
     }
-
-    return item;
   });
+
+  return rows;
 }
 
-/** API 응답 + fallback (platformBudgets 없으면 mock) */
+/** API 응답 우선 — 필드가 있으면(빈 배열 포함) 그대로 사용 */
 export function resolvePlatformBudgets(input: {
   providers: TPlatform[];
-  platformBudgets?: IPlatformProjectBudget[];
-}): IPlatformProjectBudget[] {
-  if (input.platformBudgets?.length) return input.platformBudgets;
+  platformBudgets?: IPlatformBudgetSummary[];
+}): IPlatformBudgetSummary[] {
+  if (input.platformBudgets !== undefined) return input.platformBudgets;
   if (input.providers.length === 0) return [];
   return buildPlaceholderPlatformBudgets(input.providers);
+}
+
+export function groupPlatformBudgetsByPlatform(
+  budgets: IPlatformBudgetSummary[],
+): Map<TPlatform, IPlatformBudgetSummary[]> {
+  const map = new Map<TPlatform, IPlatformBudgetSummary[]>();
+  for (const budget of budgets) {
+    const platform = providerTypeToPlatform(budget.provider);
+    const list = map.get(platform) ?? [];
+    list.push(budget);
+    map.set(platform, list);
+  }
+  return map;
 }

--- a/src/utils/dashboard/budget.ts
+++ b/src/utils/dashboard/budget.ts
@@ -4,8 +4,9 @@ import type {
   IBudgetViewModel,
 } from "@/types/dashboard/budget";
 import type {
-  IBudgetAmountSlice,
+  IBudgetGroup,
   IBudgetResponse,
+  TDashboardBudgetType,
 } from "@/types/dashboard/common";
 import type { TProviderType } from "@/types/dashboard/provider";
 
@@ -15,7 +16,12 @@ const DANGER_THRESHOLD = 75;
 /** BudgetGaugeChart showInsight 기본값 */
 export const SHOW_BUDGET_GAUGE_INSIGHT = true;
 
-/** Google/Meta 플랫폼 — 일일 예산 게이지 */
+const BUDGET_TYPE_LABEL: Record<TDashboardBudgetType, IBudgetSlice["label"]> = {
+  TOTAL: "전체 예산",
+  DAILY: "일일 예산",
+};
+
+/** Google/Meta 플랫폼 — 일일 예산 게이지 (skeleton·ads용) */
 export function supportsDailyBudget(provider?: TProviderType): boolean {
   return provider === "GOOGLE" || provider === "META";
 }
@@ -54,26 +60,22 @@ export const statusPointClasses: Record<TBudgetStatus, string> = {
   위험: "bg-info-red",
 };
 
-function toAmountSlice(
-  data: IBudgetResponse,
-  slice?: IBudgetAmountSlice,
-): IBudgetAmountSlice {
-  return (
-    slice ?? {
-      totalBudget: data.totalBudget,
-      totalSpend: data.totalSpend,
-    }
-  );
+/** Naver 플랫폼만 DAILY 숨김 (통합 ALL은 TOTAL+DAILY 그대로) */
+function filterBudgetGroups(
+  groups: IBudgetGroup[],
+  provider?: TProviderType,
+): IBudgetGroup[] {
+  if (provider === "NAVER") {
+    return groups.filter((group) => group.budgetType === "TOTAL");
+  }
+  return groups;
 }
 
-function toBudgetSlice(
-  label: IBudgetSlice["label"],
-  amount: IBudgetAmountSlice,
-): IBudgetSlice {
+function toBudgetSliceFromGroup(group: IBudgetGroup): IBudgetSlice {
   return {
-    label,
-    totalBudget: amount.totalBudget,
-    spent: amount.totalSpend,
+    label: BUDGET_TYPE_LABEL[group.budgetType],
+    totalBudget: group.detail.budget,
+    spent: group.detail.spend,
   };
 }
 
@@ -90,53 +92,21 @@ function toGaugeProps(
   };
 }
 
-/** 통합: Google·Meta + Naver (전체 예산 각 1개) */
-function mapOverviewBudgetViewModel(data: IBudgetResponse): IBudgetViewModel {
-  const googleMeta = toAmountSlice(data, data.googleMeta);
-  const naver = data.naver ?? { totalBudget: 0, totalSpend: 0 };
-
-  return {
-    slices: [
-      toBudgetSlice("Google·Meta", googleMeta),
-      toBudgetSlice("NAVER", naver),
-    ],
-  };
-}
-
-/** 플랫폼: Google/Meta → 전체+일일, Naver → 전체만 */
-function mapPlatformBudgetViewModel(
-  data: IBudgetResponse,
-  provider: TProviderType,
-): IBudgetViewModel {
-  const lifetime = toBudgetSlice(
-    "전체 예산",
-    toAmountSlice(data, data.lifetime),
-  );
-
-  if (!supportsDailyBudget(provider)) {
-    return { slices: [lifetime] };
-  }
-
-  const daily = toBudgetSlice("일일 예산", toAmountSlice(data, data.daily));
-
-  return { slices: [lifetime, daily] };
-}
-
 /**
- * API → UI 변환 (API 스펙 변경 시 여기만 수정)
+ * API → UI 변환
  *
- * [통합] googleMeta + naver (legacy: googleMeta만 totalBudget/totalSpend fallback)
- * [Google/Meta] lifetime + daily
- * [Naver] lifetime만
+ * [통합] groups 그대로 (TOTAL + DAILY)
+ * [Google/Meta] groups 그대로
+ * [Naver] TOTAL만
  */
 export function mapBudgetResponseToViewModel(
   data: IBudgetResponse,
   provider?: TProviderType,
 ): IBudgetViewModel {
-  if (provider === undefined) {
-    return mapOverviewBudgetViewModel(data);
-  }
-  return mapPlatformBudgetViewModel(data, provider);
+  const groups = filterBudgetGroups(data.groups, provider);
+  return {
+    slices: groups.map(toBudgetSliceFromGroup),
+  };
 }
 
 /** useBudget select에서 쓸 최종 형태 */


### PR DESCRIPTION
## 🚨 관련 이슈

close #453

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [X] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 대시보드 예산 응답을 `groups`(TOTAL/DAILY) 스펙으로 타입·ViewModel 매핑
- 캠페인 상세 `platformBudgets`를 `PlatformBudgetSummary` 스펙에 맞게 수정
  - Naver: TOTAL 우선, 없으면 DAILY 표시
  - 예산 수정용 `adCampaignId` / `naverBudgetTarget` 매핑 (없으면 수정 버튼 disabled)
- 예산 수정 불가 사유 안내 문구 제거
- 캠페인 목록에서 예산 소진 열 제거 → `[체크박스] [캠페인 명] [플랫폼]` 구성

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
예산 데이터가 아직 없어서 화면에서 안 보이거나 수정이 비활성화될 수 있습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 플랫폼별 예산을 전체 예산·일일 예산 게이지로 확인하고, 편집 가능한 예산을 선택할 수 있습니다.
  - 플랫폼별 예산 편집 모달이 새로운 예산 유형과 대상 정보를 지원합니다.
  - 대시보드 예산 정보가 예산 유형별 그룹으로 표시됩니다.

- **개선 사항**
  - 캠페인 목록에서 예산 소진 현황 열을 제거하고 플랫폼 표시를 정렬했습니다.
  - 네이버는 전체 예산을 우선 표시합니다.

- **버그 수정**
  - 전체 예산 입력이 필요한 경우 누락 시 오류가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->