### PR TITLE
[Bugfix/#484] 신규 회원 온보딩 투어 조기 종료 문제 수정

### DIFF
--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -13,7 +13,8 @@ interface IOnboardingTourProps {
 export default function OnboardingTour({
   autoStart = false,
 }: IOnboardingTourProps) {
-  const { run, startTour, handleEvent, steps, myRole } = useOnboardingTour();
+  const { run, startTour, handleEvent, steps, stepIndex, myRole } =
+    useOnboardingTour();
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const tourStarted = useRef(false);
@@ -36,6 +37,7 @@ export default function OnboardingTour({
     <Joyride
       steps={steps}
       run={run}
+      stepIndex={stepIndex}
       onEvent={handleEvent}
       continuous
       scrollToFirstStep

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -44,7 +44,7 @@ export default function OnboardingTour({
       tooltipComponent={OnboardingTooltip}
       styles={{
         spotlight: {
-          style: { transition: "d 280ms cubic-bezier(0.4, 0, 0.2, 1)" },
+          style: { transition: "all 280ms cubic-bezier(0.4, 0, 0.2, 1)" },
         },
         overlay: { transition: "opacity 200ms ease-out" },
       }}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -38,7 +38,10 @@ function filterNavByRole(
   myRole: TMemberRole | null,
 ): INavItem[] {
   return items
-    .filter((item) => !item.requiredRole || item.requiredRole === myRole)
+    .filter(
+      (item) =>
+        myRole == null || !item.requiredRole || item.requiredRole === myRole,
+    )
     .map((item) => ({
       ...item,
       children: item.children

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { EventData, Step } from "react-joyride";
-import { EVENTS, STATUS } from "react-joyride";
+import { ACTIONS, EVENTS, STATUS } from "react-joyride";
 
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
@@ -115,21 +115,11 @@ const MEMBER_STEPS: Step[] = [
 export function useOnboardingTour() {
   const myRole = useWorkspaceStore((s) => s.myRole);
   const [run, setRun] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
 
   const startTour = useCallback(() => {
+    setStepIndex(0);
     setRun(true);
-  }, []);
-
-  const handleEvent = useCallback((data: EventData) => {
-    const { status, type } = data;
-
-    const isFinished = status === STATUS.FINISHED || status === STATUS.SKIPPED;
-    const isError = type === EVENTS.TARGET_NOT_FOUND;
-
-    if (isFinished || isError) {
-      setRun(false);
-      localStorage.setItem(ONBOARDING_KEY, "true");
-    }
   }, []);
 
   const steps =
@@ -139,5 +129,17 @@ export function useOnboardingTour() {
         ? ADMIN_STEPS
         : ADMIN_STEPS;
 
-  return { run, startTour, handleEvent, steps, myRole };
+  const handleEvent = useCallback((data: EventData) => {
+    const { action, index, status, type } = data;
+
+    if (type === EVENTS.STEP_AFTER || type === EVENTS.TARGET_NOT_FOUND) {
+      setStepIndex(index + (action === ACTIONS.PREV ? -1 : 1));
+    } else if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+      setRun(false);
+      setStepIndex(0);
+      localStorage.setItem(ONBOARDING_KEY, "true");
+    }
+  }, []);
+
+  return { run, startTour, handleEvent, steps, stepIndex, myRole };
 }

--- a/src/hooks/common/useOnboardingTour.ts
+++ b/src/hooks/common/useOnboardingTour.ts
@@ -4,7 +4,7 @@ import { ACTIONS, EVENTS, STATUS } from "react-joyride";
 
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
-const ONBOARDING_KEY = "hasSeenOnboarding";
+export const ONBOARDING_KEY = "hasSeenOnboarding";
 
 const ADMIN_STEPS: Step[] = [
   {
@@ -122,12 +122,7 @@ export function useOnboardingTour() {
     setRun(true);
   }, []);
 
-  const steps =
-    myRole === "MEMBER"
-      ? MEMBER_STEPS
-      : myRole === "ADMIN"
-        ? ADMIN_STEPS
-        : ADMIN_STEPS;
+  const steps = myRole === "MEMBER" ? MEMBER_STEPS : ADMIN_STEPS;
 
   const handleEvent = useCallback((data: EventData) => {
     const { action, index, status, type } = data;

--- a/src/layout/main/MainLayout.tsx
+++ b/src/layout/main/MainLayout.tsx
@@ -17,6 +17,7 @@ import {
   navItemMatchesPath,
 } from "@/utils/navigation/workspaceNavPaths";
 
+import { ONBOARDING_KEY } from "@/hooks/common/useOnboardingTour";
 import { useCoreQuery } from "@/hooks/customQuery";
 
 import OnboardingTour from "@/components/common/OnboardingTour";
@@ -201,9 +202,7 @@ export default function MainLayout() {
     <div className="flex h-dvh w-full overflow-hidden bg-surface-200">
       {(myRole !== null ||
         (workspaces !== undefined && workspaces.length === 0)) && (
-        <OnboardingTour
-          autoStart={!localStorage.getItem("hasSeenOnboarding")}
-        />
+        <OnboardingTour autoStart={!localStorage.getItem(ONBOARDING_KEY)} />
       )}
       <div
         className={twMerge(

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -12,6 +12,7 @@ import { loginSchema } from "@/utils/auth/validation";
 
 import { useAuth } from "@/hooks/auth/useAuth";
 import { useSocialLogin } from "@/hooks/auth/useSocialLogin";
+import { ONBOARDING_KEY } from "@/hooks/common/useOnboardingTour";
 
 import AuthFormShell from "@/components/auth/common/AuthFormShell";
 import CommonAuthInput from "@/components/auth/common/CommonAuthInput";
@@ -43,7 +44,7 @@ export default function Login() {
   const onSubmit: SubmitHandler<TLoginFormValues> = (data) => {
     useLogin.mutate(data, {
       onSuccess: () => {
-        const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
+        const isFirstLogin = !localStorage.getItem(ONBOARDING_KEY);
         if (isFirstLogin) {
           navigate("/workspace", { replace: true });
         } else {

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -8,6 +8,8 @@ import {
   getSafeReturnUrl,
 } from "@/utils/auth/returnUrl";
 
+import { ONBOARDING_KEY } from "@/hooks/common/useOnboardingTour";
+
 import { queryClient } from "@/lib/queryClient";
 import useAuthStore from "@/store/useAuthStore";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
@@ -44,7 +46,7 @@ export default function RedirectPage() {
       setAccessToken(accessToken);
 
       toast.success("소셜 로그인되었습니다.");
-      const isFirstLogin = !localStorage.getItem("hasSeenOnboarding");
+      const isFirstLogin = !localStorage.getItem(ONBOARDING_KEY);
       if (isFirstLogin) {
         navigate("/workspace", { replace: true });
       } else {


### PR DESCRIPTION
<!--
📌 제목: [Type] 작업 요약

예시:
- [Feature] 반응형 수정
- [Bugfix] 에러 잡기
- [Deploy] 배포
- [Refactor] 사용성 높이기

사용 가능한 Type:
Feature | Bugfix | Refactor | Deploy | Design | Docs | Setting | Test |
-->

## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- Sidebar.tsx 
    - filterNavByRole에서 myRole === null(워크스페이스 미소속 신규 유저)일 때 requiredRole 필터를 적용하지 않도록 수정 → [data-tour='tour-integrations'] 요소가 DOM에 정상 렌더링됨
- useOnboardingTour.ts 
   - 비제어 방식에서 제어(controlled) 방식으로 전환, TARGET_NOT_FOUND 이벤트 발생 시 투어를 종료하는 대신 다음 스텝으로 스킵하도록 수정
- OnboardingTour.tsx 
   - stepIndex prop 추가

## 버그 발생 흐름
1. 신규 회원 가입 직후 → 워크스페이스 없음 → myRole: null
2. filterNavByRole이 requiredRole: "ADMIN"인 integrations 항목을 숨김
3. 온보딩 6번 스텝([data-tour='tour-integrations']) 타겟이 DOM에 없음
4. react-joyride가 TARGET_NOT_FOUND 이벤트 발생
5. 기존 handleEvent가 이를 에러로 처리하여 투어 강제 종료 → 6·7번 스텝 미노출

## 수정 방향
- myRole === null은 "워크스페이스에 소속되지 않은 상태"이므로 역할 기반 필터를 적용하지 않아 신규 유저도 전체 사이드바 항목을 볼 수 있도록 변경. 
- 추가로 투어를 제어 방식으로 전환하여 타겟 미존재 시에도 투어가 중단되지 않는 방어 처리 추가.

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.
