### PR TITLE
[Bugfix/#478] 워크스페이스 생성 모달 왼쪽 치우쳐짐 문제 해결

### DIFF
--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -224,7 +224,7 @@ export default function WorkspacePage() {
       </ErrorBoundary>
 
       <Modal isOpen={createOpen} onClose={onCloseCreate} size="md" padding="lg">
-        <div className="flex flex-col items-start pr-10 px-2 tablet:px-0 tablet:pr-0">
+        <div className="flex flex-col items-start px-2 tablet:px-0 tablet:pr-0">
           <h2 className="mb-2 font-heading3 text-text-title">
             워크스페이스 생성
           </h2>


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #478 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 기존 UX 개선 PR로 Modal Components의 좌우 대칭이 되도록 개선하였지만, 워크스페이스 생성 모달만 왼쪽 치우쳐짐 문제가 있음.
- 따라서 확인결과 이 모달만 pr-10 스타일이 적용되어서 문제 현상이 발생했었다를 발견하고 해당 스타일 제거 작업 진행

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 워크스페이스 생성 모달의 불필요한 우측 여백을 제거했습니다.
  - 기존 수평 여백과 태블릿 화면 대응 여백은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->