### PR TITLE
[Bugfix/#488] 모바일 알림창 하단 떠있는 문제 해결

### DIFF
--- a/src/components/notification/NotificationPanel.tsx
+++ b/src/components/notification/NotificationPanel.tsx
@@ -24,7 +24,7 @@ export default function NotificationPanel({
           <BellIcon className="h-6 w-6 text-text-title" /> 알림
         </h2>
       }
-      className="max-w-90 h-auto min-h-[min(72vh,560px)] my-4 rounded-l-3xl"
+      className="max-w-90 h-auto min-h-[min(72vh,560px)] my-4 rounded-l-3xl tablet:my-0"
     >
       {children}
     </Drawer>


### PR DESCRIPTION

## 🚨 관련 이슈

Closed #488 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 알림 패널 `my-4`가 태블릿/모바일에서는 아래가 뜨는것같이 보이는 현상이 발생해서, `tablet:my-0`을 추가하여 태블릿/모바일에서는 하단에 버텀에 붙도록 수정

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

데스크톱일때는 `my-4` 그대로 유지합니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 워크스페이스 로고 설정 화면에서 로고가 없을 때 이름의 첫 글자를 표시합니다.
  * 로고 영역에 마우스를 올리면 업로드 안내가 표시됩니다.
  * 이미지 로드 실패 시에도 적절한 대체 미리보기를 제공합니다.

* **버그 수정**
  * 워크스페이스 이름 확인 입력란의 접근성 안내 문구를 수정했습니다.
  * 태블릿 화면에서 알림 패널과 워크스페이스 생성 화면의 여백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->