### PR TITLE
[Bugfix/#383] 계정 전환 시 이전 계정 데이터가 남는 문제 수정

### DIFF
--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,3 +1,5 @@
+import { useQueryClient } from "@tanstack/react-query";
+
 import { useCoreMutation } from "@/hooks/customQuery";
 
 import {
@@ -11,15 +13,20 @@ import {
   verifySMS,
 } from "@/api/auth/auth";
 import useAuthStore from "@/store/useAuthStore";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export const useAuth = () => {
   const { login: loginAction } = useAuthStore();
+  const queryClient = useQueryClient();
 
   const useLogin = useCoreMutation(login, {
     userOnSuccess: (response, vars) => {
+      queryClient.clear();
+      useWorkspaceStore.getState().reset();
       loginAction(vars.email, response.data.accessToken);
     },
   });
+
   const useSignUp = useCoreMutation(signUp);
   const useSendCode = useCoreMutation(sendEmail);
   const useCheckCode = useCoreMutation(verifyEmail);

--- a/src/hooks/auth/useDeleteMyAccount.ts
+++ b/src/hooks/auth/useDeleteMyAccount.ts
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -8,9 +7,9 @@ import { useCoreMutation } from "@/hooks/customQuery";
 
 import { deleteMyAccount } from "@/api/auth/auth";
 import useAuthStore from "@/store/useAuthStore";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export function useDeleteMyAccount() {
-  const nav = useNavigate();
   const queryClient = useQueryClient();
   const logout = useAuthStore((s) => s.logout);
 
@@ -20,8 +19,9 @@ export function useDeleteMyAccount() {
         "회원 탈퇴가 완료되었습니다. 30일 후 계정이 완전히 삭제됩니다",
       );
       queryClient.clear();
+      useWorkspaceStore.getState().reset();
       logout();
-      nav("/", { replace: true });
+      window.location.replace("/");
     },
     userOnError: (error) => {
       const apiError = error as IApiErrorResponse;

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -8,9 +7,9 @@ import { useCoreMutation } from "@/hooks/customQuery";
 
 import { postLogout } from "@/api/auth/auth";
 import useAuthStore from "@/store/useAuthStore";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export function useLogout() {
-  const nav = useNavigate();
   const logout = useAuthStore((s) => s.logout);
   const queryClient = useQueryClient();
 
@@ -18,8 +17,9 @@ export function useLogout() {
     userOnSuccess: () => {
       toast.success("로그아웃이 완료되었습니다");
       queryClient.clear();
+      useWorkspaceStore.getState().reset();
       logout();
-      nav("/", { replace: true });
+      window.location.replace("/");
     },
     userOnError: (error) => {
       const apiError = error as IApiErrorResponse;

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -68,19 +68,22 @@ export default function MainLayout() {
   useEffect(() => {
     if (!workspaces?.length || !savedWorkspaceQuery.isFetched) return;
 
-    // orgId는 있는데 myRole만 null/불일치인 경우(새로고침 등) 역할 동기화
+    // 현재 유저 목록에 있는 orgId만 유지 (+ role 동기화)
+    // 목록에 없으면 return하지 않고 아래 saved/current 초기화로 계속
     if (selectedOrgId !== null) {
       const workspace = workspaces.find((w) => w.orgId === selectedOrgId);
-      if (workspace && myRole !== workspace.myRole) {
-        setMyRole(workspace.myRole);
+      if (workspace) {
+        if (myRole !== workspace.myRole) {
+          setMyRole(workspace.myRole);
+        }
+        return;
       }
-      return;
     }
 
     const savedId = savedData?.orgId;
     const isExist = workspaces.some((w) => w.orgId === savedId);
 
-    // 1. 현재 워크스페이스 조회 API 데이터 (저장된 워크스페이스가 있는 경우)
+    // 1. 저장된 워크스페이스가 현재 유저 목록에 있으면 선택
     if (savedId !== undefined && isExist) {
       const workspace = workspaces.find((w) => w.orgId === savedId);
       setSelectedOrgId(savedId);

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -44,6 +44,7 @@ export default function MainLayout() {
 
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
   const setMyRole = useWorkspaceStore((s) => s.setMyRole);
+  const resetWorkspace = useWorkspaceStore((s) => s.reset);
   const myRole = useWorkspaceStore((s) => s.myRole);
 
   const savedWorkspaceQuery = useCoreQuery(
@@ -66,7 +67,15 @@ export default function MainLayout() {
   );
 
   useEffect(() => {
-    if (!workspaces?.length || !savedWorkspaceQuery.isFetched) return;
+    // undefined: 로딩 중 / []: 워크스페이스 없음(유효한 결과)
+    if (!workspaces || !savedWorkspaceQuery.isFetched) return;
+
+    if (workspaces.length === 0) {
+      if (selectedOrgId !== null || myRole !== null) {
+        resetWorkspace();
+      }
+      return;
+    }
 
     // 현재 유저 목록에 있는 orgId만 유지 (+ role 동기화)
     // 목록에 없으면 return하지 않고 아래 saved/current 초기화로 계속
@@ -102,6 +111,7 @@ export default function MainLayout() {
     savedData,
     setSelectedOrgId,
     setMyRole,
+    resetWorkspace,
     selectedOrgId,
     myRole,
   ]);

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -8,7 +8,9 @@ import {
   getSafeReturnUrl,
 } from "@/utils/auth/returnUrl";
 
+import { queryClient } from "@/lib/queryClient";
 import useAuthStore from "@/store/useAuthStore";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export default function RedirectPage() {
   const navigate = useNavigate();
@@ -37,6 +39,8 @@ export default function RedirectPage() {
 
     if (accessToken) {
       deleteCookie("access_token");
+      queryClient.clear();
+      useWorkspaceStore.getState().reset();
       setAccessToken(accessToken);
 
       toast.success("소셜 로그인되었습니다.");

--- a/src/store/useWorkspaceStore.ts
+++ b/src/store/useWorkspaceStore.ts
@@ -7,6 +7,7 @@ interface IWorkspaceState {
   myRole: TMemberRole | null;
   setSelectedOrgId: (orgId: number) => void;
   setMyRole: (role: TMemberRole | null) => void;
+  reset: () => void;
 }
 
 const useWorkspaceStore = create<IWorkspaceState>((set) => ({
@@ -14,6 +15,7 @@ const useWorkspaceStore = create<IWorkspaceState>((set) => ({
   myRole: null,
   setSelectedOrgId: (orgId) => set({ selectedOrgId: orgId }),
   setMyRole: (role) => set({ myRole: role }),
+  reset: () => set({ selectedOrgId: null, myRole: null }),
 }));
 
 export default useWorkspaceStore;


### PR DESCRIPTION
## 🚨 관련 이슈
close #383 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
계정 전환 시 이전 계정의 워크스페이스·대시보드 데이터가 남는 문제를 수정했습니다.
로그아웃 시 React Query 캐시 초기화만으로는 Zustand `selectedOrgId` 잔존, MainLayout 재선택 누락, 뒤로가기 복원 이슈까지 막기 어려워, 아래를 함께 반영했습니다.

- `useWorkspaceStore`에 `reset()` 추가
- 로그인 성공 시 (`useAuth` / `RedirectPage`): `queryClient.clear()` + workspace `reset()`
- `MainLayout`: 현재 유저 workspaces에 없는 `selectedOrgId`는 saved/current 기준으로 재선택
- 로그아웃·회원탈퇴 성공 시: 캐시/workspace 초기화 후 `window.location.replace("/")` hard redirect

### 테스트
- [ ] A → (뒤로가기) → B 로그인 시 B 워크스페이스/데이터로 보이는지
- [ ] A 로그아웃 후 B 로그인 시 B 기준으로 보이는지
- [ ] 로그아웃 시 랜딩으로 새로고침되며 이동하는지

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 로그인, 로그아웃, 회원 탈퇴 및 인증 리디렉션 시 이전 데이터와 워크스페이스 선택 정보가 초기화됩니다.
  * 로그아웃 및 회원 탈퇴 후 페이지가 새로고침되어 초기 화면으로 이동합니다.
  * 유효하지 않은 워크스페이스 선택 시 저장된 워크스페이스 또는 기본 워크스페이스로 올바르게 복원됩니다.
  * 워크스페이스 상태를 한 번에 초기화할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->