### PR TITLE
[Bugfix/#496] 로그아웃 시 온보딩 투어 완료 여부 초기화 제거

### DIFF
--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -29,7 +29,6 @@ const useAuthStore = create<IAuthState>((set) => ({
   },
   logout: () => {
     localStorage.removeItem("hasSession");
-    localStorage.removeItem("hasSeenOnboarding");
     set({
       isLoggedIn: false,
       isTokenInitialized: false,


### PR DESCRIPTION
## 🚨 관련 이슈

close #496

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

`useAuthStore`의 `logout` 함수에서 `localStorage.removeItem("hasSeenOnboarding")` 제거

### 원인
로그아웃 시 `hasSeenOnboarding` 키를 삭제하여 재로그인할 때마다 온보딩 투어가 초기화되는 문제
온보딩 투어는 기기 단위 1회 노출이 의도된 동작이므로 로그아웃과 무관하게 유지되어야 함
- `src/store/useAuthStore.ts`

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃 후에도 온보딩 완료 상태가 유지되도록 개선했습니다.
  * 로그아웃 시 인증 세션은 계속 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->