### PR TITLE
[Bugfix/#474] 사이드바 워크스페이스 전환 시 URL·로컬 상태 동기화

### DIFF
--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
@@ -21,6 +21,7 @@ export function WorkspaceSwitcher({
   className?: string;
 }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const latestSaveOrgIdRef = useRef<number | null>(null);
@@ -69,6 +70,10 @@ export function WorkspaceSwitcher({
         const workspace = workspaceList.find((w) => w.orgId === orgId);
         setSelectedOrgId(orgId);
         if (workspace) setMyRole(workspace.myRole);
+
+        if (/^\/ads\/\d+\/\d+/.test(location.pathname)) {
+          navigate("/ads", { replace: true });
+        }
       },
       userOnError: (error, orgId) => {
         if (latestSaveOrgIdRef.current === orgId) {

--- a/src/components/sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/sidebar/WorkspaceSwitcher.tsx
@@ -71,8 +71,20 @@ export function WorkspaceSwitcher({
         setSelectedOrgId(orgId);
         if (workspace) setMyRole(workspace.myRole);
 
-        if (/^\/ads\/\d+\/\d+/.test(location.pathname)) {
+        const path = location.pathname;
+
+        // 캠페인 상세 → 목록
+        if (/^\/ads\/\d+\/\d+/.test(path)) {
           navigate("/ads", { replace: true });
+          return;
+        }
+
+        // 워크스페이스 설정/멤버/결제 → 같은 하위 경로로 org만 교체
+        const wsMatch = path.match(
+          /^\/workspace\/\d+\/(settings|members|billing)$/,
+        );
+        if (wsMatch) {
+          navigate(`/workspace/${orgId}/${wsMatch[1]}`, { replace: true });
         }
       },
       userOnError: (error, orgId) => {

--- a/src/hooks/ads/useCampaignDetail.ts
+++ b/src/hooks/ads/useCampaignDetail.ts
@@ -5,17 +5,15 @@ import { useCoreQuery } from "@/hooks/customQuery";
 import { getCampaignDetail } from "@/api/ads/ads";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 
-export const useCampaignDetail = () => {
+export const useCampaignDetail = (options?: { enabled?: boolean }) => {
   const { orgId, projectId } = useParams<{
     orgId: string;
     projectId: string;
   }>();
 
-  // URL 파라미터를 숫자로 변환
   const parsedOrgId = Number(orgId);
   const parsedProjectId = Number(projectId);
 
-  // 유효한 ID일 때만 요청
   const isValid =
     Number.isFinite(parsedOrgId) &&
     parsedOrgId > 0 &&
@@ -25,6 +23,6 @@ export const useCampaignDetail = () => {
   return useCoreQuery(
     QUERY_KEYS.campaign.detail(parsedOrgId, parsedProjectId),
     () => getCampaignDetail(parsedOrgId, parsedProjectId),
-    { enabled: isValid },
+    { enabled: isValid && (options?.enabled ?? true) },
   );
 };

--- a/src/hooks/ads/useCampaignGroup.ts
+++ b/src/hooks/ads/useCampaignGroup.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
@@ -31,6 +31,14 @@ export const useCampaignGroup = () => {
   const [metaSelected, setMetaSelected] = useState<IPlatformCampaign | null>(
     null,
   );
+
+  useEffect(() => {
+    setName("");
+    setDescription("");
+    setGoogleSelected(null);
+    setNaverSelected(null);
+    setMetaSelected(null);
+  }, [orgId]);
 
   const { data: googleData = [], isLoading: isGoogleLoading } = useCoreQuery(
     QUERY_KEYS.campaign.platformList(orgId, "GOOGLE"),

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useControlModal } from "@/hooks/ads/useControlModal";
@@ -27,6 +27,10 @@ export default function AdsListPage() {
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<number>>(
     () => new Set(),
   );
+
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [orgId]);
 
   const [pauseScope, setPauseScope] = useState<"selection" | "all">("all");
   const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -62,18 +62,25 @@ export default function CampaignDetail() {
   }>();
   const orgIdNum = orgId ? Number(orgId) : null;
   const projectIdNum = projectId ? Number(projectId) : null;
+  const isOrgMatched =
+    selectedOrgId != null && orgIdNum != null && orgIdNum === selectedOrgId;
+
   useEffect(() => {
     if (selectedOrgId == null || orgIdNum == null) return;
-    if (orgIdNum !== selectedOrgId) {
+    if (!isOrgMatched) {
       navigate("/ads", { replace: true });
     }
-  }, [selectedOrgId, orgIdNum, navigate]);
-  const { data, isLoading } = useCampaignDetail();
+  }, [selectedOrgId, orgIdNum, isOrgMatched, navigate]);
 
-  const { ads, isAdLoading } = useAdList(orgIdNum, projectIdNum);
+  const { data, isLoading } = useCampaignDetail({ enabled: isOrgMatched });
+
+  const { ads, isAdLoading } = useAdList(
+    isOrgMatched ? orgIdNum : null,
+    isOrgMatched ? projectIdNum : null,
+  );
   const { mutateAsync: mutateAdStatus } = useUpdateAdStatus(
-    orgIdNum,
-    projectIdNum,
+    isOrgMatched ? orgIdNum : null,
+    isOrgMatched ? projectIdNum : null,
   );
 
   const { setCampaignDetailHeaderTitle } =
@@ -231,6 +238,10 @@ export default function CampaignDetail() {
 
   useEffect(() => {
     if (!setCampaignDetailHeaderTitle) return;
+    if (!isOrgMatched) {
+      setCampaignDetailHeaderTitle(null);
+      return undefined;
+    }
     if (data?.name) {
       setCampaignDetailHeaderTitle(data.name);
       return () => {
@@ -239,7 +250,12 @@ export default function CampaignDetail() {
     }
     setCampaignDetailHeaderTitle(null);
     return undefined;
-  }, [data?.name, setCampaignDetailHeaderTitle]);
+  }, [data?.name, isOrgMatched, setCampaignDetailHeaderTitle]);
+
+  // 선택 워크스페이스와 URL org 불일치/미확정 시 상세·캐시 노출 방지
+  if (!isOrgMatched) {
+    return <CampaignDetailPageSkeleton />;
+  }
 
   if (isLoading) {
     return <CampaignDetailPageSkeleton />;

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useOutletContext, useParams } from "react-router-dom";
+import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 
 import type { IPlatformBudgetSummary, TPlatform } from "@/types/ads/campaign";
 
@@ -32,6 +32,7 @@ import ModalContent from "@/components/common/modal/ModalContent";
 
 import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 import type { TMainLayoutOutletContext } from "@/layout/main/MainLayout";
+import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 const PLATFORM_WORDMARK: Record<TPlatform, string> = {
   naver: "NAVER",
@@ -53,13 +54,20 @@ function providerWordmark(provider: string): string {
 }
 
 export default function CampaignDetail() {
+  const navigate = useNavigate();
+  const selectedOrgId = useWorkspaceStore((s) => s.selectedOrgId);
   const { orgId, projectId } = useParams<{
     orgId: string;
     projectId: string;
   }>();
   const orgIdNum = orgId ? Number(orgId) : null;
   const projectIdNum = projectId ? Number(projectId) : null;
-
+  useEffect(() => {
+    if (selectedOrgId == null || orgIdNum == null) return;
+    if (orgIdNum !== selectedOrgId) {
+      navigate("/ads", { replace: true });
+    }
+  }, [selectedOrgId, orgIdNum, navigate]);
   const { data, isLoading } = useCampaignDetail();
 
   const { ads, isAdLoading } = useAdList(orgIdNum, projectIdNum);


### PR DESCRIPTION
## 🚨 관련 이슈
close #474 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

사이드바 워크스페이스 스위처는 Zustand `selectedOrgId`만 갱신하고, 일부 화면은 URL의 org/workspaceId로 API를 호출해서 전환 후에도 이전 워크스페이스 데이터가 남는 문제를 수정했습니다.

### 1) URL 동기화 (`WorkspaceSwitcher`)
전환 성공 후 현재 경로에 따라:
- 캠페인 상세 `/ads/:orgId/:projectId` → `/ads`로 `replace` 이동
- 워크스페이스 관리 `/workspace/:id/(settings|members|billing)` → `/workspace/{새orgId}/{동일 subpath}`로 `replace` 이동

### 2) 캠페인 상세 안전망 (`CampaignDetail`)
URL `orgId` ≠ `selectedOrgId`이면 `/ads`로 리다이렉트 (뒤로가기·직접 진입 대응)

### 3) 로컬 state 초기화
쿼리는 orgId로 갱신되지만 `useState`는 남아 이전 선택이 남을 수 있어 함께 정리:
- `AdsListPage`: org 변경 시 `selectedIds` 초기화
- `useCampaignGroup`: org 변경 시 이름/설명/플랫폼 선택 초기화

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
워크스페이스 관리 전환도 함께 수정했습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 워크스페이스 변경 후 현재 페이지 맥락에 맞게 새 워크스페이스로 이동합니다.
  - 캠페인 상세 화면에서 선택한 워크스페이스와 URL의 워크스페이스가 다를 경우 광고 목록으로 안전하게 이동합니다.
  - 워크스페이스 전환 시 캠페인 작성 정보와 플랫폼 선택 상태가 초기화됩니다.
  - 광고 목록에서도 이전 워크스페이스의 캠페인 선택 정보가 남지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->