### PR TITLE
[Bugfix/#514] 백그라운드 푸시 동기화 실패 시 Sentry unhandled 방지

### DIFF
--- a/src/utils/notification/webPush.ts
+++ b/src/utils/notification/webPush.ts
@@ -103,11 +103,15 @@ export async function syncPushSubscription(orgId: number) {
   if (!isWebPushSupported()) return;
   if (Notification.permission !== "granted") return;
 
-  await registerPushServiceWorker();
-  const { publicKey } = await getVapidPublicKey();
-  const subscription = await getOrCreateSubscription(publicKey);
-  await registerPushSubscription(
-    orgId,
-    toPushSubscriptionRequest(subscription),
-  );
+  try {
+    await registerPushServiceWorker();
+    const { publicKey } = await getVapidPublicKey();
+    const subscription = await getOrCreateSubscription(publicKey);
+    await registerPushSubscription(
+      orgId,
+      toPushSubscriptionRequest(subscription),
+    );
+  } catch {
+    // 백그라운드 동기화 실패는 설정 저장 흐름이 아님. unhandled rejection으로 Sentry에 올리지 않음
+  }
 }


### PR DESCRIPTION
## 🚨 관련 이슈

Closed #514 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

- `syncPushSubscription`에 try/catch 문 추가
- 앱 진입할 때 백그라운드 푸시 동기화가 실패해서 unhandle rejection으로 Sentry에 올라가지 않도록 처리했습니다.
- 푸시 on/saved에서는 잘 작동중이라 `enabledBrowserPushSubscription`은 그대로 두었습니다.

## 😅 미완성 작업

N/A

## 📢 논의 사항 및 참고 사항

- VAPID 공개키 API는 현재 잘 작동 중이고, Sentry에서 `AbortError: Registration failed - could not retrieve the public key` 에러메세지가 발생중인데, 확인 결과 `subscribe()` 단계에서 Chrome과 FCM 사이에서의 구독 실패로 보이고, 코드 수정으로 해결하기 어려워 보입니다.
- 배포 진행 후에 같은 에러가 Sentry에 새로 찍히는 것만 확인하면 됩니다.
- 일부 팀원 푸시 미수신은 코드 수정보다는 PC의 Chrome/FCM 쪽으로 확인되기에, 대면회의때 확인해볼 예정입니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 푸시 알림 구독 동기화 중 발생하는 오류로 인해 백그라운드 작업이 중단되거나 오류 보고가 발생하는 문제를 수정했습니다.
  * 동기화 실패가 사용자 경험에 영향을 주지 않도록 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->