### PR TITLE
[Refactor/#507] 캠페인·광고 벌크 중단/재개 로직 공통화

### DIFF
--- a/src/components/ads/BulkStatusActionModals.tsx
+++ b/src/components/ads/BulkStatusActionModals.tsx
@@ -1,0 +1,108 @@
+import type {
+  IBulkOperableCopy,
+  TBulkScope,
+} from "@/hooks/ads/useBulkOperableControl";
+
+import Modal from "@/components/common/modal/Modal";
+import ModalContent, {
+  type TModalDetailItem,
+} from "@/components/common/modal/ModalContent";
+
+import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
+
+interface IBulkControlModalHandle {
+  isOpen: boolean;
+  isLoading: boolean;
+  closeModal: () => void;
+  handleConfirm: (action: () => Promise<void>) => Promise<void>;
+}
+
+interface IBulkStatusActionModalsProps {
+  copy: IBulkOperableCopy;
+  pauseScope: TBulkScope;
+  resumeScope: TBulkScope;
+  selectedOngoingCount: number;
+  selectedPausedCount: number;
+  ongoingAllCount: number;
+  pausedAllCount: number;
+  pauseDetailItems: readonly TModalDetailItem[];
+  resumeDetailItems: readonly TModalDetailItem[];
+  pauseModal: IBulkControlModalHandle;
+  resumeModal: IBulkControlModalHandle;
+  onConfirmPause: () => Promise<void>;
+  onConfirmResume: () => Promise<void>;
+}
+
+export default function BulkStatusActionModals({
+  copy,
+  pauseScope,
+  resumeScope,
+  selectedOngoingCount,
+  selectedPausedCount,
+  ongoingAllCount,
+  pausedAllCount,
+  pauseDetailItems,
+  resumeDetailItems,
+  pauseModal,
+  resumeModal,
+  onConfirmPause,
+  onConfirmResume,
+}: IBulkStatusActionModalsProps) {
+  const { entityName, entityObject, exposureNoun } = copy;
+
+  return (
+    <>
+      <Modal
+        isOpen={pauseModal.isOpen}
+        onClose={pauseModal.closeModal}
+        title={copy.pauseModalTitle}
+      >
+        <ModalContent
+          icon={<WarnCircleIcon className="h-7 w-7 text-info-red" />}
+          title={
+            pauseScope === "all"
+              ? `운영 중인 ${entityObject} 모두 중단할까요?`
+              : `선택한 ${entityObject} 중단할까요?`
+          }
+          description={
+            pauseScope === "all"
+              ? `운영 중인 ${ongoingAllCount}개 ${entityName}의 ${exposureNoun}이 즉시 중단됩니다.`
+              : `선택한 ${selectedOngoingCount}개 ${entityName}의 ${exposureNoun}이 즉시 중단됩니다.`
+          }
+          detailItems={pauseDetailItems}
+          detailListTitle={copy.pauseDetailListTitle}
+          buttonText="중단하기"
+          onConfirm={() => pauseModal.handleConfirm(onConfirmPause)}
+          isLoading={pauseModal.isLoading}
+          variant="danger"
+        />
+      </Modal>
+
+      <Modal
+        isOpen={resumeModal.isOpen}
+        onClose={resumeModal.closeModal}
+        title={copy.resumeModalTitle}
+      >
+        <ModalContent
+          icon={<WarnCircleIcon className="h-7 w-7 text-info-blue" />}
+          title={
+            resumeScope === "all"
+              ? `중단된 ${entityObject} 모두 재개할까요?`
+              : `선택한 ${entityObject} 재개할까요?`
+          }
+          description={
+            resumeScope === "all"
+              ? `중단된 ${pausedAllCount}개 ${entityName}의 ${exposureNoun}이 즉시 재개됩니다.`
+              : `선택한 ${selectedPausedCount}개 ${entityName}의 ${exposureNoun}이 즉시 재개됩니다.`
+          }
+          detailItems={resumeDetailItems}
+          detailListTitle={copy.resumeDetailListTitle}
+          buttonText="재개하기"
+          onConfirm={() => resumeModal.handleConfirm(onConfirmResume)}
+          isLoading={resumeModal.isLoading}
+          variant="primary"
+        />
+      </Modal>
+    </>
+  );
+}

--- a/src/hooks/ads/useBulkOperableControl.ts
+++ b/src/hooks/ads/useBulkOperableControl.ts
@@ -24,8 +24,10 @@ export interface IBulkOperableItem {
  * 캠페인 목록 / 캠페인 상세(광고 소재)에서 entityName 등만 바꿔 재사용
  */
 export interface IBulkOperableCopy {
-  /** "캠페인" | "광고 소재" — 모달 제목·설명에 삽입 */
+  /** "캠페인" | "광고 소재" — 모달 설명에 삽입 */
   entityName: string;
+  /** 목적격 조사 포함 — "캠페인을" | "광고 소재를" (모달 제목용) */
+  entityObject: string;
   pauseModalTitle: string;
   resumeModalTitle: string;
   pauseDetailListTitle: string;

--- a/src/hooks/ads/useBulkOperableControl.ts
+++ b/src/hooks/ads/useBulkOperableControl.ts
@@ -1,4 +1,10 @@
+import { useMemo, useState } from "react";
+
 import type { TStatus } from "@/types/ads/campaign";
+
+import { useControlModal } from "@/hooks/ads/useControlModal";
+
+import type { TModalDetailItem } from "@/components/common/modal/ModalContent";
 
 /** 중단/재개 적용 범위 — 선택 항목만 vs 전체(운영 중·중단 상태 기준) */
 export type TBulkScope = "selection" | "all";
@@ -29,4 +35,138 @@ export interface IBulkOperableCopy {
   resumeErrorMessage: string;
   /** 설명 문구용 — 캠페인: "광고 노출", 광고 소재: "노출" */
   exposureNoun: string;
+}
+
+export interface IUseBulkOperableControlParams<T> {
+  items: readonly T[];
+  selectedIds: ReadonlySet<number>;
+  getId: (item: T) => number;
+  getLabel: (item: T) => string;
+  getStatus: (item: T) => TStatus;
+  copy: IBulkOperableCopy;
+  /** 중단/재개 성공 후 선택 해제 등 */
+  onSuccess?: () => void;
+}
+
+/** 캠페인·광고 소재 공통 — 선택/scope 계산, 모달 상태, 대상 목록 */
+export function useBulkOperableControl<T>({
+  items,
+  selectedIds,
+  getId,
+  getLabel,
+  getStatus,
+  copy,
+  onSuccess,
+}: IUseBulkOperableControlParams<T>) {
+  const normalizedItems = useMemo<IBulkOperableItem[]>(
+    () =>
+      items.map((item) => ({
+        id: getId(item),
+        status: getStatus(item),
+        label: getLabel(item),
+      })),
+    [items, getId, getLabel, getStatus],
+  );
+
+  const [pauseScope, setPauseScope] = useState<TBulkScope>("all");
+  const [resumeScope, setResumeScope] = useState<TBulkScope>("all");
+
+  const selectedOngoingIds = useMemo(
+    () =>
+      [...selectedIds].filter((id) =>
+        normalizedItems.some(
+          (item) => item.id === id && item.status === "ON_GOING",
+        ),
+      ),
+    [selectedIds, normalizedItems],
+  );
+
+  const selectedPausedIds = useMemo(
+    () =>
+      [...selectedIds].filter((id) =>
+        normalizedItems.some(
+          (item) => item.id === id && item.status === "PAUSED",
+        ),
+      ),
+    [selectedIds, normalizedItems],
+  );
+
+  const ongoingAllCount = useMemo(
+    () => normalizedItems.filter((item) => item.status === "ON_GOING").length,
+    [normalizedItems],
+  );
+
+  const pausedAllCount = useMemo(
+    () => normalizedItems.filter((item) => item.status === "PAUSED").length,
+    [normalizedItems],
+  );
+
+  const canPause = useMemo(() => {
+    if (selectedOngoingIds.length > 0) return true;
+    return selectedIds.size === 0 && ongoingAllCount > 0;
+  }, [selectedOngoingIds.length, selectedIds.size, ongoingAllCount]);
+
+  const canResume = useMemo(() => {
+    if (selectedPausedIds.length > 0) return true;
+    return selectedIds.size === 0 && pausedAllCount > 0;
+  }, [selectedPausedIds.length, selectedIds.size, pausedAllCount]);
+
+  const pauseModal = useControlModal({
+    successMessage: copy.successMessage,
+    errorMessage: copy.pauseErrorMessage,
+    onSuccess,
+  });
+
+  const resumeModal = useControlModal({
+    successMessage: copy.successMessage,
+    errorMessage: copy.resumeErrorMessage,
+    onSuccess,
+  });
+
+  const openPauseModal = () => {
+    const scope: TBulkScope =
+      selectedOngoingIds.length > 0 ? "selection" : "all";
+    setPauseScope(scope);
+    pauseModal.openModal();
+  };
+
+  const openResumeModal = () => {
+    const scope: TBulkScope =
+      selectedPausedIds.length > 0 ? "selection" : "all";
+    setResumeScope(scope);
+    resumeModal.openModal();
+  };
+
+  const pauseDetailItems = useMemo((): TModalDetailItem[] => {
+    const rows =
+      pauseScope === "selection"
+        ? normalizedItems.filter((item) => selectedOngoingIds.includes(item.id))
+        : normalizedItems.filter((item) => item.status === "ON_GOING");
+    return rows.map((item) => ({ id: item.id, label: item.label }));
+  }, [pauseScope, normalizedItems, selectedOngoingIds]);
+
+  const resumeDetailItems = useMemo((): TModalDetailItem[] => {
+    const rows =
+      resumeScope === "selection"
+        ? normalizedItems.filter((item) => selectedPausedIds.includes(item.id))
+        : normalizedItems.filter((item) => item.status === "PAUSED");
+    return rows.map((item) => ({ id: item.id, label: item.label }));
+  }, [resumeScope, normalizedItems, selectedPausedIds]);
+
+  return {
+    canPause,
+    canResume,
+    pauseScope,
+    resumeScope,
+    selectedOngoingIds,
+    selectedPausedIds,
+    ongoingAllCount,
+    pausedAllCount,
+    pauseDetailItems,
+    resumeDetailItems,
+    pauseModal,
+    resumeModal,
+    openPauseModal,
+    openResumeModal,
+  };
 }

--- a/src/hooks/ads/useBulkOperableControl.ts
+++ b/src/hooks/ads/useBulkOperableControl.ts
@@ -1,0 +1,32 @@
+import type { TStatus } from "@/types/ads/campaign";
+
+/** 중단/재개 적용 범위 — 선택 항목만 vs 전체(운영 중·중단 상태 기준) */
+export type TBulkScope = "selection" | "all";
+
+/**
+ * 훅 내부에서 공통 계산에 쓰는 정규화된 항목.
+ * 캠페인(projectId) / 광고 소재(id) 등 원본 타입을 getId·getLabel·getStatus로 맞춘 뒤 사용
+ */
+export interface IBulkOperableItem {
+  id: number;
+  status: TStatus;
+  label: string;
+}
+
+/**
+ * 중단/재개 모달·토스트 문구
+ * 캠페인 목록 / 캠페인 상세(광고 소재)에서 entityName 등만 바꿔 재사용
+ */
+export interface IBulkOperableCopy {
+  /** "캠페인" | "광고 소재" — 모달 제목·설명에 삽입 */
+  entityName: string;
+  pauseModalTitle: string;
+  resumeModalTitle: string;
+  pauseDetailListTitle: string;
+  resumeDetailListTitle: string;
+  successMessage: string;
+  pauseErrorMessage: string;
+  resumeErrorMessage: string;
+  /** 설명 문구용 — 캠페인: "광고 노출", 광고 소재: "노출" */
+  exposureNoun: string;
+}

--- a/src/pages/ads/list/AdsListPage.tsx
+++ b/src/pages/ads/list/AdsListPage.tsx
@@ -1,21 +1,41 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useControlModal } from "@/hooks/ads/useControlModal";
+import type { ICampaign } from "@/types/ads/campaign";
+
+import {
+  type IBulkOperableCopy,
+  useBulkOperableControl,
+} from "@/hooks/ads/useBulkOperableControl";
 import { useUpdateCampaignStatus } from "@/hooks/ads/useUpdateCampaignStatus";
 import { useOverviewCampaignList } from "@/hooks/dashboard/useOverviewCampaignList";
 
+import BulkStatusActionModals from "@/components/ads/BulkStatusActionModals";
 import CampaignTable from "@/components/ads/CampaignTable";
 import AdsListPageSkeleton from "@/components/ads/skeleton/AdsSkeleton";
 import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
-import Modal from "@/components/common/modal/Modal";
-import ModalContent from "@/components/common/modal/ModalContent";
 
-import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+const CAMPAIGN_BULK_COPY: IBulkOperableCopy = {
+  entityName: "캠페인",
+  entityObject: "캠페인을",
+  pauseModalTitle: "캠페인 운영 중단",
+  resumeModalTitle: "캠페인 운영 재개",
+  pauseDetailListTitle: "중단 대상 캠페인",
+  resumeDetailListTitle: "재개 대상 캠페인",
+  successMessage: "캠페인 운영 상태가 반영되었습니다.",
+  pauseErrorMessage: "중단 처리에 실패하였습니다.",
+  resumeErrorMessage: "재개 처리에 실패하였습니다.",
+  exposureNoun: "광고 노출",
+};
+
+const getCampaignId = (campaign: ICampaign) => campaign.projectId;
+const getCampaignLabel = (campaign: ICampaign) => campaign.name;
+const getCampaignStatus = (campaign: ICampaign) => campaign.status;
 
 export default function AdsListPage() {
   const navigate = useNavigate();
@@ -32,12 +52,19 @@ export default function AdsListPage() {
     setSelectedIds(new Set());
   }, [orgId]);
 
-  const [pauseScope, setPauseScope] = useState<"selection" | "all">("all");
-  const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
-
   const clearSelection = useCallback(() => {
     setSelectedIds(new Set());
   }, []);
+
+  const bulk = useBulkOperableControl({
+    items: campaigns,
+    selectedIds,
+    getId: getCampaignId,
+    getLabel: getCampaignLabel,
+    getStatus: getCampaignStatus,
+    copy: CAMPAIGN_BULK_COPY,
+    onSuccess: clearSelection,
+  });
 
   const toggleProject = useCallback((projectId: number) => {
     setSelectedIds((prev) => {
@@ -63,78 +90,6 @@ export default function AdsListPage() {
       return new Set([...prev, ...visibleIds]);
     });
   }, [campaigns]);
-
-  const selectedOngoingIds = useMemo(() => {
-    return [...selectedIds].filter((id) =>
-      campaigns.some((c) => c.projectId === id && c.status === "ON_GOING"),
-    );
-  }, [selectedIds, campaigns]);
-
-  const selectedPausedIds = useMemo(() => {
-    return [...selectedIds].filter((id) =>
-      campaigns.some((c) => c.projectId === id && c.status === "PAUSED"),
-    );
-  }, [selectedIds, campaigns]);
-
-  const ongoingAllCount = useMemo(
-    () => campaigns.filter((c) => c.status === "ON_GOING").length,
-    [campaigns],
-  );
-
-  const pausedAllCount = useMemo(
-    () => campaigns.filter((c) => c.status === "PAUSED").length,
-    [campaigns],
-  );
-
-  const canPause = useMemo(() => {
-    if (selectedOngoingIds.length > 0) return true;
-    return selectedIds.size === 0 && ongoingAllCount > 0;
-  }, [selectedOngoingIds.length, selectedIds.size, ongoingAllCount]);
-
-  const canResume = useMemo(() => {
-    if (selectedPausedIds.length > 0) return true;
-    return selectedIds.size === 0 && pausedAllCount > 0;
-  }, [selectedPausedIds.length, selectedIds.size, pausedAllCount]);
-
-  const bulkStop = useControlModal({
-    successMessage: "캠페인 운영 상태가 반영되었습니다.",
-    errorMessage: "중단 처리에 실패하였습니다.",
-    onSuccess: clearSelection,
-  });
-
-  const bulkResume = useControlModal({
-    successMessage: "캠페인 운영 상태가 반영되었습니다.",
-    errorMessage: "재개 처리에 실패하였습니다.",
-    onSuccess: clearSelection,
-  });
-
-  const openPauseModal = () => {
-    const scope = selectedOngoingIds.length > 0 ? "selection" : "all";
-    setPauseScope(scope);
-    bulkStop.openModal();
-  };
-
-  const openResumeModal = () => {
-    const scope = selectedPausedIds.length > 0 ? "selection" : "all";
-    setResumeScope(scope);
-    bulkResume.openModal();
-  };
-
-  const pauseDetailItems = useMemo(() => {
-    const rows =
-      pauseScope === "selection"
-        ? campaigns.filter((c) => selectedOngoingIds.includes(c.projectId))
-        : campaigns.filter((c) => c.status === "ON_GOING");
-    return rows.map((c) => ({ id: c.projectId, label: c.name }));
-  }, [pauseScope, campaigns, selectedOngoingIds]);
-
-  const resumeDetailItems = useMemo(() => {
-    const rows =
-      resumeScope === "selection"
-        ? campaigns.filter((c) => selectedPausedIds.includes(c.projectId))
-        : campaigns.filter((c) => c.status === "PAUSED");
-    return rows.map((c) => ({ id: c.projectId, label: c.name }));
-  }, [resumeScope, campaigns, selectedPausedIds]);
 
   const handleCampaignClick = (id: number) => {
     navigate(`/ads/${orgId}/${id}`);
@@ -179,8 +134,8 @@ export default function AdsListPage() {
                 size="small"
                 variant="dangerSoft"
                 className="mobile:min-w-0 mobile:flex-1"
-                onClick={openPauseModal}
-                disabled={!canPause || bulkStop.isLoading}
+                onClick={bulk.openPauseModal}
+                disabled={!bulk.canPause || bulk.pauseModal.isLoading}
               >
                 중단
               </Button>
@@ -189,8 +144,8 @@ export default function AdsListPage() {
                 size="small"
                 variant="outline"
                 className="border-info-blue text-info-blue hover:bg-info-blue/5 mobile:min-w-0 mobile:flex-1"
-                onClick={openResumeModal}
-                disabled={!canResume || bulkResume.isLoading}
+                onClick={bulk.openResumeModal}
+                disabled={!bulk.canResume || bulk.resumeModal.isLoading}
               >
                 재개
               </Button>
@@ -224,75 +179,39 @@ export default function AdsListPage() {
         </div>
       </Card>
 
-      <Modal
-        isOpen={bulkStop.isOpen}
-        onClose={bulkStop.closeModal}
-        title="캠페인 운영 중단"
-      >
-        <ModalContent
-          icon={<WarnCircleIcon className="h-7 w-7 text-info-red" />}
-          title={
-            pauseScope === "all"
-              ? "운영 중인 캠페인을 모두 중단할까요?"
-              : "선택한 캠페인을 중단할까요?"
-          }
-          description={
-            pauseScope === "all"
-              ? `운영 중인 ${ongoingAllCount}개 캠페인의 광고 노출이 즉시 중단됩니다.`
-              : `선택한 ${selectedOngoingIds.length}개 캠페인의 광고 노출이 즉시 중단됩니다.`
-          }
-          detailItems={pauseDetailItems}
-          detailListTitle="중단 대상 캠페인"
-          buttonText="중단하기"
-          onConfirm={() =>
-            bulkStop.handleConfirm(() =>
-              mutateCampaignStatus({
-                scope: pauseScope,
-                status: "PAUSED",
-                projectIds:
-                  pauseScope === "selection" ? selectedOngoingIds : undefined,
-              }),
-            )
-          }
-          isLoading={bulkStop.isLoading}
-          variant="danger"
-        />
-      </Modal>
-
-      <Modal
-        isOpen={bulkResume.isOpen}
-        onClose={bulkResume.closeModal}
-        title="캠페인 운영 재개"
-      >
-        <ModalContent
-          icon={<WarnCircleIcon className="h-7 w-7 text-info-blue" />}
-          title={
-            resumeScope === "all"
-              ? "중단된 캠페인을 모두 재개할까요?"
-              : "선택한 캠페인을 재개할까요?"
-          }
-          description={
-            resumeScope === "all"
-              ? `중단된 ${pausedAllCount}개 캠페인의 광고 노출이 즉시 재개됩니다.`
-              : `선택한 ${selectedPausedIds.length}개 캠페인의 광고 노출이 즉시 재개됩니다.`
-          }
-          detailItems={resumeDetailItems}
-          detailListTitle="재개 대상 캠페인"
-          buttonText="재개하기"
-          onConfirm={() =>
-            bulkResume.handleConfirm(() =>
-              mutateCampaignStatus({
-                scope: resumeScope,
-                status: "ON_GOING",
-                projectIds:
-                  resumeScope === "selection" ? selectedPausedIds : undefined,
-              }),
-            )
-          }
-          isLoading={bulkResume.isLoading}
-          variant="primary"
-        />
-      </Modal>
+      <BulkStatusActionModals
+        copy={CAMPAIGN_BULK_COPY}
+        pauseScope={bulk.pauseScope}
+        resumeScope={bulk.resumeScope}
+        selectedOngoingCount={bulk.selectedOngoingIds.length}
+        selectedPausedCount={bulk.selectedPausedIds.length}
+        ongoingAllCount={bulk.ongoingAllCount}
+        pausedAllCount={bulk.pausedAllCount}
+        pauseDetailItems={bulk.pauseDetailItems}
+        resumeDetailItems={bulk.resumeDetailItems}
+        pauseModal={bulk.pauseModal}
+        resumeModal={bulk.resumeModal}
+        onConfirmPause={() =>
+          mutateCampaignStatus({
+            scope: bulk.pauseScope,
+            status: "PAUSED",
+            projectIds:
+              bulk.pauseScope === "selection"
+                ? bulk.selectedOngoingIds
+                : undefined,
+          })
+        }
+        onConfirmResume={() =>
+          mutateCampaignStatus({
+            scope: bulk.resumeScope,
+            status: "ON_GOING",
+            projectIds:
+              bulk.resumeScope === "selection"
+                ? bulk.selectedPausedIds
+                : undefined,
+          })
+        }
+      />
     </section>
   );
 }

--- a/src/pages/ads/list/CampaignDetail.tsx
+++ b/src/pages/ads/list/CampaignDetail.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 
-import type { IPlatformBudgetSummary, TPlatform } from "@/types/ads/campaign";
+import type {
+  IAd,
+  IPlatformBudgetSummary,
+  TPlatform,
+} from "@/types/ads/campaign";
 
 import { AD_PLATFORM_ORDER, groupAdsByPlatform } from "@/utils/ads/adPlatform";
 import {
@@ -11,11 +15,15 @@ import {
 } from "@/utils/ads/projectBudget";
 
 import { useAdList } from "@/hooks/ads/useAdList";
+import {
+  type IBulkOperableCopy,
+  useBulkOperableControl,
+} from "@/hooks/ads/useBulkOperableControl";
 import { useCampaignDetail } from "@/hooks/ads/useCampaignDetail";
-import { useControlModal } from "@/hooks/ads/useControlModal";
 import { useUpdateAdStatus } from "@/hooks/ads/useUpdateAdStatus";
 
 import AdListTable from "@/components/ads/AdListTable";
+import BulkStatusActionModals from "@/components/ads/BulkStatusActionModals";
 import CampaignPlatformSection from "@/components/ads/CampaignPlatformSection";
 import EditPlatformBudgetModal from "@/components/ads/EditPlatformBudgetModal";
 import {
@@ -27,12 +35,26 @@ import Button from "@/components/common/button/Button";
 import Card from "@/components/common/card/Card";
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
-import Modal from "@/components/common/modal/Modal";
-import ModalContent from "@/components/common/modal/ModalContent";
 
-import WarnCircleIcon from "@/assets/icon/common/warn-circle.svg?react";
 import type { TMainLayoutOutletContext } from "@/layout/main/MainLayout";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+const AD_BULK_COPY: IBulkOperableCopy = {
+  entityName: "광고 소재",
+  entityObject: "광고 소재를",
+  pauseModalTitle: "광고 소재 중단",
+  resumeModalTitle: "광고 소재 재개",
+  pauseDetailListTitle: "중단 대상 광고",
+  resumeDetailListTitle: "재개 대상 광고",
+  successMessage: "광고 소재 운영 상태가 반영되었습니다.",
+  pauseErrorMessage: "중단 처리에 실패했습니다.",
+  resumeErrorMessage: "재개 처리에 실패했습니다.",
+  exposureNoun: "노출",
+};
+
+const getAdId = (ad: IAd) => ad.id;
+const getAdLabel = (ad: IAd) => ad.name;
+const getAdStatus = (ad: IAd) => ad.status;
 
 const PLATFORM_WORDMARK: Record<TPlatform, string> = {
   naver: "NAVER",
@@ -91,8 +113,6 @@ export default function CampaignDetail() {
   const [selectedAdIds, setSelectedAdIds] = useState<ReadonlySet<number>>(
     () => new Set(),
   );
-  const [pauseScope, setPauseScope] = useState<"selection" | "all">("all");
-  const [resumeScope, setResumeScope] = useState<"selection" | "all">("all");
 
   const [budgetEditTarget, setBudgetEditTarget] =
     useState<IPlatformBudgetSummary | null>(null);
@@ -101,6 +121,16 @@ export default function CampaignDetail() {
   const clearAdSelection = useCallback(() => {
     setSelectedAdIds(new Set());
   }, []);
+
+  const bulk = useBulkOperableControl({
+    items: adsList,
+    selectedIds: selectedAdIds,
+    getId: getAdId,
+    getLabel: getAdLabel,
+    getStatus: getAdStatus,
+    copy: AD_BULK_COPY,
+    onSuccess: clearAdSelection,
+  });
 
   const toggleAd = useCallback((adId: number) => {
     setSelectedAdIds((prev) => {
@@ -123,82 +153,6 @@ export default function CampaignDetail() {
       return new Set([...prev, ...targetIds]);
     });
   }, []);
-
-  const selectedOngoingIds = useMemo(
-    () =>
-      [...selectedAdIds].filter((id) =>
-        adsList.some((a) => a.id === id && a.status === "ON_GOING"),
-      ),
-    [selectedAdIds, adsList],
-  );
-
-  const selectedPausedIds = useMemo(
-    () =>
-      [...selectedAdIds].filter((id) =>
-        adsList.some((a) => a.id === id && a.status === "PAUSED"),
-      ),
-    [selectedAdIds, adsList],
-  );
-
-  const ongoingAllCount = useMemo(
-    () => adsList.filter((a) => a.status === "ON_GOING").length,
-    [adsList],
-  );
-
-  const pausedAllCount = useMemo(
-    () => adsList.filter((a) => a.status === "PAUSED").length,
-    [adsList],
-  );
-
-  const canPauseAds = useMemo(() => {
-    if (selectedOngoingIds.length > 0) return true;
-    return selectedAdIds.size === 0 && ongoingAllCount > 0;
-  }, [selectedOngoingIds.length, selectedAdIds.size, ongoingAllCount]);
-
-  const canResumeAds = useMemo(() => {
-    if (selectedPausedIds.length > 0) return true;
-    return selectedAdIds.size === 0 && pausedAllCount > 0;
-  }, [selectedPausedIds.length, selectedAdIds.size, pausedAllCount]);
-
-  const bulkAdPause = useControlModal({
-    successMessage: "광고 소재 운영 상태가 반영되었습니다.",
-    errorMessage: "중단 처리에 실패했습니다.",
-    onSuccess: clearAdSelection,
-  });
-
-  const bulkAdResume = useControlModal({
-    successMessage: "광고 소재 운영 상태가 반영되었습니다.",
-    errorMessage: "재개 처리에 실패했습니다.",
-    onSuccess: clearAdSelection,
-  });
-
-  const openAdPauseModal = () => {
-    const scope = selectedOngoingIds.length > 0 ? "selection" : "all";
-    setPauseScope(scope);
-    bulkAdPause.openModal();
-  };
-
-  const openAdResumeModal = () => {
-    const scope = selectedPausedIds.length > 0 ? "selection" : "all";
-    setResumeScope(scope);
-    bulkAdResume.openModal();
-  };
-
-  const pauseAdDetailItems = useMemo(() => {
-    const rows =
-      pauseScope === "selection"
-        ? adsList.filter((a) => selectedOngoingIds.includes(a.id))
-        : adsList.filter((a) => a.status === "ON_GOING");
-    return rows.map((a) => ({ id: a.id, label: a.name }));
-  }, [pauseScope, adsList, selectedOngoingIds]);
-
-  const resumeAdDetailItems = useMemo(() => {
-    const rows =
-      resumeScope === "selection"
-        ? adsList.filter((a) => selectedPausedIds.includes(a.id))
-        : adsList.filter((a) => a.status === "PAUSED");
-    return rows.map((a) => ({ id: a.id, label: a.name }));
-  }, [resumeScope, adsList, selectedPausedIds]);
 
   const platformBudgets = useMemo(
     () =>
@@ -356,8 +310,8 @@ export default function CampaignDetail() {
                 size="small"
                 variant="dangerSoft"
                 className="mobile:min-w-0 mobile:flex-1"
-                onClick={openAdPauseModal}
-                disabled={!canPauseAds || bulkAdPause.isLoading}
+                onClick={bulk.openPauseModal}
+                disabled={!bulk.canPause || bulk.pauseModal.isLoading}
               >
                 중단
               </Button>
@@ -366,8 +320,8 @@ export default function CampaignDetail() {
                 size="small"
                 variant="outline"
                 className="border-info-blue text-info-blue hover:bg-info-blue/5 mobile:min-w-0 mobile:flex-1"
-                onClick={openAdResumeModal}
-                disabled={!canResumeAds || bulkAdResume.isLoading}
+                onClick={bulk.openResumeModal}
+                disabled={!bulk.canResume || bulk.resumeModal.isLoading}
               >
                 재개
               </Button>
@@ -423,81 +377,39 @@ export default function CampaignDetail() {
         </Card>
       )}
 
-      <Modal
-        isOpen={bulkAdPause.isOpen}
-        onClose={bulkAdPause.closeModal}
-        title="광고 소재 중단"
-      >
-        <ModalContent
-          icon={<WarnCircleIcon className="h-7 w-7 text-info-red" />}
-          title={
-            pauseScope === "all"
-              ? "운영 중인 광고 소재를 모두 중단할까요?"
-              : "선택한 광고 소재를 중단할까요?"
-          }
-          description={
-            pauseScope === "all"
-              ? `운영 중인 ${ongoingAllCount}개 광고 소재의 노출이 즉시 중단됩니다.`
-              : `선택한 ${selectedOngoingIds.length}개 광고 소재의 노출이 즉시 중단됩니다.`
-          }
-          detailItems={pauseAdDetailItems}
-          detailListTitle="중단 대상 광고"
-          buttonText="중단하기"
-          onConfirm={() =>
-            bulkAdPause.handleConfirm(() =>
-              mutateAdStatus({
-                adContentIds:
-                  pauseScope === "all"
-                    ? adsList
-                        .filter((a) => a.status === "ON_GOING")
-                        .map((a) => a.id)
-                    : selectedOngoingIds,
-                status: "PAUSED",
-              }),
-            )
-          }
-          isLoading={bulkAdPause.isLoading}
-          variant="danger"
-        />
-      </Modal>
-
-      <Modal
-        isOpen={bulkAdResume.isOpen}
-        onClose={bulkAdResume.closeModal}
-        title="광고 소재 재개"
-      >
-        <ModalContent
-          icon={<WarnCircleIcon className="h-7 w-7 text-info-blue" />}
-          title={
-            resumeScope === "all"
-              ? "중단된 광고 소재를 모두 재개할까요?"
-              : "선택한 광고 소재를 재개할까요?"
-          }
-          description={
-            resumeScope === "all"
-              ? `중단된 ${pausedAllCount}개 광고 소재의 노출이 즉시 재개됩니다.`
-              : `선택한 ${selectedPausedIds.length}개 광고 소재의 노출이 즉시 재개됩니다.`
-          }
-          detailItems={resumeAdDetailItems}
-          detailListTitle="재개 대상 광고"
-          buttonText="재개하기"
-          onConfirm={() =>
-            bulkAdResume.handleConfirm(() =>
-              mutateAdStatus({
-                adContentIds:
-                  resumeScope === "all"
-                    ? adsList
-                        .filter((a) => a.status === "PAUSED")
-                        .map((a) => a.id)
-                    : selectedPausedIds,
-                status: "ON_GOING",
-              }),
-            )
-          }
-          isLoading={bulkAdResume.isLoading}
-          variant="primary"
-        />
-      </Modal>
+      <BulkStatusActionModals
+        copy={AD_BULK_COPY}
+        pauseScope={bulk.pauseScope}
+        resumeScope={bulk.resumeScope}
+        selectedOngoingCount={bulk.selectedOngoingIds.length}
+        selectedPausedCount={bulk.selectedPausedIds.length}
+        ongoingAllCount={bulk.ongoingAllCount}
+        pausedAllCount={bulk.pausedAllCount}
+        pauseDetailItems={bulk.pauseDetailItems}
+        resumeDetailItems={bulk.resumeDetailItems}
+        pauseModal={bulk.pauseModal}
+        resumeModal={bulk.resumeModal}
+        onConfirmPause={() =>
+          mutateAdStatus({
+            adContentIds:
+              bulk.pauseScope === "all"
+                ? adsList
+                    .filter((a) => a.status === "ON_GOING")
+                    .map((a) => a.id)
+                : bulk.selectedOngoingIds,
+            status: "PAUSED",
+          })
+        }
+        onConfirmResume={() =>
+          mutateAdStatus({
+            adContentIds:
+              bulk.resumeScope === "all"
+                ? adsList.filter((a) => a.status === "PAUSED").map((a) => a.id)
+                : bulk.selectedPausedIds,
+            status: "ON_GOING",
+          })
+        }
+      />
       {orgIdNum != null && projectIdNum != null ? (
         <EditPlatformBudgetModal
           isOpen={isBudgetEditOpen}


### PR DESCRIPTION
## 🚨 관련 이슈
close #507 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

### 추가
- `src/hooks/ads/useBulkOperableControl.ts`
  - 선택 상태 기반 `canPause` / `canResume` 계산
  - `scope`(`selection` | `all`) 결정
  - 모달 대상 목록(`pauseDetailItems` / `resumeDetailItems`)
  - `useControlModal` × 2 래핑
- `src/components/ads/BulkStatusActionModals.tsx`
  - 중단/재개 확인 모달 UI 공통화
  - `IBulkOperableCopy`로 캠페인·광고 소재 문구 분기

### 수정
- `src/pages/ads/list/AdsListPage.tsx`
  - 중복 로직 제거 후 훅·컴포넌트 적용
  - mutation은 기존과 동일하게 `scope` + `projectIds` 사용
- `src/pages/ads/list/CampaignDetail.tsx`
  - 동일 패턴 적용
  - mutation은 기존과 동일하게 `adContentIds` 배열 구성

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 광고 캠페인과 소재를 선택 항목 또는 전체 대상으로 일괄 일시중지하거나 재개할 수 있습니다.
  - 실행 전 대상, 진행 중인 항목 수, 일시중지된 항목 수를 확인하는 안내 모달을 제공합니다.
  - 작업 진행 중 로딩 상태를 표시하고, 완료 또는 오류 결과를 안내합니다.

- **개선**
  - 캠페인 목록과 상세 화면에서 일괄 상태 변경 흐름과 확인 UI를 일관되게 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->