### PR TITLE
[Bugfix/#428] 트래픽 차트 PNG/SVG 저장 시 선이 보이도록 수정

### DIFF
--- a/src/components/dashboard/charts/trafficChart.config.ts
+++ b/src/components/dashboard/charts/trafficChart.config.ts
@@ -26,18 +26,11 @@ const FILENAME = `overview-traffic-chart-${TODAY}`;
 export const DOWNLOAD_ITEMS = [
   {
     label: "PNG 저장",
-    onClick: () =>
-      downloadChartPng(CHART_ID, FILENAME, {
-        mode: "preserve-fill",
-        containerId: CHART_CONTAINER_ID,
-      }),
+    onClick: () => downloadChartPng(CHART_ID, FILENAME),
   },
   {
     label: "SVG 저장",
-    onClick: () =>
-      downloadChartSvg(CHART_CONTAINER_ID, FILENAME, {
-        mode: "preserve-fill",
-      }),
+    onClick: () => downloadChartSvg(CHART_CONTAINER_ID, FILENAME),
   },
   {
     label: "CSV 다운로드",

--- a/src/components/dashboard/charts/trafficChart.config.ts
+++ b/src/components/dashboard/charts/trafficChart.config.ts
@@ -26,11 +26,18 @@ const FILENAME = `overview-traffic-chart-${TODAY}`;
 export const DOWNLOAD_ITEMS = [
   {
     label: "PNG 저장",
-    onClick: () => downloadChartPng(CHART_ID, FILENAME),
+    onClick: () =>
+      downloadChartPng(CHART_ID, FILENAME, {
+        mode: "preserve-fill",
+        containerId: CHART_CONTAINER_ID,
+      }),
   },
   {
     label: "SVG 저장",
-    onClick: () => downloadChartSvg(CHART_CONTAINER_ID, FILENAME),
+    onClick: () =>
+      downloadChartSvg(CHART_CONTAINER_ID, FILENAME, {
+        mode: "preserve-fill",
+      }),
   },
   {
     label: "CSV 다운로드",

--- a/src/components/dashboard/platform/AllPlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/AllPlatformTrafficChart.tsx
@@ -7,6 +7,10 @@ import {
   PLATFORM_MAP,
   PROVIDER_TYPES,
 } from "@/types/dashboard/provider";
+import {
+  ALL_PLATFORM_TRAFFIC_FILL,
+  ALL_PLATFORM_TRAFFIC_STROKE,
+} from "@/constants/dashboard/trafficChartExportStyles";
 
 import {
   formatCountChartAxis,
@@ -105,19 +109,9 @@ const AllPlatformTrafficChart = memo(function AllPlatformTrafficChart() {
       animations: { enabled: true, speed: 800 },
     },
     dataLabels: { enabled: false },
-    stroke: {
-      curve: "smooth",
-      width: 2,
-    },
-    fill: {
-      type: "gradient",
-      gradient: {
-        shadeIntensity: 1,
-        opacityFrom: 0.2,
-        opacityTo: 0.05,
-        stops: [20, 100],
-      },
-    },
+    stroke: ALL_PLATFORM_TRAFFIC_STROKE,
+    fill: ALL_PLATFORM_TRAFFIC_FILL,
+    colors: PROVIDER_TYPES.map((platform) => PLATFORM_CHART_COLORS[platform]),
     markers: { size: 0, hover: { size: 5 } },
     xaxis: {
       type: "numeric",

--- a/src/components/dashboard/platform/PlatformTrafficChart.tsx
+++ b/src/components/dashboard/platform/PlatformTrafficChart.tsx
@@ -17,6 +17,10 @@ import type {
 } from "@/types/dashboard/overview";
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
 import {
+  SINGLE_PLATFORM_TRAFFIC_FILL,
+  SINGLE_PLATFORM_TRAFFIC_STROKE,
+} from "@/constants/dashboard/trafficChartExportStyles";
+import {
   PLATFORM_TRAFFIC_CHART_HEIGHT_DUAL_MIN,
   PLATFORM_TRAFFIC_CHART_HEIGHT_SINGLE,
 } from "@/constants/dashboard/trafficChartHeights";
@@ -190,19 +194,10 @@ const PlatformTrafficChart = memo(function PlatformTrafficChart({
     },
     dataLabels: { enabled: false },
     stroke: {
-      curve: "smooth",
-      width: 2,
+      ...SINGLE_PLATFORM_TRAFFIC_STROKE,
       colors: [platformColor],
     },
-    fill: {
-      type: "gradient",
-      gradient: {
-        shadeIntensity: 1,
-        opacityFrom: 0.45,
-        opacityTo: 0.05,
-        stops: [20, 100],
-      },
-    },
+    fill: SINGLE_PLATFORM_TRAFFIC_FILL,
     colors: [platformColor],
     markers: { size: 0, hover: { size: 5 } },
     annotations: {

--- a/src/components/dashboard/platform/PlatformTrafficChartDownload.tsx
+++ b/src/components/dashboard/platform/PlatformTrafficChartDownload.tsx
@@ -46,7 +46,12 @@ export default function PlatformTrafficChartDownload({
           />
         </button>
       }
-      items={getTrafficChartDownloadItems(chartId, containerId, filename)}
+      items={getTrafficChartDownloadItems(
+        chartId,
+        containerId,
+        filename,
+        platform ? "preserve-fill" : "line-forward",
+      )}
     />
   );
 }

--- a/src/components/dashboard/platform/platformTrafficChartDownload.config.ts
+++ b/src/components/dashboard/platform/platformTrafficChartDownload.config.ts
@@ -21,20 +21,21 @@ export function getTrafficChartDownloadItems(
   chartId: string,
   containerId: string,
   filename: string,
+  /** 전체: 겹침 대비 선만 / 개별: fill+선 */
+  mode: "line-forward" | "preserve-fill" = "line-forward",
 ) {
   return [
     {
       label: "PNG 저장",
       onClick: () =>
         downloadChartPng(chartId, filename, {
-          mode: "line-forward",
+          mode,
           containerId,
         }),
     },
     {
       label: "SVG 저장",
-      onClick: () =>
-        downloadChartSvg(containerId, filename, { mode: "line-forward" }),
+      onClick: () => downloadChartSvg(containerId, filename, { mode }),
     },
     {
       label: "CSV 다운로드",

--- a/src/components/dashboard/platform/platformTrafficChartDownload.config.ts
+++ b/src/components/dashboard/platform/platformTrafficChartDownload.config.ts
@@ -25,11 +25,16 @@ export function getTrafficChartDownloadItems(
   return [
     {
       label: "PNG 저장",
-      onClick: () => downloadChartPng(chartId, filename),
+      onClick: () =>
+        downloadChartPng(chartId, filename, {
+          mode: "line-forward",
+          containerId,
+        }),
     },
     {
       label: "SVG 저장",
-      onClick: () => downloadChartSvg(containerId, filename),
+      onClick: () =>
+        downloadChartSvg(containerId, filename, { mode: "line-forward" }),
     },
     {
       label: "CSV 다운로드",

--- a/src/constants/dashboard/trafficChartExportStyles.ts
+++ b/src/constants/dashboard/trafficChartExportStyles.ts
@@ -1,0 +1,33 @@
+import type { ApexOptions } from "apexcharts";
+
+/** 화면 표시용 — 전체보기 (시리즈 겹침 대비 연한 fill) */
+export const ALL_PLATFORM_TRAFFIC_STROKE: ApexOptions["stroke"] = {
+  curve: "smooth",
+  width: 2,
+};
+
+export const ALL_PLATFORM_TRAFFIC_FILL: ApexOptions["fill"] = {
+  type: "gradient",
+  gradient: {
+    shadeIntensity: 1,
+    opacityFrom: 0.2,
+    opacityTo: 0.05,
+    stops: [20, 100],
+  },
+};
+
+/** 화면 표시용 — 개별 플랫폼 (단일 시리즈라 fill을 더 진하게) */
+export const SINGLE_PLATFORM_TRAFFIC_STROKE: ApexOptions["stroke"] = {
+  curve: "smooth",
+  width: 2,
+};
+
+export const SINGLE_PLATFORM_TRAFFIC_FILL: ApexOptions["fill"] = {
+  type: "gradient",
+  gradient: {
+    shadeIntensity: 1,
+    opacityFrom: 0.45,
+    opacityTo: 0.05,
+    stops: [20, 100],
+  },
+};

--- a/src/utils/dashboard/downloadChart.ts
+++ b/src/utils/dashboard/downloadChart.ts
@@ -5,7 +5,7 @@ type TExportMode = "line-forward" | "preserve-fill";
 type TDownloadOptions = {
   /**
    * line-forward: fill 제거 + stroke 강조 (플랫폼 전체보기)
-   * preserve-fill: 화면 fill 유지 + stroke hex 고정 (통합·플랫폼 개별)
+   * preserve-fill: 화면 fill 유지 + stroke hex 고정 (플랫폼 개별)
    */
   mode?: TExportMode;
   /** SVG 복제 저장 시 컨테이너 ID */

--- a/src/utils/dashboard/downloadChart.ts
+++ b/src/utils/dashboard/downloadChart.ts
@@ -4,8 +4,8 @@ type TExportMode = "line-forward" | "preserve-fill";
 
 type TDownloadOptions = {
   /**
-   * line-forward: fill 제거 + stroke 강조 (플랫폼 전체/개별)
-   * preserve-fill: 화면 fill 유지 + stroke를 hex로 고정 (통합)
+   * line-forward: fill 제거 + stroke 강조 (플랫폼 전체보기)
+   * preserve-fill: 화면 fill 유지 + stroke hex 고정 (통합·플랫폼 개별)
    */
   mode?: TExportMode;
   /** SVG 복제 저장 시 컨테이너 ID */

--- a/src/utils/dashboard/downloadChart.ts
+++ b/src/utils/dashboard/downloadChart.ts
@@ -1,30 +1,330 @@
 import ApexCharts from "apexcharts";
 
-export async function downloadChartPng(chartId: string, filename: string) {
+type TExportMode = "line-forward" | "preserve-fill";
+
+type TDownloadOptions = {
+  /**
+   * line-forward: fill 제거 + stroke 강조 (플랫폼 전체/개별)
+   * preserve-fill: 화면 fill 유지 + stroke를 hex로 고정 (통합)
+   */
+  mode?: TExportMode;
+  /** SVG 복제 저장 시 컨테이너 ID */
+  containerId?: string;
+};
+
+const SERIES_PATH_SELECTOR = [
+  ".apexcharts-series path",
+  ".apexcharts-area-series path",
+  ".apexcharts-line-series path",
+  ".apexcharts-area",
+  ".apexcharts-line",
+].join(", ");
+
+/** 닫힌 area fill path — 여기에 stroke를 주면 아래·옆까지 테두리가 생김 */
+function isAreaFillPath(el: Element): boolean {
+  const fill = el.getAttribute("fill");
+  const stroke = el.getAttribute("stroke");
+  // Apex area: fill 있음 + stroke none / 0
+  if (fill && fill !== "none") return true;
+  if (stroke === "none") return true;
+  return false;
+}
+
+/** 데이터 선만 그리는 path (fill none + stroke) */
+function isLineStrokePath(el: Element): boolean {
+  const fill = el.getAttribute("fill");
+  const stroke = el.getAttribute("stroke");
+  return (
+    (fill === "none" || fill == null) && Boolean(stroke && stroke !== "none")
+  );
+}
+
+/** tokens.css --color-info-blue */
+const INFO_BLUE_HEX = "#0084fe";
+
+/** 플랫폼 시리즈명 → 토큰 hex */
+const SERIES_HEX_BY_NAME: Record<string, string> = {
+  Google: "#f9ab00",
+  NAVER: "#03c75a",
+  Meta: "#1877f2",
+};
+
+function seriesHexFallback(el: Element): string | null {
+  const group = el.closest(".apexcharts-series");
+  const rawName = group?.getAttribute("seriesName") ?? "";
+  // 플랫폼 시리즈명만 매칭. realIndex로 추론하면 통합(클릭수, index 0)이 Google 노랑으로 잘못 잡힘
+  return SERIES_HEX_BY_NAME[rawName] ?? null;
+}
+
+function resolveCssColor(color: string): string {
+  if (!color || color === "none" || color === "transparent") return color;
+  if (!color.includes("var(")) return color;
+
+  const el = document.createElement("span");
+  el.style.color = color;
+  document.body.appendChild(el);
+  const resolved = getComputedStyle(el).color;
+  el.remove();
+
+  if (
+    !resolved ||
+    resolved === "rgba(0, 0, 0, 0)" ||
+    resolved === "transparent"
+  ) {
+    return color;
+  }
+  return resolved;
+}
+
+function getChartSvg(containerId: string): SVGSVGElement | null {
+  const root = document.getElementById(containerId);
+  if (!root) return null;
+  return (
+    (root.querySelector("svg.apexcharts-svg") as SVGSVGElement | null) ??
+    (root.querySelector("svg") as SVGSVGElement | null)
+  );
+}
+
+function resolveSeriesStroke(livePath: Element, clonePath: SVGElement): string {
+  const computed = getComputedStyle(livePath);
+  const fromComputed =
+    computed.stroke && computed.stroke !== "none" ? computed.stroke : null;
+  const fromAttr = clonePath.getAttribute("stroke");
+
+  // 화면 계산색 우선 → 플랫폼 시리즈명 hex → 통합 info-blue
+  return (
+    (fromComputed && !fromComputed.includes("var(") ? fromComputed : null) ??
+    (fromAttr && fromAttr !== "none"
+      ? fromAttr.includes("var(")
+        ? resolveCssColor(fromAttr)
+        : fromAttr
+      : null) ??
+    seriesHexFallback(livePath) ??
+    INFO_BLUE_HEX
+  );
+}
+
+/**
+ * Apex dataURI는 stroke var(--*)를 해석하지 않아 선이 빠진다.
+ * 화면 SVG를 복제해 실제 색을 심은 뒤 저장한다.
+ */
+function cloneSvgForExport(
+  liveSvg: SVGSVGElement,
+  mode: TExportMode,
+): SVGSVGElement {
+  const clone = liveSvg.cloneNode(true) as SVGSVGElement;
+  const liveNodes = liveSvg.querySelectorAll("*");
+  const cloneNodes = clone.querySelectorAll("*");
+
+  liveNodes.forEach((liveNode, index) => {
+    const cloneNode = cloneNodes[index];
+    if (
+      !(liveNode instanceof SVGElement) ||
+      !(cloneNode instanceof SVGElement)
+    ) {
+      return;
+    }
+
+    const computed = getComputedStyle(liveNode);
+    const attrFill = liveNode.getAttribute("fill");
+    const attrStroke = liveNode.getAttribute("stroke");
+
+    if (attrFill && attrFill !== "none" && !attrFill.startsWith("url(")) {
+      const fill = computed.fill;
+      if (fill && fill !== "none") {
+        cloneNode.setAttribute("fill", fill);
+      }
+    } else if (attrFill?.includes("var(")) {
+      cloneNode.setAttribute("fill", resolveCssColor(attrFill));
+    }
+
+    if (attrStroke && attrStroke !== "none") {
+      const stroke = computed.stroke;
+      if (stroke && stroke !== "none") {
+        cloneNode.setAttribute("stroke", stroke);
+      } else if (attrStroke.includes("var(")) {
+        cloneNode.setAttribute("stroke", resolveCssColor(attrStroke));
+      }
+    }
+
+    if (liveNode.tagName.toLowerCase() === "stop") {
+      const stopColor = computed.stopColor;
+      if (stopColor && stopColor !== "none") {
+        cloneNode.setAttribute("stop-color", stopColor);
+      }
+    }
+  });
+
+  const livePaths = liveSvg.querySelectorAll(SERIES_PATH_SELECTOR);
+  const clonePaths = clone.querySelectorAll(SERIES_PATH_SELECTOR);
+
+  livePaths.forEach((livePath, index) => {
+    const clonePath = clonePaths[index] as SVGElement | undefined;
+    if (!clonePath) return;
+
+    // Apex area는 fill path(닫힌 면) + line path(위쪽 선)를 따로 그림
+    const linePath = isLineStrokePath(livePath);
+    const areaPath = isAreaFillPath(livePath);
+
+    if (mode === "line-forward") {
+      clonePath.setAttribute("fill", "none");
+      clonePath.setAttribute("fill-opacity", "0");
+      if (!linePath) {
+        // 닫힌 area fill path에는 선을 주지 않음
+        clonePath.setAttribute("stroke", "none");
+        clonePath.setAttribute("stroke-opacity", "0");
+        return;
+      }
+    } else if (areaPath && !linePath) {
+      // preserve-fill: 면만 유지, 테두리 선 제거 (화면과 동일)
+      clonePath.setAttribute("stroke", "none");
+      clonePath.setAttribute("stroke-width", "0");
+      clonePath.setAttribute("stroke-opacity", "0");
+      return;
+    }
+
+    if (!linePath && !areaPath) return;
+
+    const stroke = resolveSeriesStroke(livePath, clonePath);
+    clonePath.setAttribute("stroke", stroke);
+    clonePath.setAttribute(
+      "stroke-width",
+      mode === "line-forward" ? "2" : "1.5",
+    );
+    clonePath.setAttribute("stroke-opacity", "1");
+    clonePath.setAttribute("stroke-linecap", "round");
+    clonePath.setAttribute("stroke-linejoin", "round");
+  });
+
+  const rect = liveSvg.getBoundingClientRect();
+  const width = Math.max(Math.round(rect.width), 1);
+  const height = Math.max(Math.round(rect.height), 1);
+  clone.setAttribute("width", String(width));
+  clone.setAttribute("height", String(height));
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  if (!clone.getAttribute("viewBox")) {
+    clone.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  }
+
+  const bg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  bg.setAttribute("x", "0");
+  bg.setAttribute("y", "0");
+  bg.setAttribute("width", "100%");
+  bg.setAttribute("height", "100%");
+  bg.setAttribute("fill", "#ffffff");
+  clone.insertBefore(bg, clone.firstChild);
+
+  return clone;
+}
+
+function serializeSvg(svg: SVGSVGElement): string {
+  return new XMLSerializer().serializeToString(svg);
+}
+
+function svgToPngDataUri(svg: SVGSVGElement, scale = 2): Promise<string> {
+  const width = Number(svg.getAttribute("width")) || 640;
+  const height = Number(svg.getAttribute("height")) || 280;
+  const svgData = serializeSvg(svg);
+  const url = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgData)}`;
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("canvas context 생성 실패"));
+        return;
+      }
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+      ctx.drawImage(img, 0, 0, width, height);
+      resolve(canvas.toDataURL("image/png"));
+    };
+    img.onerror = () => reject(new Error("SVG → PNG 변환 실패"));
+    img.src = url;
+  });
+}
+
+function triggerDownload(href: string, filename: string) {
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  a.click();
+}
+
+async function downloadWithSvgClone(
+  containerId: string,
+  filename: string,
+  mode: TExportMode,
+  format: "png" | "svg",
+) {
+  const liveSvg = getChartSvg(containerId);
+  if (!liveSvg) {
+    console.error("차트 SVG를 찾을 수 없습니다:", containerId);
+    return;
+  }
+
+  const exportSvg = cloneSvgForExport(liveSvg, mode);
+
+  if (format === "png") {
+    const imgURI = await svgToPngDataUri(exportSvg, 2);
+    triggerDownload(imgURI, `${filename}.png`);
+    return;
+  }
+
+  const svgData = serializeSvg(exportSvg);
+  const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  triggerDownload(url, `${filename}.svg`);
+  URL.revokeObjectURL(url);
+}
+
+export async function downloadChartPng(
+  chartId: string,
+  filename: string,
+  options?: TDownloadOptions,
+) {
   try {
+    if (options?.mode) {
+      const containerId = options.containerId ?? `${chartId}-container`;
+      await downloadWithSvgClone(containerId, filename, options.mode, "png");
+      return;
+    }
+
     const { imgURI } = (await ApexCharts.exec(chartId, "dataURI")) as {
       imgURI: string;
     };
-    const a = document.createElement("a");
-    a.href = imgURI;
-    a.download = `${filename}.png`;
-    a.click();
+    triggerDownload(imgURI, `${filename}.png`);
   } catch (e) {
     console.error("PNG 저장 실패:", e);
   }
 }
 
-export function downloadChartSvg(containerId: string, filename: string) {
-  const svgEl = document.getElementById(containerId)?.querySelector("svg");
-  if (!svgEl) return;
-  const svgData = new XMLSerializer().serializeToString(svgEl);
-  const blob = new Blob([svgData], { type: "image/svg+xml" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `${filename}.svg`;
-  a.click();
-  URL.revokeObjectURL(url);
+export async function downloadChartSvg(
+  containerId: string,
+  filename: string,
+  options?: TDownloadOptions,
+) {
+  try {
+    if (options?.mode) {
+      await downloadWithSvgClone(containerId, filename, options.mode, "svg");
+      return;
+    }
+
+    const svgEl = document.getElementById(containerId)?.querySelector("svg");
+    if (!svgEl) return;
+    const svgData = new XMLSerializer().serializeToString(svgEl);
+    const blob = new Blob([svgData], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(url, `${filename}.svg`);
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    console.error("SVG 저장 실패:", e);
+  }
 }
 
 export function downloadChartCsv(chartId: string) {

--- a/src/utils/dashboard/downloadChart.ts
+++ b/src/utils/dashboard/downloadChart.ts
@@ -1,4 +1,5 @@
 import ApexCharts from "apexcharts";
+import { toast } from "sonner";
 
 import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
 
@@ -317,8 +318,7 @@ async function downloadWithSvgClone(
 ) {
   const liveSvg = getChartSvg(containerId);
   if (!liveSvg) {
-    console.error("차트 SVG를 찾을 수 없습니다:", containerId);
-    return;
+    throw new Error(`차트 SVG를 찾을 수 없습니다: ${containerId}`);
   }
 
   const exportSvg = cloneSvgForExport(liveSvg, mode);
@@ -354,6 +354,7 @@ export async function downloadChartPng(
     triggerDownload(imgURI, `${filename}.png`);
   } catch (e) {
     console.error("PNG 저장 실패:", e);
+    toast.error("차트 저장에 실패했습니다.");
   }
 }
 
@@ -369,7 +370,9 @@ export async function downloadChartSvg(
     }
 
     const svgEl = document.getElementById(containerId)?.querySelector("svg");
-    if (!svgEl) return;
+    if (!svgEl) {
+      throw new Error(`차트 SVG를 찾을 수 없습니다: ${containerId}`);
+    }
     const svgData = new XMLSerializer().serializeToString(svgEl);
     const blob = new Blob([svgData], { type: "image/svg+xml" });
     const url = URL.createObjectURL(blob);
@@ -377,6 +380,7 @@ export async function downloadChartSvg(
     URL.revokeObjectURL(url);
   } catch (e) {
     console.error("SVG 저장 실패:", e);
+    toast.error("차트 저장에 실패했습니다.");
   }
 }
 

--- a/src/utils/dashboard/downloadChart.ts
+++ b/src/utils/dashboard/downloadChart.ts
@@ -1,11 +1,13 @@
 import ApexCharts from "apexcharts";
 
+import { PLATFORM_CHART_COLORS } from "@/types/dashboard/provider";
+
 type TExportMode = "line-forward" | "preserve-fill";
 
 type TDownloadOptions = {
   /**
    * line-forward: fill 제거 + stroke 강조 (플랫폼 전체보기)
-   * preserve-fill: 화면 fill 유지 + stroke hex 고정 (플랫폼 개별)
+   * preserve-fill: 화면 fill 유지 + stroke 색 고정 (플랫폼 개별)
    */
   mode?: TExportMode;
   /** SVG 복제 저장 시 컨테이너 ID */
@@ -19,6 +21,17 @@ const SERIES_PATH_SELECTOR = [
   ".apexcharts-area",
   ".apexcharts-line",
 ].join(", ");
+
+/** PNG/SVG에 var()가 안 먹히므로, 저장 직전에 토큰을 해석한 값을 넣음 */
+const INFO_BLUE_TOKEN = "var(--color-info-blue)";
+const EXPORT_BG_TOKEN = "var(--color-surface-100)";
+
+/** Apex seriesName → 플랫폼 차트 색 토큰 */
+const SERIES_TOKEN_BY_NAME: Record<string, string> = {
+  Google: PLATFORM_CHART_COLORS.GOOGLE,
+  NAVER: PLATFORM_CHART_COLORS.NAVER,
+  Meta: PLATFORM_CHART_COLORS.META,
+};
 
 /** 닫힌 area fill path — 여기에 stroke를 주면 아래·옆까지 테두리가 생김 */
 function isAreaFillPath(el: Element): boolean {
@@ -37,23 +50,6 @@ function isLineStrokePath(el: Element): boolean {
   return (
     (fill === "none" || fill == null) && Boolean(stroke && stroke !== "none")
   );
-}
-
-/** tokens.css --color-info-blue */
-const INFO_BLUE_HEX = "#0084fe";
-
-/** 플랫폼 시리즈명 → 토큰 hex */
-const SERIES_HEX_BY_NAME: Record<string, string> = {
-  Google: "#f9ab00",
-  NAVER: "#03c75a",
-  Meta: "#1877f2",
-};
-
-function seriesHexFallback(el: Element): string | null {
-  const group = el.closest(".apexcharts-series");
-  const rawName = group?.getAttribute("seriesName") ?? "";
-  // 플랫폼 시리즈명만 매칭. realIndex로 추론하면 통합(클릭수, index 0)이 Google 노랑으로 잘못 잡힘
-  return SERIES_HEX_BY_NAME[rawName] ?? null;
 }
 
 function resolveCssColor(color: string): string {
@@ -76,6 +72,14 @@ function resolveCssColor(color: string): string {
   return resolved;
 }
 
+function seriesColorFallback(el: Element): string | null {
+  const group = el.closest(".apexcharts-series");
+  const rawName = group?.getAttribute("seriesName") ?? "";
+  // 플랫폼 시리즈명만 매칭. realIndex로 추론하면 통합(클릭수, index 0)이 Google 노랑으로 잘못 잡힘
+  const token = SERIES_TOKEN_BY_NAME[rawName];
+  return token ? resolveCssColor(token) : null;
+}
+
 function getChartSvg(containerId: string): SVGSVGElement | null {
   const root = document.getElementById(containerId);
   if (!root) return null;
@@ -91,7 +95,7 @@ function resolveSeriesStroke(livePath: Element, clonePath: SVGElement): string {
     computed.stroke && computed.stroke !== "none" ? computed.stroke : null;
   const fromAttr = clonePath.getAttribute("stroke");
 
-  // 화면 계산색 우선 → 플랫폼 시리즈명 hex → 통합 info-blue
+  // 화면 계산색 우선 → 플랫폼 토큰 해석 → info-blue 토큰 해석
   return (
     (fromComputed && !fromComputed.includes("var(") ? fromComputed : null) ??
     (fromAttr && fromAttr !== "none"
@@ -99,8 +103,8 @@ function resolveSeriesStroke(livePath: Element, clonePath: SVGElement): string {
         ? resolveCssColor(fromAttr)
         : fromAttr
       : null) ??
-    seriesHexFallback(livePath) ??
-    INFO_BLUE_HEX
+    seriesColorFallback(livePath) ??
+    resolveCssColor(INFO_BLUE_TOKEN)
   );
 }
 
@@ -260,7 +264,7 @@ function cloneSvgForExport(
   bg.setAttribute("y", "0");
   bg.setAttribute("width", "100%");
   bg.setAttribute("height", "100%");
-  bg.setAttribute("fill", "#ffffff");
+  bg.setAttribute("fill", resolveCssColor(EXPORT_BG_TOKEN));
   clone.insertBefore(bg, clone.firstChild);
 
   return clone;
@@ -287,7 +291,7 @@ function svgToPngDataUri(svg: SVGSVGElement, scale = 2): Promise<string> {
         reject(new Error("canvas context 생성 실패"));
         return;
       }
-      ctx.fillStyle = "#ffffff";
+      ctx.fillStyle = resolveCssColor(EXPORT_BG_TOKEN);
       ctx.fillRect(0, 0, canvas.width, canvas.height);
       ctx.setTransform(scale, 0, 0, scale, 0, 0);
       ctx.drawImage(img, 0, 0, width, height);

--- a/src/utils/dashboard/downloadChart.ts
+++ b/src/utils/dashboard/downloadChart.ts
@@ -104,6 +104,48 @@ function resolveSeriesStroke(livePath: Element, clonePath: SVGElement): string {
   );
 }
 
+/** 플롯 상·하 테두리 그룹 */
+function isPlotBorderChrome(el: Element): boolean {
+  return Boolean(el.closest('[class*="grid-borders"]'));
+}
+
+/**
+ * 맨 위 가로선만 제거/그리드 가로선은 남김
+ */
+function removePlotRoofLine(clone: SVGSVGElement) {
+  clone.querySelectorAll('[class*="grid-borders"]').forEach((el) => {
+    el.remove();
+  });
+
+  const scope =
+    clone.querySelector(".apexcharts-inner") ??
+    clone.querySelector(".apexcharts-graphical") ??
+    clone;
+
+  const roofCandidates = [...scope.querySelectorAll("line")].filter((el) => {
+    // 시리즈(데이터) 선은 건드리지 않음
+    if (el.closest(".apexcharts-series")) return false;
+
+    const y1 = parseFloat(el.getAttribute("y1") ?? "NaN");
+    const y2 = parseFloat(el.getAttribute("y2") ?? "NaN");
+    const x1 = parseFloat(el.getAttribute("x1") ?? "NaN");
+    const x2 = parseFloat(el.getAttribute("x2") ?? "NaN");
+    if ([y1, y2, x1, x2].some((v) => Number.isNaN(v))) return false;
+    if (Math.abs(y1 - y2) > 0.5) return false; // 가로선만
+    if (Math.abs(x2 - x1) < 40) return false; // 짧은 tick 제외
+    return true;
+  });
+
+  if (roofCandidates.length === 0) return;
+
+  roofCandidates.sort(
+    (a, b) =>
+      parseFloat(a.getAttribute("y1")!) - parseFloat(b.getAttribute("y1")!),
+  );
+  // y가 가장 작은 가로선 = 플롯 천장
+  roofCandidates[0]?.remove();
+}
+
 /**
  * Apex dataURI는 stroke var(--*)를 해석하지 않아 선이 빠진다.
  * 화면 SVG를 복제해 실제 색을 심은 뒤 저장한다.
@@ -122,6 +164,11 @@ function cloneSvgForExport(
       !(liveNode instanceof SVGElement) ||
       !(cloneNode instanceof SVGElement)
     ) {
+      return;
+    }
+
+    // 지붕/바닥 테두리는 색 인라인하지 않음 (아래에서 그룹 제거)
+    if (isPlotBorderChrome(liveNode)) {
       return;
     }
 
@@ -195,6 +242,8 @@ function cloneSvgForExport(
     clonePath.setAttribute("stroke-linecap", "round");
     clonePath.setAttribute("stroke-linejoin", "round");
   });
+
+  removePlotRoofLine(clone);
 
   const rect = liveSvg.getBoundingClientRect();
   const width = Math.max(Math.round(rect.width), 1);


### PR DESCRIPTION
## 🚨 관련 이슈
close #428 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- Apex `dataURI`가 stroke의 `var(--*)`를 해석하지 않아, 플랫폼 트래픽 차트 저장본에서 선이 빠지거나 fill만 탁하게 보이던 문제를 수정

- 화면 SVG를 복제한 뒤 색을 인라인하고, area 닫힌 path에는 stroke를 주지 않아 아래·옆 테두리가 생기지 않도록 함.
- 저장 모드를 뷰별로 분리
  - **플랫폼 전체보기**: Google / NAVER / Meta 3개 시리즈가 겹치면 fill만으로는 색이 섞여 구분이 어려움. 그래서 저장본에서는 fill을 빼고 플랫폼별 색의 선만 보이도록 수정. (`line-forward`)
  - **플랫폼 개별보기**: 시리즈가 하나라 fill만으로도 형태는 보이지만, Apex `dataURI`에서 stroke `var()`가 빠지면 경계가 흐려짐. 화면의 연한 fill은 유지하고 위쪽 선만 살림. (`preserve-fill`)
- 저장본에서 플롯 상단 테두리 선만 제거, 가로 그리드 유지
- 화면 차트 UX는 기존과 동일하게 유지
- 플랫폼 차트 fill/stroke 옵션은 `trafficChartExportStyles.ts` 로 분리

### 플랫폼 전체뷰
| Before | After |
|---|---|
| <img width="751" height="365" alt="platform-all-traffic-2026-08-24 (16)" src="https://github.com/user-attachments/assets/9e51f7b7-44b2-4e0d-b532-9769fe015dba" />| <img width="1502" height="730" alt="platform-all-traffic-2026-08-24 (17)" src="https://github.com/user-attachments/assets/d51d8bdb-5ef2-4ba3-a82f-ebbff7f69a52" /> |

### 플랫폼 개별뷰
| Before | After |
|---|---|
| <img width="751" height="365" alt="platform-traffic-META-2026-08-24 (14)" src="https://github.com/user-attachments/assets/f494be82-ef06-4190-bc93-e691b372dd6a" />| <img width="1502" height="730" alt="platform-traffic-META-2026-08-24 (15)" src="https://github.com/user-attachments/assets/9ba5a7b6-8e56-45d6-9f87-7c1baedc5fb7" /> |



## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
- 통합 대시보드 부분은 기존 저장본으로도 잘 보여서 이번 PR에서는 수정하지 않았습니다.
- 수정 과정에서  저장본에 왼쪽 세로 점선이 생겼는데, 제거를 시도했지만 부작용(위쪽 테두리 재등장 등)이 있어 이번 PR에서는 일단 그대로 두었습니다.
- PNG 저장 시 CSS 변수 미해석 때문에 플랫폼 선 색은 hex로 고정하여, 토큰 색을 바꾸면 `downloadChart.ts`도 함께 맞춰야 합니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 플랫폼 트래픽 차트의 선과 영역 채우기 표시를 일관된 스타일로 개선했습니다.
  * 플랫폼별 차트 색상 표시를 명확하게 정리했습니다.
  * 차트 다운로드 시 전체 보기와 개별 플랫폼 보기의 표시 방식이 적절히 적용됩니다.
  * PNG 및 SVG 다운로드 품질과 색상 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->