### PR TITLE
[Feature/#500] 플랫폼 연동 UI에서 계정명 표시 제거

### DIFF
--- a/src/components/integration/PlatformDisconnectModal.tsx
+++ b/src/components/integration/PlatformDisconnectModal.tsx
@@ -10,7 +10,6 @@ interface IPlatformDisconnectModalProps {
   isOpen: boolean;
   onClose: () => void;
   provider: TIntegrationProvider;
-  externalAccountId?: string;
   onConfirm: () => void;
   isLoading?: boolean;
 }
@@ -19,7 +18,6 @@ export default function PlatformDisconnectModal({
   isOpen,
   onClose,
   provider,
-  externalAccountId,
   onConfirm,
   isLoading = false,
 }: IPlatformDisconnectModalProps) {
@@ -55,14 +53,6 @@ export default function PlatformDisconnectModal({
         </h3>
 
         <p className="mb-7 font-body1 text-text-auth-sub">
-          {externalAccountId ? (
-            <>
-              연동 계정 ·{" "}
-              <span className="text-text-title">{externalAccountId}</span>
-              <br />
-              <br />
-            </>
-          ) : null}
           해제 후에도 기존 계정을 다시 연동할 수 있으며, 계정은 매일 새벽 4시에
           삭제됩니다.
           <br />

--- a/src/components/integration/PlatformIntegrationCard.tsx
+++ b/src/components/integration/PlatformIntegrationCard.tsx
@@ -68,19 +68,13 @@ function PlatformConnectionMeta({
   provider,
   status,
   syncedAt,
-  externalAccountId,
   platformAccountId,
   tokenExpireAt,
   onSync,
   isSyncLoading = false,
 }: Pick<
   IPlatformConnectionItem,
-  | "provider"
-  | "status"
-  | "syncedAt"
-  | "externalAccountId"
-  | "platformAccountId"
-  | "tokenExpireAt"
+  "provider" | "status" | "syncedAt" | "platformAccountId" | "tokenExpireAt"
 > & {
   onSync?: () => void;
   isSyncLoading?: boolean;
@@ -97,17 +91,6 @@ function PlatformConnectionMeta({
     <div className="flex w-full flex-col gap-2">
       {isSoftDisconnected ? (
         <>
-          {externalAccountId ? (
-            <p className="min-w-0 font-body2 text-text-muted">
-              <span>연동 계정 · </span>
-              <span
-                className="truncate text-text-title"
-                title={externalAccountId}
-              >
-                {externalAccountId}
-              </span>
-            </p>
-          ) : null}
           {showTokenExpire ? (
             <p className="font-body2 text-text-muted">
               <span>토큰 만료 예정 · </span>
@@ -125,10 +108,6 @@ function PlatformConnectionMeta({
         <>
           <p className="font-body2 text-text-muted/60">
             <span>마지막 동기화 · </span>
-            <span className="text-text-muted/60">—</span>
-          </p>
-          <p className="font-body2 text-text-muted/60">
-            <span>연동 계정 · </span>
             <span className="text-text-muted/60">—</span>
           </p>
           {showTokenExpire ? (
@@ -170,18 +149,6 @@ function PlatformConnectionMeta({
             </p>
           ) : null}
 
-          {externalAccountId ? (
-            <p className="min-w-0 font-body2 text-text-muted">
-              <span>연동 계정 · </span>
-              <span
-                className="truncate text-text-title"
-                title={externalAccountId}
-              >
-                {externalAccountId}
-              </span>
-            </p>
-          ) : null}
-
           {showTokenExpire ? (
             expireLabel ? (
               <p className="font-body2 text-text-muted">
@@ -204,18 +171,6 @@ function PlatformConnectionMeta({
             <p className="font-body2 text-text-muted">
               <span>마지막 동기화 · </span>
               <span className="text-text-title">{syncedLabel}</span>
-            </p>
-          ) : null}
-
-          {externalAccountId ? (
-            <p className="min-w-0 font-body2 text-text-muted">
-              <span>연동 계정 · </span>
-              <span
-                className="truncate text-text-title"
-                title={externalAccountId}
-              >
-                {externalAccountId}
-              </span>
             </p>
           ) : null}
 
@@ -244,7 +199,6 @@ function PlatformIntegrationCard({
   provider,
   status,
   syncedAt,
-  externalAccountId,
   platformAccountId,
   tokenExpireAt,
   errorMessage,
@@ -282,7 +236,6 @@ function PlatformIntegrationCard({
         provider={provider}
         status={status}
         syncedAt={syncedAt}
-        externalAccountId={externalAccountId}
         platformAccountId={platformAccountId}
         tokenExpireAt={tokenExpireAt}
         onSync={status === "connected" ? onSync : undefined}

--- a/src/components/integration/skeleton/PlatformIntegrationsSkeleton.tsx
+++ b/src/components/integration/skeleton/PlatformIntegrationsSkeleton.tsx
@@ -22,7 +22,6 @@ export function PlatformIntegrationCardSkeleton() {
       <div className="flex w-full flex-col gap-2">
         <Skeleton className="h-4 w-full max-w-56" />
         <Skeleton className="h-4 w-full max-w-48" />
-        <Skeleton className="h-4 w-full max-w-40" />
       </div>
 
       <div className="flex-1" aria-hidden />

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -38,7 +38,6 @@ type TDisconnectTarget = {
   orgId: number;
   provider: TIntegrationProvider;
   platformAccountId: number;
-  externalAccountId?: string;
 };
 
 export default function PlatformIntegrationsPage() {
@@ -180,7 +179,6 @@ export default function PlatformIntegrationsPage() {
       orgId,
       provider: item.provider,
       platformAccountId: item.platformAccountId,
-      externalAccountId: item.externalAccountId,
     });
   };
 
@@ -314,7 +312,6 @@ export default function PlatformIntegrationsPage() {
         isOpen={disconnectTarget != null}
         onClose={() => setDisconnectTarget(null)}
         provider={disconnectTarget?.provider ?? "META"}
-        externalAccountId={disconnectTarget?.externalAccountId}
         onConfirm={handleConfirmDisconnect}
         isLoading={disconnectMutation.isPending}
       />


### PR DESCRIPTION
## 🚨 관련 이슈

close #500 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [X] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

한 플랫폼에 여러 광고 계정이 연결될 수 있는데, 기존에는 플랫폼당 계정 하나만 골라 `연동 계정 · {externalAccountId}`로 표시해 어느 계정을 대표로 보여주는지 알 수 없었음. 
플랫폼 연동 카드·해제 모달의 역할은 특정 광고계정 식별이 아니라 플랫폼 연동 상태 확인이므로, 계정명 노출을 제거함.

## 😅 미완성 작업
N/A

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 플랫폼 연동 해제 모달과 연동 카드에서 외부 계정 ID 표시를 제거했습니다.
  * 연동 상태 정보가 간소화되어 핵심 정보에 집중할 수 있습니다.
  * Google을 제외한 플랫폼에서만 토큰 만료 정보가 표시됩니다.

* **UI 개선**
  * 연동 목록 로딩 화면의 텍스트 너비를 조정해 실제 콘텐츠와 더 자연스럽게 보이도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->