### PR TITLE
[Bugfix/#476] 로그아웃 시 hasSeenOnboarding 미삭제로 인한 신규 계정 온보딩 스킵 버그 수정

### DIFF
--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -29,6 +29,7 @@ const useAuthStore = create<IAuthState>((set) => ({
   },
   logout: () => {
     localStorage.removeItem("hasSession");
+    localStorage.removeItem("hasSeenOnboarding");
     set({
       isLoggedIn: false,
       isTokenInitialized: false,


### PR DESCRIPTION
## 🚨 관련 이슈

#476 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- useAuthStore의 logout()에 localStorage.removeItem("hasSeenOnboarding") 추가

## 원인

- logout() 함수가 hasSession만 삭제하고 hasSeenOnboarding은 삭제하지 않아, 같은 브라우저에서 새 계정으로 회원가입 시 이전 계정의 온보딩 완료 기록이 남아있는 상태가 됨.
- 이로 인해 신규 유저의 첫 로그인 시 isFirstLogin = false로 판단되어 온보딩 플로우(/workspace)를 거치지 않고 바로 /dashboard로 이동.
- 이메일 로그인 및 소셜 로그인 모두 동일하게 재현됨.

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항
N/A


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃 시 온보딩 완료 상태도 함께 초기화되도록 개선했습니다.
  * 이후 다시 로그인하면 온보딩 상태가 올바르게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->