### PR TITLE
[Bugfix/#481] 워크스페이스 삭제 모달 에러 수정

### DIFF
--- a/src/components/workspace/DeleteWorkspaceModal.tsx
+++ b/src/components/workspace/DeleteWorkspaceModal.tsx
@@ -63,7 +63,7 @@ export default function DeleteWorkspaceModal({
           아래 워크스페이스 이름을 그대로 입력해 주세요
         </p>
         <div className="mb-8 space-y-3">
-          <div className="rounded-xl border border-surface-400/50 bg-surface-100 px-3 py-2.5">
+          <div className="rounded-2xl border border-surface-400/50 bg-surface-100 px-4.5 py-2.5">
             <p className="font-caption text-text-muted">확인용 이름</p>
             <p className="mt-0.5 break-all font-label text-text-title">
               {workspaceName}

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -51,7 +51,6 @@ export default function WorkspaceSetting() {
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteNameSnapshot, setDeleteNameSnapshot] = useState("");
-  const [deleteConfirmInput, setDeleteConfirmInput] = useState("");
   const [transferOpen, setTransferOpen] = useState(false);
 
   const [serverLogoUrl, setServerLogoUrl] = useState<string | null>(null);
@@ -202,10 +201,6 @@ export default function WorkspaceSetting() {
 
   const onDelete = () => {
     if (orgId === null) return;
-    if (deleteConfirmInput.trim() !== deleteNameSnapshot) {
-      toast.error("워크스페이스 이름이 일치하지 않습니다");
-      return;
-    }
     deleteMutation.mutate(orgId);
   };
 
@@ -216,7 +211,6 @@ export default function WorkspaceSetting() {
       return;
     }
     setDeleteNameSnapshot(snapshot);
-    setDeleteConfirmInput("");
     setDeleteOpen(true);
   };
 

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -374,7 +374,7 @@ export default function WorkspaceSetting() {
                     size="small"
                     onClick={openDeleteModal}
                     disabled={saving || deleting}
-                    className="w-auto tablet:w-full"
+                    className="w-auto rounded-2xl tablet:w-full"
                   >
                     워크스페이스 삭제
                   </Button>
@@ -391,7 +391,7 @@ export default function WorkspaceSetting() {
                       !hasChanges
                     }
                     aria-label="변경사항 저장하기"
-                    className="w-auto tablet:w-full"
+                    className="w-auto rounded-2xl tablet:w-full"
                   >
                     {saving ? "저장 중.." : "저장"}
                   </Button>


### PR DESCRIPTION


## 🚨 관련 이슈

Closed #481 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 워크스페이스 삭제 모달에서 삭제 확인 입력이 오류가 나는 문제가 있어서 확인해보니, DeleteModal로 컴포넌트 분리하는 과정에서, Delete Modal에서 삭제 확인 검증을 이미 1차 진행후, text가 일치할 시에만 영구 삭제 버튼이 열리도록 구현했습니다.
하지만,기존에 부모 컴포넌트에 존재하던 검증 로직에 새로적은 text가 전달된적이 없기 때문에 부모 컴포넌트는 모달을 열때 `""`로만 맞춰둔 상태로 빈문자열과 비교를 해서 항상 불일치가 뜨는 문제가 발생했었습니다.
따라서, 부모 컴포넌트에 있는 2차 비교 검증 로직을 제거하여서, DeleteModal 컴포넌트내 비교 로직만을 이용하도록 수정하였습니다.


- 삭제 모달 확인용 이름 박스 rounded와 pading을 Input과 맞춤
- 삭제/저장 버튼 `rounded-2xl` 추가 

- 작업 내용

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- 공통 `Button`의 `size="small"`의 radius는 바꾸지 않았습니다. 추후에, 다른 버튼들도 비교시 필요하면 교체하겠습니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
