### PR TITLE
[Refactor/#499] useCoreInfiniteQuery 추가 및 useInfiniteQuery 교체

### DIFF
--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -1,7 +1,10 @@
 import {
+  type InfiniteData,
   type MutationFunction,
   type QueryFunction,
   type QueryKey,
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
   useMutation,
   useQuery,
   useQueryClient,
@@ -10,6 +13,7 @@ import {
 
 import type {
   IApiErrorResponse,
+  TUseInfiniteQueryCustomOptions,
   TUseMutationCustomOptions,
   TUseQueryCustomOptions,
 } from "@/types/common/common";
@@ -20,6 +24,22 @@ export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
   options?: TUseQueryCustomOptions<TQueryFnData, TData>,
 ): UseQueryResult<TData, IApiErrorResponse> {
   return useQuery({
+    queryKey: keyName,
+    queryFn: query,
+    ...options,
+  });
+}
+
+export function useCoreInfiniteQuery<
+  TQueryFnData,
+  TData = InfiniteData<TQueryFnData>,
+  TPageParam = string | null,
+>(
+  keyName: QueryKey,
+  query: QueryFunction<TQueryFnData, QueryKey, TPageParam>,
+  options: TUseInfiniteQueryCustomOptions<TQueryFnData, TData, TPageParam>,
+): UseInfiniteQueryResult<TData, IApiErrorResponse> {
+  return useInfiniteQuery({
     queryKey: keyName,
     queryFn: query,
     ...options,

--- a/src/hooks/notification/useNotificationHistory.ts
+++ b/src/hooks/notification/useNotificationHistory.ts
@@ -1,8 +1,7 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
-
-import type { IApiErrorResponse } from "@/types/common/common";
 import type { INotificationHistoryData } from "@/types/notification/notification";
 import { MOCK_NOTIFICATION_HISTORY } from "@/types/notification/notification.mock";
+
+import { useCoreInfiniteQuery } from "@/hooks/customQuery";
 
 import { getNotificationHistory } from "@/api/notification/notification";
 import { QUERY_KEYS } from "@/lib/queryKeys";
@@ -14,24 +13,26 @@ const USE_MOCK_NOTIFICATION_HISTORY = true;
 export function useNotificationHistory() {
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
 
-  const query = useInfiniteQuery<INotificationHistoryData, IApiErrorResponse>({
-    queryKey: [
+  const query = useCoreInfiniteQuery<INotificationHistoryData>(
+    [
       ...QUERY_KEYS.notification.history(orgId),
       USE_MOCK_NOTIFICATION_HISTORY ? "mock" : "api",
     ],
-    queryFn: ({ pageParam }) => {
+    ({ pageParam }) => {
       if (USE_MOCK_NOTIFICATION_HISTORY) {
         return Promise.resolve(MOCK_NOTIFICATION_HISTORY);
       }
       return getNotificationHistory(orgId as number, {
-        cursor: (pageParam as string | null) ?? undefined,
+        cursor: pageParam ?? undefined,
       });
     },
-    initialPageParam: null as string | null,
-    getNextPageParam: (lastPage) =>
-      lastPage.hasNext ? lastPage.nextCursor : undefined,
-    enabled: orgId != null,
-  });
+    {
+      initialPageParam: null,
+      getNextPageParam: (lastPage) =>
+        lastPage.hasNext ? lastPage.nextCursor : undefined,
+      enabled: orgId != null,
+    },
+  );
 
   const notifications =
     query.data?.pages.flatMap((page) => page.notifications) ?? [];

--- a/src/hooks/setting/useNotificationMembers.ts
+++ b/src/hooks/setting/useNotificationMembers.ts
@@ -1,21 +1,22 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
-
-import type { IApiErrorResponse } from "@/types/common/common";
 import type { INotificationMembersData } from "@/types/setting/notification";
+
+import { useCoreInfiniteQuery } from "@/hooks/customQuery";
 
 import { getNotificationMembers } from "@/api/notification/notification";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 
 export function useNotificationMembers(orgId: number) {
-  return useInfiniteQuery<INotificationMembersData, IApiErrorResponse>({
-    queryKey: QUERY_KEYS.notification.members(orgId),
-    queryFn: ({ pageParam }) =>
+  return useCoreInfiniteQuery<INotificationMembersData>(
+    QUERY_KEYS.notification.members(orgId),
+    ({ pageParam }) =>
       getNotificationMembers(orgId, {
-        cursor: (pageParam as string | null) ?? undefined,
+        cursor: pageParam ?? undefined,
       }),
-    initialPageParam: null as string | null,
-    getNextPageParam: (lastPage) =>
-      lastPage.hasNext ? lastPage.nextCursor : undefined,
-    enabled: Number.isFinite(orgId) && orgId > 0,
-  });
+    {
+      initialPageParam: null,
+      getNextPageParam: (lastPage) =>
+        lastPage.hasNext ? lastPage.nextCursor : undefined,
+      enabled: Number.isFinite(orgId) && orgId > 0,
+    },
+  );
 }

--- a/src/pages/workspace/MemberManagement.tsx
+++ b/src/pages/workspace/MemberManagement.tsx
@@ -1,16 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useInfiniteQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
 import {
+  type TGetWorkspaceMembersData,
   type TMemberRole,
   type TUpdateMemberRoleRequest,
   type TWorkspaceMember,
 } from "@/types/workspace/workspace";
 
-import { useCoreMutation, useCoreQuery } from "@/hooks/customQuery";
+import {
+  useCoreInfiniteQuery,
+  useCoreMutation,
+  useCoreQuery,
+} from "@/hooks/customQuery";
 import { useNotificationMembers } from "@/hooks/setting/useNotificationMembers";
 import { useUpdateNotificationMembers } from "@/hooks/setting/useUpdateNotificationMembers";
 
@@ -52,17 +56,18 @@ export default function MemberManagement() {
     { enabled: Number.isFinite(orgId) && orgId > 0 },
   );
 
-  const membersQuery = useInfiniteQuery({
-    queryKey: QUERY_KEYS.workspace.membersWithPageSize(orgId, PAGE_SIZE),
-    queryFn: ({ pageParam }: { pageParam: string | null }) =>
-      getWorkspaceMembers(orgId, pageParam, PAGE_SIZE),
-    initialPageParam: null,
-    getNextPageParam: (lastPage) => {
-      if (!lastPage.hasNext) return undefined;
-      return lastPage.nextCursor;
+  const membersQuery = useCoreInfiniteQuery<TGetWorkspaceMembersData>(
+    QUERY_KEYS.workspace.membersWithPageSize(orgId, PAGE_SIZE),
+    ({ pageParam }) => getWorkspaceMembers(orgId, pageParam, PAGE_SIZE),
+    {
+      initialPageParam: null,
+      getNextPageParam: (lastPage) => {
+        if (!lastPage.hasNext) return undefined;
+        return lastPage.nextCursor;
+      },
+      enabled: Number.isFinite(orgId) && orgId > 0,
     },
-    enabled: Number.isFinite(orgId) && orgId > 0,
-  });
+  );
 
   const members = useMemo(() => {
     return membersQuery.data?.pages.flatMap((page) => page.members) ?? [];

--- a/src/types/common/common.ts
+++ b/src/types/common/common.ts
@@ -1,5 +1,7 @@
 import type {
+  InfiniteData,
   QueryKey,
+  UseInfiniteQueryOptions,
   UseMutationOptions,
   UseQueryOptions,
 } from "@tanstack/react-query";
@@ -24,6 +26,21 @@ export type TUseQueryCustomOptions<
   TData = TQueryFnData,
 > = Omit<
   UseQueryOptions<TQueryFnData, IApiErrorResponse, TData, QueryKey>,
+  "queryKey" | "queryFn"
+>;
+
+export type TUseInfiniteQueryCustomOptions<
+  TQueryFnData = unknown,
+  TData = InfiniteData<TQueryFnData>,
+  TPageParam = unknown,
+> = Omit<
+  UseInfiniteQueryOptions<
+    TQueryFnData,
+    IApiErrorResponse,
+    TData,
+    QueryKey,
+    TPageParam
+  >,
   "queryKey" | "queryFn"
 >;
 


### PR DESCRIPTION


## 🚨 관련 이슈

Closed #499 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `useCoreInfiniteQuery` 래퍼 추가 (`customQuery.ts`)
- 알림 기록, 알림 멤버, 멤버 관리의 기존 사용하던 `useInfiniteQuery` 직접 호출을 래퍼로 변경하였습니다.
- UI와 기능은 유지되고 리팩토링 작업만 진행했습니다.

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 무한 스크롤 쿼리를 지원하는 공통 기능을 추가했습니다.
  - 알림 내역, 알림 멤버, 워크스페이스 멤버 목록에서 페이지 단위 추가 로딩을 안정적으로 사용할 수 있습니다.
  - 페이지 커서와 초기 페이지 설정을 일관되게 처리합니다.

- **개선**
  - 여러 목록 화면의 무한 쿼리 사용 방식을 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->