### PR TITLE
[Refactor/#470] WorkspaceManageLayout Query/Mutation 컨벤션 정리

### DIFF
--- a/src/layout/workspace/WorkspaceManageLayout.tsx
+++ b/src/layout/workspace/WorkspaceManageLayout.tsx
@@ -1,30 +1,26 @@
 import { useEffect, useMemo } from "react";
 import { Outlet, useParams } from "react-router-dom";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { useCoreQuery } from "@/hooks/customQuery";
+import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
 import { getMyWorkspaces, saveSelectedWorkspace } from "@/api/workspace/org";
+import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 export default function WorkspaceManageLayout() {
   const { workspaceId } = useParams();
   const setSelectedOrgId = useWorkspaceStore((s) => s.setSelectedOrgId);
 
-  const queryClient = useQueryClient();
   const setMyRole = useWorkspaceStore((s) => s.setMyRole);
-  const { data: workspaces } = useCoreQuery(["my-workspaces"], getMyWorkspaces);
+  const { data: workspaces } = useCoreQuery(
+    QUERY_KEYS.workspace.list(),
+    getMyWorkspaces,
+  );
 
-  const { mutate: saveWorkspace } = useMutation({
-    mutationFn: (orgId: number) => saveSelectedWorkspace(orgId),
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["my-workspaces"] }),
-        queryClient.invalidateQueries({ queryKey: ["savedWorkspace"] }),
-      ]);
-    },
-    onError: () => {
+  const { mutate: saveWorkspace } = useCoreMutation(saveSelectedWorkspace, {
+    invalidateKeys: [QUERY_KEYS.workspace.list(), QUERY_KEYS.workspace.saved()],
+    userOnError: () => {
       toast.error("워크스페이스 변경에 실패했습니다. 다시 시도해 주세요");
     },
   });


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #470 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `WorkspaceManageLayout`의 워크스페이스 조회/저장을 팀 컨벤션에 맞게 정리했습니다.
- `useMutation` + `useCoreClient`를 `useCoreMutation`으로 교체
- 하드코딩된 `["my-workspaces"]`, `["savedWorkspace"]`를 `QUERY_KEYS.workspace.list()`, `QUERY_KEYS.workspace.saved()`로 교체
- 저장 성공 시 캐시 무효화는 `invalidateKeys`로 처리

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 워크스페이스 저장 후 관련 목록과 저장된 워크스페이스 정보가 최신 상태로 즉시 갱신됩니다.
  * 저장 성공 및 오류 알림 동작을 개선해 일관된 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->