### PR TITLE
[Bugfix/#486] 워크스페이스 생성 모달 정렬 정리 및 설정 로고 UX 개선

### DIFF
--- a/src/components/workspace/DeleteWorkspaceModal.tsx
+++ b/src/components/workspace/DeleteWorkspaceModal.tsx
@@ -76,7 +76,7 @@ export default function DeleteWorkspaceModal({
             placeholder="워크스페이스 이름"
             autoComplete="off"
             disabled={isLoading}
-            aria-label="우커스페이스 이름 확인 입력"
+            aria-label="워크스페이스 이름 확인 입력"
             containerClassName="mt-0"
             inputClassName="font-body2"
           />

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -224,7 +224,7 @@ export default function WorkspacePage() {
       </ErrorBoundary>
 
       <Modal isOpen={createOpen} onClose={onCloseCreate} size="md" padding="lg">
-        <div className="flex flex-col items-start px-2 tablet:px-0">
+        <div className="flex flex-col items-start px-2">
           <h2 className="mb-2 font-heading3 text-text-title">
             워크스페이스 생성
           </h2>

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -224,7 +224,7 @@ export default function WorkspacePage() {
       </ErrorBoundary>
 
       <Modal isOpen={createOpen} onClose={onCloseCreate} size="md" padding="lg">
-        <div className="flex flex-col items-start px-2 tablet:px-0 tablet:pr-0">
+        <div className="flex flex-col items-start px-2 tablet:px-0">
           <h2 className="mb-2 font-heading3 text-text-title">
             워크스페이스 생성
           </h2>

--- a/src/pages/workspace/Workspace.tsx
+++ b/src/pages/workspace/Workspace.tsx
@@ -224,7 +224,7 @@ export default function WorkspacePage() {
       </ErrorBoundary>
 
       <Modal isOpen={createOpen} onClose={onCloseCreate} size="md" padding="lg">
-        <div className="flex flex-col items-start px-2">
+        <div className="flex flex-col items-start px-2 tablet:px-0">
           <h2 className="mb-2 font-heading3 text-text-title">
             워크스페이스 생성
           </h2>

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
+import { twMerge } from "tailwind-merge";
 
 import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
 
@@ -23,7 +24,6 @@ import {
   getWorkspace,
   updateWorkspace,
 } from "@/api/workspace/org";
-import BuildingIcon from "@/assets/icon/common/building.svg?react";
 import { getImageUrl } from "@/lib/getImageUrl";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 
@@ -257,6 +257,9 @@ export default function WorkspaceSetting() {
       ? getImageUrl(serverLogoUrl)
       : null;
 
+  const showLogoPlaceholder = !logoPreview && !resolvedLogoUrl;
+  const logoInitial = (name.trim()[0] ?? "?").toUpperCase();
+
   return (
     <section className="w-full flex flex-col gap-8">
       {loading && <WorkspaceSettingLoading />}
@@ -299,7 +302,13 @@ export default function WorkspaceSetting() {
                     onClick={openFilePicker}
                     disabled={!isAdmin || saving || deleting}
                     aria-label="로고 이미지 업로드 또는 변경"
-                    className="flex h-52 w-52 cursor-pointer items-center justify-center overflow-hidden rounded-lg border border-surface-400 bg-surface-200 outline-none transition-colors hover:bg-surface-300/70 focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:cursor-not-allowed disabled:opacity-50 tablet:h-40 tablet:w-40"
+                    className={twMerge(
+                      "flex h-52 w-52 cursor-pointer items-center justify-center overflow-hidden rounded-lg border border-surface-400 bg-surface-200 outline-none transition-colors hover:bg-surface-300/70 focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:cursor-not-allowed disabled:opacity-50 tablet:h-40 tablet:w-40",
+
+                      showLogoPlaceholder
+                        ? "bg-primary-100 text-primary-500"
+                        : "bg-surface-200 hover:bg-surface-300/70",
+                    )}
                   >
                     {logoPreview ? (
                       <img
@@ -317,10 +326,7 @@ export default function WorkspaceSetting() {
                         }}
                       />
                     ) : (
-                      <BuildingIcon
-                        aria-hidden="true"
-                        className="h-11 w-11 text-text-placeholder"
-                      />
+                      <span className="font-heading1">{logoInitial}</span>
                     )}
                   </button>
                   <div className="flex gap-2 mt-4 justify-center">

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -317,7 +317,13 @@ export default function WorkspaceSetting() {
                           alt=""
                           className="h-full w-full rounded-lg object-cover transition-transform duration-500 group-hover:scale-110"
                           onError={() => {
-                            if (!logoPreview) setImageError(true);
+                            if (logoPreview) {
+                              setLogoPreview(null);
+                              setLogoFile(null);
+                              return;
+                            }
+
+                            setImageError(true);
                           }}
                         />
                         <div className="absolute inset-0 flex flex-col items-center justify-center bg-text-400/40 opacity-0 backdrop-blur-[2px] transition-all duration-300 group-hover:opacity-100">

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -259,7 +259,9 @@ export default function WorkspaceSetting() {
       : null;
 
   const showLogoPlaceholder = !logoPreview && !resolvedLogoUrl;
-  const logoInitial = (name.trim()[0] ?? "?").toUpperCase();
+  const logoInitial = (
+    (name.trim() || detail?.name?.trim() || "")[0] ?? "?"
+  ).toUpperCase();
 
   return (
     <section className="w-full flex flex-col gap-8">

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -326,12 +326,12 @@ export default function WorkspaceSetting() {
                             setImageError(true);
                           }}
                         />
-                        <div className="absolute inset-0 flex flex-col items-center justify-center bg-text-400/40 opacity-0 backdrop-blur-[2px] transition-all duration-300 group-hover:opacity-100">
+                        <span className="absolute inset-0 flex flex-col items-center justify-center bg-text-400/40 opacity-0 backdrop-blur-[2px] transition-all duration-300 group-hover:opacity-100">
                           <UpLoadImgIcon className="mb-1 h-6 w-6 text-surface-100" />
                           <span className="font-caption text-surface-100">
                             사진 변경
                           </span>
-                        </div>
+                        </span>
                       </>
                     ) : (
                       <span className="font-heading1">{logoInitial}</span>

--- a/src/pages/workspace/WorkspaceSetting.tsx
+++ b/src/pages/workspace/WorkspaceSetting.tsx
@@ -24,6 +24,7 @@ import {
   getWorkspace,
   updateWorkspace,
 } from "@/api/workspace/org";
+import UpLoadImgIcon from "@/assets/icon/common/uploadImg.svg?react";
 import { getImageUrl } from "@/lib/getImageUrl";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 
@@ -303,28 +304,29 @@ export default function WorkspaceSetting() {
                     disabled={!isAdmin || saving || deleting}
                     aria-label="로고 이미지 업로드 또는 변경"
                     className={twMerge(
-                      "flex h-52 w-52 cursor-pointer items-center justify-center overflow-hidden rounded-lg border border-surface-400 bg-surface-200 outline-none transition-colors hover:bg-surface-300/70 focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:cursor-not-allowed disabled:opacity-50 tablet:h-40 tablet:w-40",
-
+                      "group relative flex h-52 w-52 cursor-pointer items-center justify-center overflow-hidden rounded-lg border border-surface-400 outline-none transition-all duration-300 focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:cursor-not-allowed disabled:opacity-50 tablet:h-40 tablet:w-40",
                       showLogoPlaceholder
-                        ? "bg-primary-100 text-primary-500"
-                        : "bg-surface-200 hover:bg-surface-300/70",
+                        ? "bg-primary-100 text-primary-500 hover:border-primary-400 hover:bg-primary-100/50"
+                        : "border-transparent bg-surface-200",
                     )}
                   >
-                    {logoPreview ? (
-                      <img
-                        src={logoPreview}
-                        alt=""
-                        className="h-full w-full object-cover rounded-lg"
-                      />
-                    ) : resolvedLogoUrl ? (
-                      <img
-                        src={resolvedLogoUrl}
-                        alt=""
-                        className="h-full w-full object-cover rounded-lg"
-                        onError={() => {
-                          setImageError(true);
-                        }}
-                      />
+                    {logoPreview || resolvedLogoUrl ? (
+                      <>
+                        <img
+                          src={logoPreview ?? resolvedLogoUrl ?? ""}
+                          alt=""
+                          className="h-full w-full rounded-lg object-cover transition-transform duration-500 group-hover:scale-110"
+                          onError={() => {
+                            if (!logoPreview) setImageError(true);
+                          }}
+                        />
+                        <div className="absolute inset-0 flex flex-col items-center justify-center bg-text-400/40 opacity-0 backdrop-blur-[2px] transition-all duration-300 group-hover:opacity-100">
+                          <UpLoadImgIcon className="mb-1 h-6 w-6 text-surface-100" />
+                          <span className="font-caption text-surface-100">
+                            사진 변경
+                          </span>
+                        </div>
+                      </>
                     ) : (
                       <span className="font-heading1">{logoInitial}</span>
                     )}


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #486 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 생성 모달 잔여 `tablet:pr-0`제거
- 설정 페이지 로고가 없을대는 워크스페이스 이름 첫 글자 표시
- 로고 hover시 생성 모달과 같이 확대 + 사진 변경 오버레이

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- 워크스페이스 생성 모달 첫 오픈시에는 왼쪽 치우침이 있고, 새로고침하면 다시 기존 버그수정한대로 대칭이 이루어지는 오류가 발생하여 해당 이슈를 생성하여 진행중이었습니다.
그러나, 작업 중 첫 오픈 시에도 대칭으로 잘 보여지는 상황이 나와서, 이부분에 대해서는 사용하지 않는 스타일 정리로 간략히 진행하였습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 워크스페이스 로고가 없거나 로드에 실패하면 이름의 첫 글자를 표시합니다.
  * 로고에 마우스를 올리면 사진 변경 안내와 업로드 아이콘이 표시됩니다.

* **스타일 개선**
  * 워크스페이스 생성 모달의 태블릿 화면 여백을 조정했습니다.
  * 로고 이미지의 표시 및 확대 효과를 개선했습니다.

* **버그 수정**
  * 워크스페이스 삭제 확인 입력란의 접근성 안내 문구를 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->