### PR TITLE
[Bugfix/#512] 광고 상세 랜딩 URL 입력 및 트래킹 발급 연동

### DIFF
--- a/src/components/ads/AdDetailContent.tsx
+++ b/src/components/ads/AdDetailContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
@@ -34,6 +35,14 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
   });
 
   const isTrackingActive = !!ad.trackingUrl && ad.trackingUrl.length > 0;
+
+  const [landingUrlInput, setLandingUrlInput] = useState(ad.landingUrl ?? "");
+
+  useEffect(() => {
+    setLandingUrlInput(ad.landingUrl ?? "");
+  }, [ad.id, ad.landingUrl]);
+
+  const landingUrlValue = landingUrlInput.trim();
 
   //targetInfo 변환
   const targetTags = () => {
@@ -96,17 +105,26 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
               랜딩 URL
             </h3>
             <div className="relative w-full max-w-160">
-              <div className="flex h-9 w-full items-center justify-between rounded-lg border border-surface-400 bg-surface-100 px-4 py-2 transition-colors hover:border-primary-200">
-                <span className="truncate pr-10 font-body2 text-text-auth-sub select-all">
-                  {ad.landingUrl}
-                </span>
+              <div className="flex h-9 w-full items-center justify-between rounded-lg border border-surface-400 bg-surface-100 px-4 py-2 transition-colors focus-within:border-primary-200 hover:border-primary-200">
+                <input
+                  type="url"
+                  value={landingUrlInput}
+                  readOnly={isTrackingActive}
+                  placeholder="https://example.com"
+                  onChange={(e) => setLandingUrlInput(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  className="min-w-0 flex-1 truncate border-none bg-transparent pr-2 font-body2 text-text-auth-sub outline-none placeholder:text-text-placeholder read-only:cursor-default disabled:cursor-not-allowed"
+                  aria-label="랜딩 URL"
+                />
                 <button
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    ad.landingUrl && handleCopy(ad.landingUrl);
+                    landingUrlValue && handleCopy(landingUrlValue);
                   }}
-                  className="shrink-0 p-1 text-text-placeholder transition-colors hover:text-primary-500"
+                  disabled={!landingUrlValue}
+                  className="shrink-0 p-1 text-text-placeholder transition-colors hover:text-primary-500 disabled:cursor-not-allowed disabled:opacity-40"
                   title="링크 복사"
                 >
                   <LinkIcon className="h-5 w-5" />
@@ -174,15 +192,15 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
           buttonText="발급하기"
           onConfirm={() =>
             trackControl.handleConfirm(async () => {
-              if (!ad.landingUrl) {
+              if (!landingUrlValue) {
                 toast.error(
-                  "광고에 등록된 랜딩 URL이 없어 발급이 불가능합니다.",
+                  "랜딩 URL을 입력해야 트래킹 링크를 발급할 수 있습니다.",
                 );
                 throw new Error("랜딩 URL이 없습니다.");
               }
               await mutateCreateTrackingUrl({
                 adContentId: ad.id,
-                landingUrl: ad.landingUrl,
+                landingUrl: landingUrlValue,
               });
             })
           }

--- a/src/components/ads/AdDetailContent.tsx
+++ b/src/components/ads/AdDetailContent.tsx
@@ -130,6 +130,12 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
                   <LinkIcon className="h-5 w-5" />
                 </button>
               </div>
+              {!isTrackingActive ? (
+                <p className="mt-1.5 pl-1.5 font-caption text-text-muted">
+                  입력한 URL은 트래킹 링크 발급 시 저장됩니다. 발급하지 않거나
+                  취소하면 저장되지 않습니다.
+                </p>
+              ) : null}
             </div>
           </section>
         </div>

--- a/src/components/ads/AdDetailContent.tsx
+++ b/src/components/ads/AdDetailContent.tsx
@@ -196,20 +196,21 @@ export default function AdDetailContent({ ad }: { ad: IAd }) {
             </>
           }
           buttonText="발급하기"
-          onConfirm={() =>
+          onConfirm={() => {
+            if (!landingUrlValue) {
+              toast.error(
+                "랜딩 URL을 입력해야 트래킹 링크를 발급할 수 있습니다.",
+              );
+              return;
+            }
+
             trackControl.handleConfirm(async () => {
-              if (!landingUrlValue) {
-                toast.error(
-                  "랜딩 URL을 입력해야 트래킹 링크를 발급할 수 있습니다.",
-                );
-                throw new Error("랜딩 URL이 없습니다.");
-              }
               await mutateCreateTrackingUrl({
                 adContentId: ad.id,
                 landingUrl: landingUrlValue,
               });
-            })
-          }
+            });
+          }}
           isLoading={trackControl.isLoading}
           variant="primary"
         />


### PR DESCRIPTION
## 🚨 관련 이슈

close #512 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [X] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- 캠페인 상세 광고 펼침 시 랜딩 URL 영역을 읽기 전용 <span> → <input>으로 변경해 입력 가능하게 수정
- 트래킹 링크 발급 시 사용자 입력값(landingUrl)을 POST /api/clicks/{orgId}/{adContentId}/tracking-url에 전달
- 트래킹 링크 발급 후(trackingUrl 존재) 랜딩 URL input readOnly 처리
- 랜딩 URL은 트래킹 발급 시에만 저장된다는 안내 문구 추가

## 😅 미완성 작업

발급 후 랜딩 URL 수정·재발급 → 별도 이슈

## 📢 논의 사항 및 참고 사항
N/A

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 랜딩 URL을 직접 입력하고 수정할 수 있습니다.
  * 트래킹 링크 발급 시 입력한 랜딩 URL이 사용됩니다.
  * 랜딩 URL이 입력되지 않으면 안내 메시지가 표시되고 발급이 중단됩니다.
  * URL 복사 기능은 값이 입력된 경우에만 사용할 수 있습니다.
  * 트래킹 링크가 활성화된 URL은 읽기 전용으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->