### PR TITLE
[BugFix/#494] 구글 광고 연동 토큰 만료 예정 UI 및 판정 제거

### DIFF
--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -65,6 +65,7 @@ const SYNC_LINK_CLASS =
   "inline-flex shrink-0 items-center gap-1 font-body2 text-text-muted transition-colors hover:text-primary-400 disabled:cursor-wait disabled:opacity-50";
 
 function PlatformConnectionMeta({
+  provider,
   status,
   syncedAt,
   externalAccountId,
@@ -74,6 +75,7 @@ function PlatformConnectionMeta({
   isSyncLoading = false,
 }: Pick<
   IPlatformConnectionItem,
+  | "provider"
   | "status"
   | "syncedAt"
   | "externalAccountId"
@@ -88,6 +90,8 @@ function PlatformConnectionMeta({
   const expireTone = getTokenExpireTone(tokenExpireAt);
   const isSoftDisconnected =
     status === "disconnected" && platformAccountId != null;
+  // 구글: refresh 장기 유효·단기 access만료일은 연동 수명이 아님 → 토큰 만료 예정 미표시
+  const showTokenExpire = provider !== "GOOGLE";
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -104,16 +108,18 @@ function PlatformConnectionMeta({
               </span>
             </p>
           ) : null}
-          <p className="font-body2 text-text-muted">
-            <span>토큰 만료 예정 · </span>
-            {expireLabel ? (
-              <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
-                {expireLabel}
-              </span>
-            ) : (
-              <span className="text-text-muted/60">—</span>
-            )}
-          </p>
+          {showTokenExpire ? (
+            <p className="font-body2 text-text-muted">
+              <span>토큰 만료 예정 · </span>
+              {expireLabel ? (
+                <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
+                  {expireLabel}
+                </span>
+              ) : (
+                <span className="text-text-muted/60">—</span>
+              )}
+            </p>
+          ) : null}
         </>
       ) : status === "disconnected" ? (
         <>
@@ -125,10 +131,12 @@ function PlatformConnectionMeta({
             <span>연동 계정 · </span>
             <span className="text-text-muted/60">—</span>
           </p>
-          <p className="font-body2 text-text-muted/60">
-            <span>토큰 만료 예정 · </span>
-            <span className="text-text-muted/60">—</span>
-          </p>
+          {showTokenExpire ? (
+            <p className="font-body2 text-text-muted/60">
+              <span>토큰 만료 예정 · </span>
+              <span className="text-text-muted/60">—</span>
+            </p>
+          ) : null}
         </>
       ) : status === "connected" ? (
         <>
@@ -174,19 +182,21 @@ function PlatformConnectionMeta({
             </p>
           ) : null}
 
-          {expireLabel ? (
-            <p className="font-body2 text-text-muted">
-              <span>토큰 만료 예정 · </span>
-              <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
-                {expireLabel}
-              </span>
-            </p>
-          ) : (
-            <p className="font-body2 text-text-muted">
-              <span>토큰 만료 예정 · </span>
-              <span className="text-text-muted/60">—</span>
-            </p>
-          )}
+          {showTokenExpire ? (
+            expireLabel ? (
+              <p className="font-body2 text-text-muted">
+                <span>토큰 만료 예정 · </span>
+                <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
+                  {expireLabel}
+                </span>
+              </p>
+            ) : (
+              <p className="font-body2 text-text-muted">
+                <span>토큰 만료 예정 · </span>
+                <span className="text-text-muted/60">—</span>
+              </p>
+            )
+          ) : null}
         </>
       ) : (
         <>
@@ -209,19 +219,21 @@ function PlatformConnectionMeta({
             </p>
           ) : null}
 
-          {expireLabel ? (
-            <p className="font-body2 text-text-muted">
-              <span>토큰 만료 예정 · </span>
-              <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
-                {expireLabel}
-              </span>
-            </p>
-          ) : (
-            <p className="font-body2 text-text-muted">
-              <span>토큰 만료 예정 · </span>
-              <span className="text-text-muted/60">—</span>
-            </p>
-          )}
+          {showTokenExpire ? (
+            expireLabel ? (
+              <p className="font-body2 text-text-muted">
+                <span>토큰 만료 예정 · </span>
+                <span className={TOKEN_EXPIRE_TEXT[expireTone]}>
+                  {expireLabel}
+                </span>
+              </p>
+            ) : (
+              <p className="font-body2 text-text-muted">
+                <span>토큰 만료 예정 · </span>
+                <span className="text-text-muted/60">—</span>
+              </p>
+            )
+          ) : null}
         </>
       )}
     </div>
@@ -267,6 +279,7 @@ function PlatformIntegrationCard({
       </div>
 
       <PlatformConnectionMeta
+        provider={provider}
         status={status}
         syncedAt={syncedAt}
         externalAccountId={externalAccountId}

--- a/src/utils/integration/mapPlatformAccounts.ts
+++ b/src/utils/integration/mapPlatformAccounts.ts
@@ -110,7 +110,11 @@ export function formatConnectionDate(value?: string): string | null {
 function mapApiStatusToUi(
   account: IPlatformAccountApi,
 ): TPlatformConnectionStatus {
-  if (account.status === "EXPIRED" || isTokenExpired(account.tokenExpireAt)) {
+  // 구글: tokenExpireAt은 단기 액세스 토큰 만료라 연동 수명과 무관 → status만 신뢰
+  const isExpiredByToken =
+    account.provider !== "GOOGLE" && isTokenExpired(account.tokenExpireAt);
+
+  if (account.status === "EXPIRED" || isExpiredByToken) {
     return "error";
   }
   if (account.status === "ACTIVE") {
@@ -129,7 +133,10 @@ function mapAccountToConnection(
     platformAccountId: account.platformAccountId,
     externalAccountId: account.externalAccountId,
     syncedAt: account.syncedAt,
-    tokenExpireAt: account.tokenExpireAt,
+    // 구글은 만료 UI/판정에 쓰지 않음 (메타,네이버만 전달)
+    ...(account.provider !== "GOOGLE" && {
+      tokenExpireAt: account.tokenExpireAt,
+    }),
   };
 
   if (status === "error") {


### PR DESCRIPTION
## 🚨 관련 이슈
close #494 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
구글 연동 시 백엔드 `tokenExpireAt`이 단기 액세스 토큰 만료로 내려와, FE에서 `토큰 만료 예정`/`연동 오류`로 오탐되던 문제를 수정했습니다.  
(재연동해도 만료가 안 풀린 것처럼 보여 백에 확인 → 구글은 refresh가 장기 유효하고 별도 refresh 만료일이 없으며, 동기화해도 액세스 토큰 수명이 짧아 오늘·임박으로 뜸)

⇒ 구글만 토큰 만료 예정 UI·만료 판정 제외

- `mapPlatformAccounts`: 구글은 `tokenExpireAt`으로 error 매핑·UI 전달하지 않음
- `PlatformIntegrationCard`: 구글만 `토큰 만료 예정` 미표시
- 메타/네이버는 기존과 동일

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
- 여러 개의 구글 계정이 ACTIVE인 경우 provider별 첫 번째만 표시 중이며, 표시 기준 확인 중

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * Google 연동에서 토큰 만료 예정 표시가 더 이상 노출되지 않습니다.
  * Google 계정은 토큰 만료 정보를 기준으로 만료 상태를 판단하지 않습니다.
  * Meta 및 Naver 계정에서는 기존 토큰 만료 정보가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->