### PR TITLE
[Refactor/#508] 플랫폼 연동 페이지 훅 분리

### DIFF
--- a/src/api/integration/naver.ts
+++ b/src/api/integration/naver.ts
@@ -48,7 +48,7 @@ export async function syncNaverAdData(
   body: INaverSyncRequest,
 ): Promise<INaverSyncData> {
   const { data } = await axiosInstance.post<ICommonResponse<INaverSyncData>>(
-    `/api/naver/${orgId}/sync`,
+    `/api/naver/organizations/${orgId}/sync`,
     body,
   );
   return data.data;

--- a/src/hooks/integration/usePlatformConnectionActions.ts
+++ b/src/hooks/integration/usePlatformConnectionActions.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -7,9 +8,11 @@ import type {
   TIntegrationProvider,
 } from "@/types/integration/platformConnection";
 
+import type { TNaverSyncFormValues } from "@/utils/integration/naverSyncSchema";
 import { startPlatformConnect } from "@/utils/integration/startPlatformConnect";
 
 import { useCoreMutation } from "@/hooks/customQuery";
+import { usePlatformSyncMutations } from "@/hooks/integration/usePlatformSyncMutations";
 import { useRequireOrgId } from "@/hooks/integration/useRequireOrgId";
 
 import {
@@ -30,6 +33,8 @@ interface IUsePlatformConnectionActionsParams {
   platformConnections: IPlatformConnectionItem[];
   disconnectTarget: TDisconnectTarget | null;
   onOpenNaverConnect: (mode: TNaverConnectMode, customerId?: string) => void;
+  onOpenNaverSync: () => void;
+  onNaverSyncSuccess?: () => void;
   onRequestDisconnect: (target: TDisconnectTarget) => void;
   onDisconnectSuccess?: () => void;
 }
@@ -38,11 +43,21 @@ export function usePlatformConnectionActions({
   platformConnections,
   disconnectTarget,
   onOpenNaverConnect,
+  onOpenNaverSync,
+  onNaverSyncSuccess,
   onRequestDisconnect,
   onDisconnectSuccess,
 }: IUsePlatformConnectionActionsParams) {
   const queryClient = useQueryClient();
   const { requireOrgId } = useRequireOrgId();
+  const [syncingProvider, setSyncingProvider] =
+    useState<TIntegrationProvider | null>(null);
+
+  const { syncMeta, syncGoogle, syncNaver, isSyncPending, isNaverSyncPending } =
+    usePlatformSyncMutations({
+      onSyncSettled: () => setSyncingProvider(null),
+      onNaverSyncSuccess,
+    });
 
   const invalidateConnections = async (requestOrgId: number) => {
     await queryClient.invalidateQueries({
@@ -157,11 +172,50 @@ export function usePlatformConnectionActions({
     });
   };
 
+  const handleSync = (provider: TIntegrationProvider) => {
+    const orgId = requireOrgId();
+    if (orgId == null) return;
+
+    if (isSyncPending) return;
+
+    const item = platformConnections.find((p) => p.provider === provider);
+    if (item?.status !== "connected") return;
+
+    if (provider === "NAVER") {
+      onOpenNaverSync();
+      return;
+    }
+
+    setSyncingProvider(provider);
+
+    if (provider === "META") {
+      syncMeta(orgId);
+      return;
+    }
+
+    if (provider === "GOOGLE") {
+      syncGoogle(orgId);
+    }
+  };
+
+  const handleNaverSyncSubmit = (values: TNaverSyncFormValues) => {
+    const orgId = requireOrgId();
+    if (orgId == null || isNaverSyncPending) return;
+
+    setSyncingProvider("NAVER");
+    syncNaver(orgId, values);
+  };
+
   return {
     handleConnect,
     handleDisconnect,
     handleConfirmDisconnect,
+    handleSync,
+    handleNaverSyncSubmit,
     disconnectMutation,
     reconnectMutation,
+    isSyncPending,
+    isNaverSyncPending,
+    syncingProvider,
   };
 }

--- a/src/hooks/integration/usePlatformConnectionActions.ts
+++ b/src/hooks/integration/usePlatformConnectionActions.ts
@@ -1,7 +1,16 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
+import type { IApiErrorResponse } from "@/types/common/common";
+import type {
+  IPlatformConnectionItem,
+  TIntegrationProvider,
+} from "@/types/integration/platformConnection";
+
+import { startPlatformConnect } from "@/utils/integration/startPlatformConnect";
+
 import { useCoreMutation } from "@/hooks/customQuery";
+import { useRequireOrgId } from "@/hooks/integration/useRequireOrgId";
 
 import {
   disconnectPlatformAccount,
@@ -9,17 +18,31 @@ import {
 } from "@/api/integration/platformAccounts";
 import { QUERY_KEYS } from "@/lib/queryKeys";
 
-interface IUsePlatformConnectionActionsOptions {
-  /** 연동 해제 성공 — 해제 모달 닫기 */
+export type TNaverConnectMode = "connect" | "reconnect";
+
+export type TDisconnectTarget = {
+  orgId: number;
+  provider: TIntegrationProvider;
+  platformAccountId: number;
+};
+
+interface IUsePlatformConnectionActionsParams {
+  platformConnections: IPlatformConnectionItem[];
+  disconnectTarget: TDisconnectTarget | null;
+  onOpenNaverConnect: (mode: TNaverConnectMode, customerId?: string) => void;
+  onRequestDisconnect: (target: TDisconnectTarget) => void;
   onDisconnectSuccess?: () => void;
 }
 
-/** 플랫폼 연동 해제·재연동 mutation */
-export function usePlatformConnectionActions(
-  options?: IUsePlatformConnectionActionsOptions,
-) {
+export function usePlatformConnectionActions({
+  platformConnections,
+  disconnectTarget,
+  onOpenNaverConnect,
+  onRequestDisconnect,
+  onDisconnectSuccess,
+}: IUsePlatformConnectionActionsParams) {
   const queryClient = useQueryClient();
-  const { onDisconnectSuccess } = options ?? {};
+  const { requireOrgId } = useRequireOrgId();
 
   const invalidateConnections = async (requestOrgId: number) => {
     await queryClient.invalidateQueries({
@@ -62,7 +85,82 @@ export function usePlatformConnectionActions(
     },
   );
 
+  const startNewConnect = async (provider: TIntegrationProvider) => {
+    const orgId = requireOrgId();
+    if (orgId == null) return;
+
+    if (provider === "NAVER") {
+      onOpenNaverConnect("connect");
+      return;
+    }
+
+    try {
+      await startPlatformConnect(provider, orgId);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : ((err as IApiErrorResponse)?.message ??
+            "플랫폼 연동을 시작하지 못했습니다. 다시 시도해 주세요.");
+      toast.error(message);
+    }
+  };
+
+  const handleConnect = async (provider: TIntegrationProvider) => {
+    const orgId = requireOrgId();
+    if (orgId == null) return;
+
+    const item = platformConnections.find((p) => p.provider === provider);
+    if (item?.status === "disconnected" && item.platformAccountId != null) {
+      if (reconnectMutation.isPending) return;
+      reconnectMutation.mutate({
+        orgId,
+        accountId: item.platformAccountId,
+      });
+      return;
+    }
+
+    if (provider === "NAVER") {
+      const naverItem = platformConnections.find((p) => p.provider === "NAVER");
+
+      if (naverItem?.platformAccountId != null) {
+        onOpenNaverConnect("reconnect", naverItem.externalAccountId);
+        return;
+      }
+    }
+
+    await startNewConnect(provider);
+  };
+
+  const handleDisconnect = (item: IPlatformConnectionItem) => {
+    const orgId = requireOrgId();
+    if (orgId == null) return;
+
+    if (item.platformAccountId == null) {
+      toast.error("연동 계정 정보를 찾을 수 없습니다.");
+      return;
+    }
+
+    onRequestDisconnect({
+      orgId,
+      provider: item.provider,
+      platformAccountId: item.platformAccountId,
+    });
+  };
+
+  const handleConfirmDisconnect = () => {
+    if (disconnectTarget == null || disconnectMutation.isPending) return;
+
+    disconnectMutation.mutate({
+      orgId: disconnectTarget.orgId,
+      accountId: disconnectTarget.platformAccountId,
+    });
+  };
+
   return {
+    handleConnect,
+    handleDisconnect,
+    handleConfirmDisconnect,
     disconnectMutation,
     reconnectMutation,
   };

--- a/src/hooks/integration/usePlatformConnectionActions.ts
+++ b/src/hooks/integration/usePlatformConnectionActions.ts
@@ -1,0 +1,69 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { useCoreMutation } from "@/hooks/customQuery";
+
+import {
+  disconnectPlatformAccount,
+  reconnectPlatformAccount,
+} from "@/api/integration/platformAccounts";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+
+interface IUsePlatformConnectionActionsOptions {
+  /** 연동 해제 성공 — 해제 모달 닫기 */
+  onDisconnectSuccess?: () => void;
+}
+
+/** 플랫폼 연동 해제·재연동 mutation */
+export function usePlatformConnectionActions(
+  options?: IUsePlatformConnectionActionsOptions,
+) {
+  const queryClient = useQueryClient();
+  const { onDisconnectSuccess } = options ?? {};
+
+  const invalidateConnections = async (requestOrgId: number) => {
+    await queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.platform.connections(requestOrgId),
+    });
+  };
+
+  const disconnectMutation = useCoreMutation<
+    void,
+    { orgId: number; accountId: number }
+  >(
+    ({ orgId: requestOrgId, accountId }) =>
+      disconnectPlatformAccount(requestOrgId, accountId),
+    {
+      userOnSuccess: async (_, { orgId: requestOrgId }) => {
+        await invalidateConnections(requestOrgId);
+        toast.success("광고 계정 연동을 해제했습니다.");
+        onDisconnectSuccess?.();
+      },
+      userOnError: (apiError) => {
+        toast.error(apiError.message ?? "연동 해제에 실패했습니다.");
+      },
+    },
+  );
+
+  const reconnectMutation = useCoreMutation<
+    void,
+    { orgId: number; accountId: number }
+  >(
+    ({ orgId: requestOrgId, accountId }) =>
+      reconnectPlatformAccount(requestOrgId, accountId),
+    {
+      userOnSuccess: async (_, { orgId: requestOrgId }) => {
+        await invalidateConnections(requestOrgId);
+        toast.success("광고 계정을 다시 연동했습니다.");
+      },
+      userOnError: (apiError) => {
+        toast.error(apiError.message ?? "재연동에 실패했습니다.");
+      },
+    },
+  );
+
+  return {
+    disconnectMutation,
+    reconnectMutation,
+  };
+}

--- a/src/hooks/integration/useRequireOrgId.ts
+++ b/src/hooks/integration/useRequireOrgId.ts
@@ -1,0 +1,20 @@
+import { toast } from "sonner";
+
+import useWorkspaceStore from "@/store/useWorkspaceStore";
+
+const WORKSPACE_REQUIRED_MESSAGE = "워크스페이스를 선택해 주세요.";
+
+/** 연동 액션 전 워크스페이스 선택 여부 확인. 없으면 toast 후 null */
+export function useRequireOrgId() {
+  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+
+  const requireOrgId = (): number | null => {
+    if (orgId == null) {
+      toast.error(WORKSPACE_REQUIRED_MESSAGE);
+      return null;
+    }
+    return orgId;
+  };
+
+  return { orgId, requireOrgId };
+}

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { IApiErrorResponse } from "@/types/common/common";
@@ -11,7 +10,7 @@ import type {
 import type { TNaverSyncFormValues } from "@/utils/integration/naverSyncSchema";
 import { startPlatformConnect } from "@/utils/integration/startPlatformConnect";
 
-import { useCoreMutation } from "@/hooks/customQuery";
+import { usePlatformConnectionActions } from "@/hooks/integration/usePlatformConnectionActions";
 import { usePlatformConnections } from "@/hooks/integration/usePlatformConnections";
 import { usePlatformSyncMutations } from "@/hooks/integration/usePlatformSyncMutations";
 
@@ -27,11 +26,6 @@ import {
   KakaoUpcomingCard,
 } from "@/components/integration/UpcomingPlatformCard";
 
-import {
-  disconnectPlatformAccount,
-  reconnectPlatformAccount,
-} from "@/api/integration/platformAccounts";
-import { QUERY_KEYS } from "@/lib/queryKeys";
 import useWorkspaceStore from "@/store/useWorkspaceStore";
 
 type TDisconnectTarget = {
@@ -41,7 +35,6 @@ type TDisconnectTarget = {
 };
 
 export default function PlatformIntegrationsPage() {
-  const queryClient = useQueryClient();
   const orgId = useWorkspaceStore((s) => s.selectedOrgId);
   const [isNaverModalOpen, setIsNaverModalOpen] = useState(false);
   const [naverModalMode, setNaverModalMode] = useState<"connect" | "reconnect">(
@@ -62,44 +55,10 @@ export default function PlatformIntegrationsPage() {
     error,
   } = usePlatformConnections();
 
-  const disconnectMutation = useCoreMutation<
-    void,
-    { orgId: number; accountId: number }
-  >(
-    ({ orgId: requestOrgId, accountId }) =>
-      disconnectPlatformAccount(requestOrgId, accountId),
-    {
-      userOnSuccess: async (_, { orgId: requestOrgId }) => {
-        await queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.platform.connections(requestOrgId),
-        });
-        toast.success("광고 계정 연동을 해제했습니다.");
-        setDisconnectTarget(null);
-      },
-      userOnError: (apiError) => {
-        toast.error(apiError.message ?? "연동 해제에 실패했습니다.");
-      },
-    },
-  );
-
-  const reconnectMutation = useCoreMutation<
-    void,
-    { orgId: number; accountId: number }
-  >(
-    ({ orgId: requestOrgId, accountId }) =>
-      reconnectPlatformAccount(requestOrgId, accountId),
-    {
-      userOnSuccess: async (_, { orgId: requestOrgId }) => {
-        await queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.platform.connections(requestOrgId),
-        });
-        toast.success("광고 계정을 다시 연동했습니다.");
-      },
-      userOnError: (apiError) => {
-        toast.error(apiError.message ?? "재연동에 실패했습니다.");
-      },
-    },
-  );
+  const { disconnectMutation, reconnectMutation } =
+    usePlatformConnectionActions({
+      onDisconnectSuccess: () => setDisconnectTarget(null),
+    });
 
   const { syncMeta, syncGoogle, syncNaver, isSyncPending, isNaverSyncPending } =
     usePlatformSyncMutations({

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -1,18 +1,16 @@
 import { useState } from "react";
-import { toast } from "sonner";
 
-import type { IApiErrorResponse } from "@/types/common/common";
-import type {
-  IPlatformConnectionItem,
-  TIntegrationProvider,
-} from "@/types/integration/platformConnection";
+import type { TIntegrationProvider } from "@/types/integration/platformConnection";
 
 import type { TNaverSyncFormValues } from "@/utils/integration/naverSyncSchema";
-import { startPlatformConnect } from "@/utils/integration/startPlatformConnect";
 
-import { usePlatformConnectionActions } from "@/hooks/integration/usePlatformConnectionActions";
+import {
+  type TDisconnectTarget,
+  usePlatformConnectionActions,
+} from "@/hooks/integration/usePlatformConnectionActions";
 import { usePlatformConnections } from "@/hooks/integration/usePlatformConnections";
 import { usePlatformSyncMutations } from "@/hooks/integration/usePlatformSyncMutations";
+import { useRequireOrgId } from "@/hooks/integration/useRequireOrgId";
 
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
 import { ErrorBoundary } from "@/components/common/error/ErrorBoundary";
@@ -26,16 +24,8 @@ import {
   KakaoUpcomingCard,
 } from "@/components/integration/UpcomingPlatformCard";
 
-import useWorkspaceStore from "@/store/useWorkspaceStore";
-
-type TDisconnectTarget = {
-  orgId: number;
-  provider: TIntegrationProvider;
-  platformAccountId: number;
-};
-
 export default function PlatformIntegrationsPage() {
-  const orgId = useWorkspaceStore((s) => s.selectedOrgId);
+  const { orgId, requireOrgId } = useRequireOrgId();
   const [isNaverModalOpen, setIsNaverModalOpen] = useState(false);
   const [naverModalMode, setNaverModalMode] = useState<"connect" | "reconnect">(
     "connect",
@@ -55,10 +45,23 @@ export default function PlatformIntegrationsPage() {
     error,
   } = usePlatformConnections();
 
-  const { disconnectMutation, reconnectMutation } =
-    usePlatformConnectionActions({
-      onDisconnectSuccess: () => setDisconnectTarget(null),
-    });
+  const {
+    handleConnect,
+    handleDisconnect,
+    handleConfirmDisconnect,
+    disconnectMutation,
+    reconnectMutation,
+  } = usePlatformConnectionActions({
+    platformConnections,
+    disconnectTarget,
+    onOpenNaverConnect: (mode, customerId) => {
+      setNaverModalMode(mode);
+      setNaverCustomerId(customerId);
+      setIsNaverModalOpen(true);
+    },
+    onRequestDisconnect: setDisconnectTarget,
+    onDisconnectSuccess: () => setDisconnectTarget(null),
+  });
 
   const { syncMeta, syncGoogle, syncNaver, isSyncPending, isNaverSyncPending } =
     usePlatformSyncMutations({
@@ -70,91 +73,9 @@ export default function PlatformIntegrationsPage() {
     setIsNaverSyncModalOpen(true);
   };
 
-  const startNewConnect = async (provider: TIntegrationProvider) => {
-    if (orgId == null) {
-      toast.error("워크스페이스를 선택해 주세요.");
-      return;
-    }
-
-    if (provider === "NAVER") {
-      setNaverModalMode("connect");
-      setNaverCustomerId(undefined);
-      setIsNaverModalOpen(true);
-      return;
-    }
-
-    try {
-      await startPlatformConnect(provider, orgId);
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : ((err as IApiErrorResponse)?.message ??
-            "플랫폼 연동을 시작하지 못했습니다. 다시 시도해 주세요.");
-      toast.error(message);
-    }
-  };
-
-  const handleConnect = async (provider: TIntegrationProvider) => {
-    if (orgId == null) {
-      toast.error("워크스페이스를 선택해 주세요.");
-      return;
-    }
-
-    const item = platformConnections.find((p) => p.provider === provider);
-    if (item?.status === "disconnected" && item.platformAccountId != null) {
-      if (reconnectMutation.isPending) return;
-      reconnectMutation.mutate({
-        orgId,
-        accountId: item.platformAccountId,
-      });
-      return;
-    }
-
-    if (provider === "NAVER") {
-      const naverItem = platformConnections.find((p) => p.provider === "NAVER");
-
-      if (naverItem?.platformAccountId != null) {
-        setNaverModalMode("reconnect");
-        setNaverCustomerId(naverItem.externalAccountId);
-        setIsNaverModalOpen(true);
-        return;
-      }
-    }
-
-    await startNewConnect(provider);
-  };
-
-  const handleDisconnect = (item: IPlatformConnectionItem) => {
-    if (orgId == null) {
-      toast.error("워크스페이스를 선택해 주세요.");
-      return;
-    }
-    if (item.platformAccountId == null) {
-      toast.error("연동 계정 정보를 찾을 수 없습니다.");
-      return;
-    }
-    setDisconnectTarget({
-      orgId,
-      provider: item.provider,
-      platformAccountId: item.platformAccountId,
-    });
-  };
-
-  const handleConfirmDisconnect = () => {
-    if (disconnectTarget == null || disconnectMutation.isPending) return;
-
-    disconnectMutation.mutate({
-      orgId: disconnectTarget.orgId,
-      accountId: disconnectTarget.platformAccountId,
-    });
-  };
-
   const handleSync = (provider: TIntegrationProvider) => {
-    if (orgId == null) {
-      toast.error("워크스페이스를 선택해 주세요.");
-      return;
-    }
+    const currentOrgId = requireOrgId();
+    if (currentOrgId == null) return;
 
     if (isSyncPending) return;
 
@@ -169,12 +90,12 @@ export default function PlatformIntegrationsPage() {
     setSyncingProvider(provider);
 
     if (provider === "META") {
-      syncMeta(orgId);
+      syncMeta(currentOrgId);
       return;
     }
 
     if (provider === "GOOGLE") {
-      syncGoogle(orgId);
+      syncGoogle(currentOrgId);
     }
   };
 

--- a/src/pages/integration/PlatformIntegrationsPage.tsx
+++ b/src/pages/integration/PlatformIntegrationsPage.tsx
@@ -1,15 +1,10 @@
 import { useState } from "react";
 
-import type { TIntegrationProvider } from "@/types/integration/platformConnection";
-
-import type { TNaverSyncFormValues } from "@/utils/integration/naverSyncSchema";
-
 import {
   type TDisconnectTarget,
   usePlatformConnectionActions,
 } from "@/hooks/integration/usePlatformConnectionActions";
 import { usePlatformConnections } from "@/hooks/integration/usePlatformConnections";
-import { usePlatformSyncMutations } from "@/hooks/integration/usePlatformSyncMutations";
 import { useRequireOrgId } from "@/hooks/integration/useRequireOrgId";
 
 import AreaErrorFallback from "@/components/common/error/AreaErrorFallback";
@@ -25,16 +20,13 @@ import {
 } from "@/components/integration/UpcomingPlatformCard";
 
 export default function PlatformIntegrationsPage() {
-  const { orgId, requireOrgId } = useRequireOrgId();
+  const { orgId } = useRequireOrgId();
   const [isNaverModalOpen, setIsNaverModalOpen] = useState(false);
   const [naverModalMode, setNaverModalMode] = useState<"connect" | "reconnect">(
     "connect",
   );
   const [naverCustomerId, setNaverCustomerId] = useState<string | undefined>();
   const [isNaverSyncModalOpen, setIsNaverSyncModalOpen] = useState(false);
-  const [syncingProvider, setSyncingProvider] =
-    useState<TIntegrationProvider | null>(null);
-
   const [disconnectTarget, setDisconnectTarget] =
     useState<TDisconnectTarget | null>(null);
 
@@ -49,8 +41,13 @@ export default function PlatformIntegrationsPage() {
     handleConnect,
     handleDisconnect,
     handleConfirmDisconnect,
+    handleSync,
+    handleNaverSyncSubmit,
     disconnectMutation,
     reconnectMutation,
+    isSyncPending,
+    isNaverSyncPending,
+    syncingProvider,
   } = usePlatformConnectionActions({
     platformConnections,
     disconnectTarget,
@@ -59,52 +56,11 @@ export default function PlatformIntegrationsPage() {
       setNaverCustomerId(customerId);
       setIsNaverModalOpen(true);
     },
+    onOpenNaverSync: () => setIsNaverSyncModalOpen(true),
+    onNaverSyncSuccess: () => setIsNaverSyncModalOpen(false),
     onRequestDisconnect: setDisconnectTarget,
     onDisconnectSuccess: () => setDisconnectTarget(null),
   });
-
-  const { syncMeta, syncGoogle, syncNaver, isSyncPending, isNaverSyncPending } =
-    usePlatformSyncMutations({
-      onSyncSettled: () => setSyncingProvider(null),
-      onNaverSyncSuccess: () => setIsNaverSyncModalOpen(false),
-    });
-
-  const handleNaverConnectSuccess = () => {
-    setIsNaverSyncModalOpen(true);
-  };
-
-  const handleSync = (provider: TIntegrationProvider) => {
-    const currentOrgId = requireOrgId();
-    if (currentOrgId == null) return;
-
-    if (isSyncPending) return;
-
-    const item = platformConnections.find((p) => p.provider === provider);
-    if (item?.status !== "connected") return;
-
-    if (provider === "NAVER") {
-      setIsNaverSyncModalOpen(true);
-      return;
-    }
-
-    setSyncingProvider(provider);
-
-    if (provider === "META") {
-      syncMeta(currentOrgId);
-      return;
-    }
-
-    if (provider === "GOOGLE") {
-      syncGoogle(currentOrgId);
-    }
-  };
-
-  const handleNaverSyncSubmit = (values: TNaverSyncFormValues) => {
-    if (orgId == null || isNaverSyncPending) return;
-
-    setSyncingProvider("NAVER");
-    syncNaver(orgId, values);
-  };
 
   return (
     <section className="flex w-full min-w-0 flex-col gap-6">
@@ -174,7 +130,7 @@ export default function PlatformIntegrationsPage() {
           orgId={orgId}
           mode={naverModalMode}
           initialCustomerId={naverCustomerId}
-          onConnectSuccess={handleNaverConnectSuccess}
+          onConnectSuccess={() => setIsNaverSyncModalOpen(true)}
         />
       ) : null}
       {orgId != null ? (

--- a/src/utils/integration/platformSync.ts
+++ b/src/utils/integration/platformSync.ts
@@ -54,7 +54,7 @@ export function getPlatformSyncToast(
   if ("message" in data) {
     return {
       type: "success",
-      message: data.message || `${label} 데이터를 동기화했습니다.`,
+      message: `${label} 데이터를 동기화했습니다.`,
     };
   }
 


### PR DESCRIPTION
## 🚨 관련 이슈

close #508 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [X] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

`PlatformIntegrationsPage`에 몰려 있던 연동/해제/재연동/동기화 흐름을 훅으로 분리했습니다. 페이지는 카드 렌더링과 모달 열고 닫기만 담당합니다.
### 훅 분리

- `src/hooks/integration/useRequireOrgId.ts`
  - 워크스페이스 미선택 시 toast 후 `null` 반환
- `src/hooks/integration/usePlatformConnectionActions.ts`
  - 연동 / 재연동 / 해제 mutation
  - connect·disconnect·sync 시작 핸들러
  - 기존 `usePlatformSyncMutations` 재사용
- `src/pages/integration/PlatformIntegrationsPage.tsx`
  - 렌더·모달 상태 위주로 슬림화

### 테스트 중 함께 수정
- 네이버 동기화 API 경로: `/api/naver/{orgId}/sync` → `/api/naver/organizations/{orgId}/sync`
- Google 동기화 완료 토스트: 서버 `message` 대신 Meta/Naver와 동일하게 `Google 데이터를 동기화했습니다.`

### 동작
- 연동/해제/재연동/sync UI·흐름은 기존과 동일
- 네이버 모달은 훅이 `onOpenNaverConnect` / `onOpenNaverSync`로 열도록 페이지에 위임

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 플랫폼 계정의 연결, 재연결, 해제 및 상태 갱신 흐름을 개선했습니다.
  * Meta, Google, Naver 데이터 동기화를 일관된 방식으로 지원합니다.
  * 워크스페이스가 선택되지 않은 경우 안내 메시지를 표시합니다.

* **버그 수정**
  * Naver 광고 데이터 동기화 요청 경로를 올바르게 수정했습니다.
  * 동기화 성공 메시지가 일관된 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->